### PR TITLE
console: take the Table combo hint out of flow so the filter row aligns (#1369)

### DIFF
--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1334,11 +1334,13 @@ function fieldSelect(label, name, size, isSchema, isTable, options, anyLabel, re
 // datalist on schema change), but a hand-typed name still submits — recover
 // can legitimately target a dropped table whose events are indexed, and a
 // closed <select> would make that recovery impossible from the UI. The
-// combo-hint span is the brief busy note while a listing loads.
+// combo-hint span is the brief busy note while a listing loads; field--combo
+// anchors it OUT of flow (#1369) so the empty hint reserves no height — under
+// .filters' align-items:flex-end it pushed the label+input above the row.
 let tableComboSeq = 0;
 function fieldTableCombo(label, name, size, placeholder) {
   const listId = "table-combo-list-" + (++tableComboSeq);
-  return el("div", { class: "field field--" + size },
+  return el("div", { class: "field field--combo field--" + size },
     fieldLabel(label),
     el("input", { class: "input table-combo", name, placeholder: placeholder || "",
       list: listId, autocomplete: "off", spellcheck: "false" }),

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1042,8 +1042,20 @@ button { font-family: inherit; }
 /* Focus landing for the generated reversal.sql panel header (#1363). */
 .code-head:focus { outline: 2px solid var(--accent); outline-offset: -2px; }
 
-/* table combobox busy hint (#1364) */
-.combo-hint { display: block; margin-top: 4px; font-size: 11.5px; color: var(--ink-3); min-height: 15px; }
+/* table combobox busy hint (#1364). Out of flow (#1369): the filter row
+   aligns fields by their bottom edge (align-items: flex-end), so an in-flow
+   hint — even empty — made the combo field taller than its siblings and
+   pushed its label+input above the row. Absolutely positioned below the
+   field, the field's box matches its siblings whether the hint is empty,
+   loading, or showing a note, and toggling it never shifts the layout.
+   It's a transient note that may overlap content below, hence the surface
+   background + z-index for readability. */
+.field--combo { position: relative; }
+.combo-hint {
+  position: absolute; top: 100%; left: 0; right: 0; margin-top: 3px;
+  font-size: 11.5px; color: var(--ink-3);
+  background: var(--surface); z-index: 1;
+}
 
 /* ============================================================
    tweaks panel (vanilla)

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -1434,6 +1434,19 @@ try {
     const waitFor = async (pred) => { for (let i = 0; i < 80 && !pred(); i++) await sleep(50); return pred(); };
     const pick = (schema) => { f.elements.schema.value = schema; f.elements.schema.dispatchEvent(new Event("change")); };
 
+    // Hint geometry (#1369): the hint is out of flow, so with the hint EMPTY
+    // the combo field's box must match its siblings (under .filters'
+    // align-items:flex-end an in-flow empty hint pushed the label+input above
+    // the row), and SHOWING the hint must not change the field's box. Deltas
+    // are relative to the schema field so the view-enter animation (which
+    // translates the whole filter panel) can't skew a comparison across time.
+    const geom = () => {
+      const c = input.closest(".field").getBoundingClientRect();
+      const s = f.elements.schema.closest(".field").getBoundingClientRect();
+      return { dTop: c.top - s.top, comboH: c.height, sibH: s.height };
+    };
+    const geomEmpty = geom(); // fresh form: hint is empty
+
     // The dropped-table flow: a name typed BEFORE the first schema selection
     // must survive that selection — clearing here would make the one recovery
     // a closed <select> can't do impossible from this combobox too.
@@ -1482,6 +1495,7 @@ try {
     input.value = "typed_under_failure";
     pick(FIX);
     await waitFor(() => /type the table name/.test(hintText()));
+    const geomHint = geom(); // the persistent failure note is showing
     const failed = {
       valueKept: input.value === "typed_under_failure",
       enabled: !input.disabled,
@@ -1503,8 +1517,15 @@ try {
       disabled: input.disabled,
       preseededKept, tablesA, tablesB, clearedOnSwitch, sharedKept,
       keptOnEmpty, clearedViaEmpty, failed, failedSubmit,
+      geomEmpty, geomHint,
     };
   }, FIX);
+  (Math.abs(combo.geomEmpty.dTop) <= 1 && Math.abs(combo.geomEmpty.comboH - combo.geomEmpty.sibH) <= 1)
+    ? ok("restore combo: empty hint reserves no height — field box matches its siblings (#1369)")
+    : bad("restore combo: empty hint reserves no height — field box matches its siblings (#1369)", JSON.stringify(combo.geomEmpty));
+  (Math.abs(combo.geomHint.dTop) <= 1 && Math.abs(combo.geomHint.comboH - combo.geomEmpty.comboH) <= 1)
+    ? ok("restore combo: a showing hint never changes the field box or moves the row (#1369)")
+    : bad("restore combo: a showing hint never changes the field box or moves the row (#1369)", JSON.stringify({ empty: combo.geomEmpty, hint: combo.geomHint }));
   (combo.isInput && combo.hasList)
     ? ok("restore combo: Table is an input+datalist combobox, not a closed select")
     : bad("restore combo: Table is an input+datalist combobox, not a closed select", JSON.stringify(combo));


### PR DESCRIPTION
Closes #1369

## Problem

On the Restore view the Table field rode ~25px higher than every other field in the filter row. `.filters` aligns fields by their bottom edge (`align-items: flex-end`), and the #1364 combobox's `.combo-hint` — `display: block; min-height: 15px` — reserved height **even when empty**, making the combo `.field` permanently taller than its siblings. Additionally, the failure note ("couldn't load suggestions — type the table name") wraps in a `field--md` width and blows past the 15px `min-height`, so the whole row also shifted while/after a listing load failed.

## Fix (the issue's preferred option: take the hint out of flow)

- `fieldTableCombo` (app.js) adds a `field--combo` class to its wrapper — every call site gets the behavior automatically.
- `style.css`: `.field--combo { position: relative }` and `.combo-hint { position: absolute; top: 100%; left: 0; right: 0; margin-top: 3px; }`. The field's box now matches its siblings whether the hint is empty, loading, or showing a note, and toggling the note never reflows the row. The hint keeps its `var(--ink-3)` text and gains a `var(--surface)` background + `z-index: 1` so the transient note stays readable where it overlaps content below the row. The now-pointless `min-height` is removed (grepped: nothing else referenced it).

## Test

Per the issue's ask, the console e2e's #1364 scenario now pins the hint's geometry (the combobox behavior checks can't see a flex alignment problem):

- with the hint **empty**, the combo field's box must match the schema field's (same height, same top);
- with the persistent failure note **showing**, the field's box must not change (siblings never move).

Deltas are measured relative to a sibling field so the `view-enter` translate animation can't skew a comparison across time.

**Mutation-checked**: against the old CSS both new assertions fail — `{"dTop":-25,"comboH":85.5,"sibH":60.5}` empty, `dTop:-44.5, comboH:105` with the note showing (catching both the steady-state step and the load-time shift). With the fix: full suite **217/217 PASS**.

Also green: `go test ./internal/console/ -count=1` (compiles the embed), `go vet ./internal/console/`, `node --check` on both edited JS files. `fieldTableCombo` has a single call site (Restore form); the `loadTables` hint lookup (`parentElement.querySelector(".combo-hint")`) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
