### PR TITLE
console: extend logins to new tabs with an HttpOnly SameSite=Lax session cookie

### DIFF
--- a/docs/console.md
+++ b/docs/console.md
@@ -715,6 +715,17 @@ A running server accepts it on the next login — no restart needed.
   (24 h absolute, 8 h idle, max 16 concurrent) the SPA uses as its Bearer
   credential. Sessions die on logout, on password change (which revokes all
   of them), and on process restart — nothing session-shaped touches disk.
+- The login response also sets the session token as an **HttpOnly
+  `bintrail_session` cookie** (`Secure; SameSite=Lax; Path=/`, `Max-Age`
+  matching the session's absolute expiry), so opening a console link in a new
+  tab or window is already signed in — same store, same expiry, same
+  revocation as the Bearer path; the cookie holds nothing new. Logout revokes
+  the session server-side *and* expires the cookie, killing every tab at once.
+  The `Secure` flag is safe on the local first-run flow (browsers treat
+  loopback as a secure context); **operators terminating TLS at a reverse
+  proxy** should serve the console over `https://` end-to-end from the
+  browser's point of view, or the browser will drop the cookie and each tab
+  falls back to its own login (the Bearer flow keeps working either way).
 - **An opt-in static token** for automation: set `--token` /
   `BINTRAIL_CONSOLE_TOKEN` explicitly and scripts/curl/CI can call the API with
   it. It is never generated for you, and it is not the human path — when a
@@ -791,13 +802,18 @@ itself:
   sessions are looked up by SHA-256 of the presented value, so raw session
   tokens never live server-side; unknown-username logins still burn a full
   bcrypt compare so timing cannot enumerate the username).
-- **Bearer header on the API — never a cookie.** `/api/*` requires the
-  credential (static token or login session) in the `Authorization: Bearer …`
-  header, so a cross-site form POST cannot carry ambient credentials to
-  `/api/recover`. Login itself requires `Content-Type: application/json`,
-  which an HTML form cannot send — login-CSRF dies the same way. The page
-  shell loads without a token (it reads the token from the URL to bootstrap
-  its requests).
+- **Bearer header first; the session cookie is the tab-bridging sibling.**
+  `/api/*` accepts the credential (static token or login session) in the
+  `Authorization: Bearer <token>` header, or — for browser navigation — the
+  HttpOnly session cookie a login sets. A request carrying a Bearer header is
+  judged on that header alone (no cookie fallback), so scripted access is
+  unchanged. Cookie-authenticated **state-changing** requests (anything but
+  GET/HEAD/OPTIONS) must additionally send `Content-Type: application/json`,
+  which an HTML form cannot produce — combined with `SameSite=Lax`, a
+  cross-site form POST cannot carry the ambient cookie to `/api/recover`.
+  Login itself requires `Content-Type: application/json` too — login-CSRF
+  dies the same way. The page shell loads without a token (it reads the token
+  from the URL, or probes the session cookie, to bootstrap its requests).
 - **No CORS headers.** Requests are same-origin only.
 - **Host-header allowlist.** Requests whose `Host` is a domain name are
   rejected (only IP literals and `localhost` pass), which defeats DNS-rebinding
@@ -821,7 +837,7 @@ itself:
   (does password login exist — what the login form's presence would reveal
   anyway), `POST /api/auth/login`, and — only during first-run setup —
   `POST /api/auth/setup`. Everything else needs a Bearer
-  credential.
+  credential or the login session cookie.
 
 ## PostgreSQL sources
 

--- a/ext/consoleauth.go
+++ b/ext/consoleauth.go
@@ -12,15 +12,22 @@ import (
 // in-memory session a password login mints, with the same lifetime and
 // revocation behavior.
 //
+// w is the in-flight login response the provider is about to complete: the
+// console sets its HttpOnly session cookie on it (the cookie is how a NEW
+// browser tab authenticates without the sessionStorage token), so the provider
+// must call issue BEFORE writing its response headers. The documented flow —
+// call issue, then redirect to /?token=<token> — already satisfies this.
+//
 // policy scopes what the minted session may do (see AccessPolicy). Pass nil for
 // a full-access session — identical to what the built-in password login and the
 // static token mint. Only an EE build that maps roles onto permissions passes a
 // non-nil policy; the OSS core never does, so its sessions stay full-access.
 //
-// The policy parameter was added when per-session authorization landed. There is
-// no in-repo implementor of this seam, so the signature break is absorbed in one
-// release by the sole external caller (the SSO provider in the EE build).
-type ConsoleSessionIssuer func(identity string, policy *AccessPolicy) (token string, expiresAt time.Time, err error)
+// The policy parameter was added when per-session authorization landed, and w
+// when the session cookie did. There is no in-repo implementor of this seam, so
+// each signature break is absorbed in one release by the sole external caller
+// (the SSO provider in the embedding build).
+type ConsoleSessionIssuer func(w http.ResponseWriter, identity string, policy *AccessPolicy) (token string, expiresAt time.Time, err error)
 
 // ConsoleAuthProvider plugs an external authentication flow (e.g. OIDC
 // single sign-on) into the web console's login surface. The console stays

--- a/ext/consoleauth_test.go
+++ b/ext/consoleauth_test.go
@@ -9,7 +9,7 @@ import (
 // The issuer contract is a plain func type — keep a compile-time pin on its
 // exact shape so an accidental signature change fails here, not only in the
 // console wiring.
-var _ ConsoleSessionIssuer = func(string, *AccessPolicy) (string, time.Time, error) {
+var _ ConsoleSessionIssuer = func(http.ResponseWriter, string, *AccessPolicy) (string, time.Time, error) {
 	return "", time.Time{}, nil
 }
 

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -8,6 +8,12 @@
 // Security invariants kept from the prior frontend (do not regress):
 //  1. The token comes from ?token= on first load, is stashed in sessionStorage,
 //     and is stripped from the URL — it never lingers in the address bar.
+//     Logins ALSO set an HttpOnly session cookie server-side (#1370) so a new
+//     tab is already signed in; when sessionStorage is empty this file PROBES
+//     a cheap authenticated endpoint and, on 200, runs cookie-only (no
+//     Authorization header — the middleware accepts the cookie). Every
+//     non-GET request must then send Content-Type: application/json: that is
+//     the server's cookie-CSRF marker, and api() sets it unconditionally.
 //  2. The X-Bintrail-Server header is captured INSIDE api() at dispatch time, so
 //     an in-flight request keeps the server it was fired for.
 //  3. Every async render captures `serverGen` before its await and bails if a
@@ -167,9 +173,18 @@ const VIEW = () => document.getElementById("view");
 // ── api ──────────────────────────────────────────────────────────────────────
 
 async function api(path, opts = {}) {
-  const headers = { Authorization: "Bearer " + TOKEN };
+  // No Authorization header without a token: a cookie-bootstrapped tab (fresh
+  // tab, HttpOnly session cookie, empty sessionStorage) authenticates via the
+  // cookie the browser attaches on its own (same-origin fetch sends cookies
+  // by default).
+  const headers = TOKEN ? { Authorization: "Bearer " + TOKEN } : {};
   if (currentServer) headers["X-Bintrail-Server"] = currentServer; // captured at dispatch
-  if (opts.body) headers["Content-Type"] = "application/json";
+  // Content-Type on EVERY state-changing request, body or not (a body-less
+  // POST like logout included): the server's cookie-auth CSRF belt requires
+  // the application/json marker on non-GET methods, and sending it under
+  // Bearer too keeps the request shape uniform.
+  const method = (opts.method || "GET").toUpperCase();
+  if (opts.body || (method !== "GET" && method !== "HEAD")) headers["Content-Type"] = "application/json";
   const res = await fetch(path, {
     method: opts.method || "GET",
     headers,
@@ -206,7 +221,7 @@ async function api(path, opts = {}) {
 // same central 401 handling — only the parsing differs, because views.sql is a
 // SQL file and api()'s JSON.parse would reject it as malformed.
 async function apiText(path) {
-  const headers = { Authorization: "Bearer " + TOKEN };
+  const headers = TOKEN ? { Authorization: "Bearer " + TOKEN } : {};
   if (currentServer) headers["X-Bintrail-Server"] = currentServer;
   const res = await fetch(path, { headers });
   const text = await res.text();
@@ -246,6 +261,21 @@ async function fetchAuthInfo() {
   const res = await fetch("/api/auth");
   if (!res.ok) throw new Error("HTTP " + res.status);
   return res.json();
+}
+
+// probeCookieSession: a fresh tab has no sessionStorage token (it is per-tab),
+// but a login in another tab left the HttpOnly session cookie — try one cheap
+// authenticated GET before raising the sign-in gate. /api/servers is the
+// lightest authenticated read (registry only, touches no index DB), the
+// browser attaches the cookie on its own, and a 200 means the middleware
+// accepted it: the tab then runs cookie-only with TOKEN empty. Raw fetch on
+// purpose — a 401 here is the NORMAL signed-out case and must not recurse
+// into handleUnauthorized's "session expired" messaging.
+async function probeCookieSession() {
+  try {
+    const res = await fetch("/api/servers");
+    return res.ok;
+  } catch (_) { return false; }
 }
 
 // handleUnauthorized is api()'s 401 chokepoint: the bearer is dead, so clear
@@ -544,9 +574,14 @@ async function submitPasswordChange(form, msg, firstSet) {
   };
   let res;
   try {
+    // Cookie-bootstrapped tabs have no TOKEN — the session cookie carries the
+    // credential, and the JSON Content-Type doubles as the CSRF marker.
+    const headers = TOKEN
+      ? { Authorization: "Bearer " + TOKEN, "Content-Type": "application/json" }
+      : { "Content-Type": "application/json" };
     res = await fetch("/api/auth/password", {
       method: "POST",
-      headers: { Authorization: "Bearer " + TOKEN, "Content-Type": "application/json" },
+      headers,
       body: JSON.stringify(body),
     });
   } catch (_) { loginMsg(msg, "Network error — is the console still running?"); return; }
@@ -3206,7 +3241,10 @@ async function runSQL(sql, ui) {
   statusLine.textContent = "running…";
   clear(results);
   try {
-    const headers = { Authorization: "Bearer " + TOKEN, "Content-Type": "application/json" };
+    // Content-Type doubles as the cookie-auth CSRF marker; no Authorization
+    // header in a cookie-bootstrapped tab (TOKEN empty), same as api().
+    const headers = { "Content-Type": "application/json" };
+    if (TOKEN) headers.Authorization = "Bearer " + TOKEN;
     if (currentServer) headers["X-Bintrail-Server"] = currentServer;
     const res = await fetch("/api/sql", {
       method: "POST", headers, body: JSON.stringify({ sql }), signal: sqlRunController.signal,
@@ -5142,11 +5180,15 @@ async function init() {
   document.getElementById("nav-rotation").addEventListener("click", showRotationDialog);
   window.addEventListener("popstate", renderRoute);
 
-  // Pre-auth gate: ask the (unauthenticated) probe how this console
-  // authenticates BEFORE firing data fetches that are guaranteed 401s. First
-  // run with no credential → create-password screen; password configured →
-  // sign-in form; token mode → the printed-link hint.
-  if (!TOKEN) {
+  // Pre-auth gate: with no stored token, first try the HttpOnly session
+  // cookie a login in another tab may have left (#1370) — on success the tab
+  // proceeds signed-in with TOKEN empty (api() omits the Authorization header
+  // and the cookie authenticates every call). Otherwise ask the
+  // (unauthenticated) probe how this console authenticates BEFORE firing data
+  // fetches that are guaranteed 401s. First run with no credential →
+  // create-password screen; password configured → sign-in form; token mode →
+  // the printed-link hint.
+  if (!TOKEN && !(await probeCookieSession())) {
     let auth = {};
     try { auth = await fetchAuthInfo(); } catch (_) { /* server down — fall through, the view will surface it */ }
     if (auth.setup) { showLoginOverlay({ setup: true, ssoName: auth.sso_name, ssoStart: auth.sso_start }); return; }

--- a/internal/console/auth.go
+++ b/internal/console/auth.go
@@ -41,6 +41,58 @@ func bearerToken(r *http.Request) string {
 	return h[len(prefix):]
 }
 
+// sessionCookieName carries the login session token as an HttpOnly cookie, so
+// a NEW browser tab (whose sessionStorage is empty — it is per-tab) arrives
+// already authenticated. The cookie value IS the session token the login
+// response also returns as JSON: same store, same expiry, same policy —
+// nothing new is persisted server-side.
+const sessionCookieName = "bintrail_session"
+
+// sessionCookieToken returns the session cookie's value, or "" when absent.
+func sessionCookieToken(r *http.Request) string {
+	c, err := r.Cookie(sessionCookieName)
+	if err != nil {
+		return ""
+	}
+	return c.Value
+}
+
+// setSessionCookie attaches the issued session token to a login response.
+// HttpOnly keeps it out of script reach; SameSite=Lax withholds it on
+// cross-site POSTs (the first CSRF layer — see tokenMiddleware for the belt);
+// Secure is safe for the local first-run flow because browsers treat loopback
+// as a secure context, and matters behind a TLS-terminating proxy (documented
+// in docs/console.md). Max-Age mirrors the session's absolute expiry; the
+// idle TTL may end the session earlier, which the middleware enforces — a
+// cookie outliving its session is just a refused credential.
+func setSessionCookie(w http.ResponseWriter, token string, expires time.Time) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    token,
+		Path:     "/",
+		MaxAge:   int(time.Until(expires) / time.Second),
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+// clearSessionCookie expires the session cookie (Max-Age=0 on the wire), so a
+// logout kills every tab, not just the one that clicked it. Attributes match
+// setSessionCookie — a clear that differs in Path would leave the original
+// cookie standing.
+func clearSessionCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
 // authKind records, in the request context, which credential authenticated
 // the request. The change-password first-set branch keys on it: only the
 // static token (the bootstrap trust root) may claim the first password.
@@ -81,14 +133,14 @@ func identityFrom(ctx context.Context) string {
 	return s
 }
 
-// tokenMiddleware requires a valid bearer credential on every wrapped
-// request: either the static access token or a login session. Both checks
-// run on the same path with no prefix branching, so response shape never
-// reveals which credential kind a guess was tested against. The static
-// compare is constant-time for equal-length inputs (subtle returns 0
-// immediately on a length mismatch, so credential *length* is not hidden —
-// fine: the token is 32 hex chars and sessions are "bcs_"+64 hex by
-// construction, not secrets in their shape).
+// tokenMiddleware requires a valid credential on every wrapped request:
+// either the static access token or a login session. Both checks run on the
+// same path with no prefix branching, so response shape never reveals which
+// credential kind a guess was tested against. The static compare is
+// constant-time for equal-length inputs (subtle returns 0 immediately on a
+// length mismatch, so credential *length* is not hidden — fine: the token is
+// 32 hex chars and sessions are "bcs_"+64 hex by construction, not secrets in
+// their shape).
 //
 // Two guards are independent and BOTH load-bearing in password-only mode,
 // where s.token == "" and ConstantTimeCompare("", "") returns 1: the empty-got
@@ -97,29 +149,68 @@ func identityFrom(ctx context.Context) string {
 // an empty configured token. Removing either leaves the other as the last line
 // of defense — keep both.
 //
-// The credential is required in the Authorization header specifically (not a
-// cookie): a browser fetch() must opt in to sending it, which keeps a
-// cross-site form-POST from carrying ambient credentials to /api/recover.
+// The credential arrives in the Authorization header (a browser fetch() must
+// opt in to sending it) or, since #1370, in the HttpOnly session cookie a
+// login sets — which is how a NEW tab authenticates before the SPA has a
+// token in hand. Bearer, when present, wins: a request carrying an
+// Authorization: Bearer header is judged on that header alone and never falls
+// back to the cookie, so scripted access is byte-identical to the pre-cookie
+// behavior. A cookie is an AMBIENT credential, so cookie-authenticated
+// requests pass two extra defenses: SameSite=Lax on the cookie itself, and a
+// belt here — a state-changing method (anything but GET/HEAD/OPTIONS) must
+// carry Content-Type: application/json, which a cross-site HTML form cannot
+// send (forms are limited to urlencoded/multipart/text-plain). The SPA sends
+// JSON on every write already. The belt runs AFTER the credential check on
+// purpose: an invalid cookie stays a uniform 401, and the actionable 403 is
+// only ever shown to a caller who is really signed in.
 func (s *Server) tokenMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		got := bearerToken(r)
+		viaCookie := false
+		if got == "" {
+			got = sessionCookieToken(r)
+			viaCookie = got != ""
+		}
 		if got == "" {
 			writeJSONError(w, http.StatusUnauthorized, "unauthorized: missing or invalid token")
 			return
 		}
+		// admit runs the shared post-credential steps: the cookie CSRF belt,
+		// then the handler with the auth context attached. The cookie is
+		// deliberately run through the SAME two credential checks as a Bearer
+		// (no branching by transport — same shape property as above).
+		admit := func(ctx context.Context) {
+			if viaCookie && !csrfMarkerOK(r) {
+				writeJSONError(w, http.StatusForbidden,
+					"forbidden: cookie-authenticated write requests must send Content-Type: application/json (cross-site request protection); scripted clients should use an Authorization: Bearer header instead")
+				return
+			}
+			next.ServeHTTP(w, r.WithContext(ctx))
+		}
 		if s.token != "" && subtle.ConstantTimeCompare([]byte(got), []byte(s.token)) == 1 {
-			next.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), authKindCtxKey{}, authKindToken)))
+			admit(context.WithValue(r.Context(), authKindCtxKey{}, authKindToken))
 			return
 		}
 		if identity, policy, ok := s.sessions.Lookup(got); ok {
 			ctx := context.WithValue(r.Context(), authKindCtxKey{}, authKindSession)
 			ctx = context.WithValue(ctx, policyCtxKey{}, policy)
 			ctx = context.WithValue(ctx, identityCtxKey{}, identity)
-			next.ServeHTTP(w, r.WithContext(ctx))
+			admit(ctx)
 			return
 		}
 		writeJSONError(w, http.StatusUnauthorized, "unauthorized: missing or invalid token")
 	})
+}
+
+// csrfMarkerOK is the cookie-auth CSRF belt's predicate: safe methods pass;
+// state-changing ones must carry the application/json marker, which no
+// cross-site HTML form can produce. Same media-type parse as requireJSONBody.
+func csrfMarkerOK(r *http.Request) bool {
+	switch r.Method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return true
+	}
+	return isJSONContentType(r.Header.Get("Content-Type"))
 }
 
 // maxAPIBody caps authenticated JSON request bodies (#848). 1 MiB is far

--- a/internal/console/auth_api.go
+++ b/internal/console/auth_api.go
@@ -28,13 +28,21 @@ func clientIP(r *http.Request) string {
 	return host
 }
 
+// isJSONContentType reports whether the Content-Type header names the
+// application/json media type (parameters ignored). Shared by the pre-auth
+// requireJSONBody gate and the cookie-auth CSRF belt (csrfMarkerOK) — one
+// parse, so the two defenses cannot drift on what counts as JSON.
+func isJSONContentType(ct string) bool {
+	mt, _, _ := strings.Cut(ct, ";")
+	return strings.TrimSpace(mt) == "application/json"
+}
+
 // requireJSONBody enforces Content-Type: application/json and a size cap on
 // the pre-auth endpoints. The Content-Type check is a CSRF defense in its own
 // right: an HTML form can only submit urlencoded/multipart/text-plain, so a
 // cross-site form POST can never reach the login verifier.
 func requireJSONBody(w http.ResponseWriter, r *http.Request) bool {
-	ct := r.Header.Get("Content-Type")
-	if mt, _, _ := strings.Cut(ct, ";"); strings.TrimSpace(mt) != "application/json" {
+	if !isJSONContentType(r.Header.Get("Content-Type")) {
 		writeJSONError(w, http.StatusUnsupportedMediaType, "Content-Type must be application/json")
 		return false
 	}
@@ -67,13 +75,17 @@ func (s *Server) handleAuthInfo(w http.ResponseWriter, r *http.Request) {
 // extSessionIssuer adapts the session store to the ext.ConsoleSessionIssuer
 // contract: the installed provider calls it after verifying an identity, and
 // the returned token is a normal console session (same TTLs, same revocation).
-// The identity is logged for the operator's audit trail and never stored.
+// The session cookie is set on the provider's in-flight response here — the
+// issue call, not the delivery mechanism, is what makes a login — so external
+// logins extend to new tabs exactly like password logins do. The identity is
+// logged for the operator's audit trail and never stored.
 func (s *Server) extSessionIssuer() ext.ConsoleSessionIssuer {
-	return func(identity string, policy *ext.AccessPolicy) (string, time.Time, error) {
+	return func(w http.ResponseWriter, identity string, policy *ext.AccessPolicy) (string, time.Time, error) {
 		token, expires, err := s.sessions.IssueWithPolicy(identity, policy)
 		if err != nil {
 			return "", time.Time{}, err
 		}
+		setSessionCookie(w, token, expires)
 		slog.Info("console external-auth login", "identity", identity)
 		return token, expires, nil
 	}
@@ -167,6 +179,7 @@ func (s *Server) handleSetup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	slog.Info("console password created via first-run setup", "remote", ip)
+	setSessionCookie(w, token, expires)
 	writeJSON(w, http.StatusOK, map[string]string{
 		"token":      token,
 		"expires_at": expires.UTC().Format(time.RFC3339),
@@ -229,6 +242,7 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 		// The verified identity is the operator's audit trail (like the external
 		// auth issuer); logged only on SUCCESS, where it is a real identity.
 		slog.Info("console login", "remote", ip, "identity", cred.Identity)
+		setSessionCookie(w, token, expires)
 		writeJSON(w, http.StatusOK, map[string]string{
 			"token":      token,
 			"expires_at": expires.UTC().Format(time.RFC3339),
@@ -264,6 +278,7 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	slog.Info("console login", "remote", ip)
+	setSessionCookie(w, token, expires)
 	writeJSON(w, http.StatusOK, map[string]string{
 		"token":      token,
 		"expires_at": expires.UTC().Format(time.RFC3339),
@@ -271,10 +286,15 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleLogout serves POST /api/auth/logout (authenticated). It revokes the
-// presented Bearer when it is a session; a static token is not revocable over
-// HTTP by design, so logout with one is a 204 no-op. Idempotent.
+// presented Bearer AND the session cookie's session when they are sessions
+// (usually the same one; a tab that logged in twice can hold two), and clears
+// the cookie so every tab's ambient credential dies with this click — not
+// just the tab that clicked. A static token is not revocable over HTTP by
+// design, so logout with one only clears the cookie. Idempotent.
 func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {
 	s.sessions.Revoke(bearerToken(r))
+	s.sessions.Revoke(sessionCookieToken(r))
+	clearSessionCookie(w)
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -363,6 +383,9 @@ func (s *Server) handlePasswordChange(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	slog.Info("console password changed", "remote", ip)
+	// The RevokeAll above also killed the session the cookie names; hand this
+	// tab's cookie the fresh session so its new tabs stay signed in.
+	setSessionCookie(w, token, expires)
 	writeJSON(w, http.StatusOK, map[string]string{
 		"token":      token,
 		"expires_at": expires.UTC().Format(time.RFC3339),

--- a/internal/console/auth_ext_test.go
+++ b/internal/console/auth_ext_test.go
@@ -31,7 +31,7 @@ func (fakeAuthProvider) Handler(prefix string, issue ext.ConsoleSessionIssuer) h
 		w.WriteHeader(http.StatusOK)
 	})
 	mux.HandleFunc("GET "+prefix+"finish", func(w http.ResponseWriter, r *http.Request) {
-		token, _, err := issue("tester@example.com", nil)
+		token, _, err := issue(w, "tester@example.com", nil)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/internal/console/cookie_auth_test.go
+++ b/internal/console/cookie_auth_test.go
@@ -1,0 +1,250 @@
+package console
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Session-cookie tests (#1370): every login sets the HttpOnly bintrail_session
+// cookie, the middleware accepts it as an alternative credential (Bearer wins
+// when present), state-changing cookie-authenticated requests must carry the
+// application/json CSRF marker, and logout clears the cookie after revoking
+// server-side.
+
+// sessionCookieFrom extracts the bintrail_session cookie from a recorded
+// response, failing the test when it is absent.
+func sessionCookieFrom(t *testing.T, rec *httptest.ResponseRecorder) *http.Cookie {
+	t.Helper()
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == sessionCookieName {
+			return c
+		}
+	}
+	t.Fatalf("no %s cookie in response (Set-Cookie: %v)", sessionCookieName, rec.Header().Values("Set-Cookie"))
+	return nil
+}
+
+// cookieRequest fires a request authenticated ONLY by the session cookie — no
+// Authorization header. contentType == "" sends no Content-Type at all.
+func cookieRequest(t *testing.T, srv *Server, method, path, token, contentType, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(method, "http://127.0.0.1:8090"+path, strings.NewReader(body))
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: token})
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	srv.Handler().ServeHTTP(rec, req)
+	return rec
+}
+
+// loginRec performs a password login and returns the raw response recorder
+// plus the issued session token, so callers can inspect Set-Cookie.
+func loginRec(t *testing.T, srv *Server) (*httptest.ResponseRecorder, string) {
+	t.Helper()
+	rec := postJSON(t, srv, "/api/auth/login", "", `{"username":"admin","password":"correct-horse-battery"}`)
+	if rec.Code != 200 {
+		t.Fatalf("login = %d body = %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil || resp.Token == "" {
+		t.Fatalf("login response unparseable: %s", rec.Body.String())
+	}
+	return rec, resp.Token
+}
+
+// assertSessionCookieAttrs checks the fixed attribute set every session
+// cookie must carry, and that its value is the issued session token.
+func assertSessionCookieAttrs(t *testing.T, c *http.Cookie, token string) {
+	t.Helper()
+	if c.Value != token {
+		t.Errorf("cookie value = %q, want the issued session token %q", c.Value, token)
+	}
+	if !c.HttpOnly {
+		t.Error("session cookie is not HttpOnly")
+	}
+	if !c.Secure {
+		t.Error("session cookie is not Secure")
+	}
+	if c.SameSite != http.SameSiteLaxMode {
+		t.Errorf("session cookie SameSite = %v, want Lax", c.SameSite)
+	}
+	if c.Path != "/" {
+		t.Errorf("session cookie Path = %q, want /", c.Path)
+	}
+	// Max-Age mirrors the session's absolute TTL (allow the test's own
+	// wall-clock drift downward, never upward).
+	if max := int(sessionAbsoluteTTL / time.Second); c.MaxAge > max || c.MaxAge < max-60 {
+		t.Errorf("session cookie Max-Age = %d, want ~%d", c.MaxAge, max)
+	}
+}
+
+func TestLoginSetsSessionCookie(t *testing.T) {
+	srv, _ := newPasswordServer(t, "", "admin", "correct-horse-battery")
+	rec, token := loginRec(t, srv)
+	assertSessionCookieAttrs(t, sessionCookieFrom(t, rec), token)
+}
+
+func TestSetupSetsSessionCookie(t *testing.T) {
+	srv, err := New(Config{Listen: "127.0.0.1:8090", AuthPath: filepath.Join(t.TempDir(), "auth.yaml")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := postJSON(t, srv, "/api/auth/setup", "", `{"username":"admin","password":"correct-horse-battery"}`)
+	if rec.Code != 200 {
+		t.Fatalf("setup = %d body = %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Token string `json:"token"`
+	}
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+	assertSessionCookieAttrs(t, sessionCookieFrom(t, rec), resp.Token)
+}
+
+func TestPasswordChangeRefreshesSessionCookie(t *testing.T) {
+	srv, _ := newPasswordServer(t, "", "admin", "correct-horse-battery")
+	_, tok := loginRec(t, srv)
+	rec := postJSON(t, srv, "/api/auth/password", tok, `{"current_password":"correct-horse-battery","new_password":"a-new-password"}`)
+	if rec.Code != 200 {
+		t.Fatalf("password change = %d body = %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Token string `json:"token"`
+	}
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+	// RevokeAll killed the old session; the cookie must carry the FRESH one.
+	assertSessionCookieAttrs(t, sessionCookieFrom(t, rec), resp.Token)
+}
+
+func TestSessionCookieAuthenticatesGET(t *testing.T) {
+	srv, _ := newPasswordServer(t, "", "admin", "correct-horse-battery")
+	srv.cm.boot = &bundle{} // a resolvable default so capabilities answers
+	_, tok := loginRec(t, srv)
+
+	rec := cookieRequest(t, srv, "GET", "/api/capabilities", tok, "", "")
+	if rec.Code != 200 {
+		t.Fatalf("cookie-only GET /api/capabilities = %d body = %s", rec.Code, rec.Body.String())
+	}
+	var caps capabilitiesResponse
+	json.Unmarshal(rec.Body.Bytes(), &caps)
+	if caps.Auth.AuthKind != "session" {
+		t.Errorf("auth.auth_kind = %q via cookie, want session", caps.Auth.AuthKind)
+	}
+}
+
+func TestSessionCookieCSRFBelt(t *testing.T) {
+	srv, _ := newPasswordServer(t, "", "admin", "correct-horse-battery")
+	srv.cm.boot = &bundle{}
+	_, tok := loginRec(t, srv)
+
+	// A state-changing request with only the cookie and no JSON marker is
+	// refused — the shape a cross-site HTML form produces.
+	for _, ct := range []string{"", "application/x-www-form-urlencoded", "text/plain"} {
+		if rec := cookieRequest(t, srv, "POST", "/api/auth/logout", tok, ct, ""); rec.Code != 403 {
+			t.Errorf("cookie-only POST with Content-Type %q = %d, want 403", ct, rec.Code)
+		}
+	}
+	// The belt fired BEFORE the handler: the session must still be alive.
+	if rec := cookieRequest(t, srv, "GET", "/api/capabilities", tok, "", ""); rec.Code != 200 {
+		t.Fatalf("session died on a refused CSRF probe: GET = %d", rec.Code)
+	}
+
+	// The same request with the JSON marker passes (the SPA's shape).
+	rec := cookieRequest(t, srv, "POST", "/api/auth/logout", tok, "application/json", "")
+	if rec.Code != 204 {
+		t.Fatalf("cookie-only JSON logout = %d, want 204", rec.Code)
+	}
+	// Logout cleared the cookie and revoked server-side: the cookie no longer
+	// authenticates anything.
+	if c := sessionCookieFrom(t, rec); c.MaxAge >= 0 || c.Value != "" {
+		t.Errorf("logout cookie = value %q Max-Age %d, want empty and expiring", c.Value, c.MaxAge)
+	}
+	if rec := cookieRequest(t, srv, "GET", "/api/capabilities", tok, "", ""); rec.Code != 401 {
+		t.Errorf("revoked session cookie still authenticates: %d", rec.Code)
+	}
+}
+
+func TestBearerExemptFromCSRFMarker(t *testing.T) {
+	srv, _ := newPasswordServer(t, "", "admin", "correct-horse-battery")
+	_, tok := loginRec(t, srv)
+
+	// Bearer requests never need the JSON marker — byte-identical to the
+	// pre-cookie contract (scripted access, curl, CI).
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "http://127.0.0.1:8090/api/auth/logout", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != 204 {
+		t.Fatalf("Bearer logout without Content-Type = %d, want 204", rec.Code)
+	}
+	// Logout with a Bearer also clears the cookie (all tabs die).
+	if c := sessionCookieFrom(t, rec); c.MaxAge >= 0 {
+		t.Errorf("Bearer logout cookie Max-Age = %d, want expiring", c.MaxAge)
+	}
+}
+
+func TestBearerWinsOverCookie(t *testing.T) {
+	srv, _ := newPasswordServer(t, "", "admin", "correct-horse-battery")
+	srv.cm.boot = &bundle{}
+	_, tok := loginRec(t, srv)
+
+	// An invalid Bearer is judged on its own: no silent fallback to the valid
+	// cookie riding the same request.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "http://127.0.0.1:8090/api/capabilities", nil)
+	req.Header.Set("Authorization", "Bearer wrong")
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: tok})
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != 401 {
+		t.Errorf("invalid Bearer + valid cookie = %d, want 401 (Bearer wins)", rec.Code)
+	}
+}
+
+func TestGarbageSessionCookieRefused(t *testing.T) {
+	srv, _ := newPasswordServer(t, "", "admin", "correct-horse-battery")
+	srv.cm.boot = &bundle{}
+	if rec := cookieRequest(t, srv, "GET", "/api/capabilities", "bcs_deadbeef", "", ""); rec.Code != 401 {
+		t.Errorf("garbage cookie = %d, want 401", rec.Code)
+	}
+}
+
+func TestExpiredSessionCookieRefused(t *testing.T) {
+	srv, _ := newPasswordServer(t, "", "admin", "correct-horse-battery")
+	srv.cm.boot = &bundle{}
+	_, tok := loginRec(t, srv)
+
+	// Same store, same expiry as Bearer: past the absolute TTL the cookie is
+	// refused like any dead session.
+	srv.sessions.now = func() time.Time { return time.Now().Add(sessionAbsoluteTTL + time.Hour) }
+	if rec := cookieRequest(t, srv, "GET", "/api/capabilities", tok, "", ""); rec.Code != 401 {
+		t.Errorf("expired session cookie = %d, want 401", rec.Code)
+	}
+}
+
+func TestExtLoginSetsSessionCookie(t *testing.T) {
+	installFakeProvider(t)
+	srv := newExtServer(t)
+
+	// The provider's finish flow calls the issuer, which sets the cookie on
+	// the in-flight (redirect) response — external logins extend to new tabs
+	// exactly like password logins.
+	rec := getPath(t, srv, "127.0.0.1:8090", "/api/auth/ext/finish", "")
+	if rec.Code != http.StatusFound {
+		t.Fatalf("finish = %d, want 302", rec.Code)
+	}
+	c := sessionCookieFrom(t, rec)
+	if !strings.HasPrefix(c.Value, sessionPrefix) {
+		t.Fatalf("ext-login cookie %q is not a session token", c.Value)
+	}
+	assertSessionCookieAttrs(t, c, c.Value)
+	if rec := cookieRequest(t, srv, "GET", "/api/servers", c.Value, "", ""); rec.Code != 200 {
+		t.Errorf("ext-issued session cookie GET /api/servers = %d, want 200", rec.Code)
+	}
+}

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -482,7 +482,9 @@ func (s *Server) selectedEntry(r *http.Request) (ServerEntry, bool) {
 //   - the static shell and assets are served without a token, so a browser
 //     can load the page and read its bootstrap token from the URL
 //   - every /api/* route except healthz, the auth probe, and login requires a
-//     bearer credential (static token or login session)
+//     credential (static token or login session), presented as a Bearer
+//     header or as the HttpOnly session cookie a login sets (#1370; see
+//     tokenMiddleware for the precedence and the cookie CSRF belt)
 func (s *Server) buildHandler() http.Handler {
 	api := http.NewServeMux()
 	api.HandleFunc("GET /api/status", s.handleStatus)


### PR DESCRIPTION
Closes #1370

## What

Every browser tab was its own login: the SPA keeps the session token in `sessionStorage` (per-tab) and sends it only as `Authorization: Bearer`, so "open link in new tab" always landed on the sign-in panel. This PR adds an **HttpOnly `bintrail_session` cookie alongside the Bearer path** — the cookie value IS the session token (same store, same expiry, same policy; nothing new persisted) — so a fresh tab arrives already signed in.

## Server

- **Every session-issuing branch sets the cookie** (`Secure; HttpOnly; SameSite=Lax; Path=/; Max-Age=` absolute session TTL): password login (both the credential-backend and auth-file branches), first-run setup, the external-auth issuer, and password change (which hands the response the fresh post-`RevokeAll` session).
- **Middleware precedence** (`tokenMiddleware`): a Bearer header, when present, wins and is judged alone — no cookie fallback — so `--token`, `?token=`, and scripted access are byte-identical to today. With no Bearer, the cookie value runs through the SAME two checks (constant-time static compare + session lookup), no transport branching.
- **CSRF belt**: a request that authenticated via cookie and uses a state-changing method (non-GET/HEAD/OPTIONS) must carry `Content-Type: application/json` — a cross-site HTML form cannot send it; `SameSite=Lax` remains the first layer. Refusal is an actionable 403, and it fires AFTER the credential check so an invalid cookie stays a uniform 401. Bearer requests are exempt. `/api/auth/login` and `/api/auth/setup` sit outside the middleware (exempt by construction; the login rate limiter stays in front); `/mcp` keeps its own auth; `/api/healthz` stays unauthenticated.
- **Logout** revokes the presented Bearer AND the cookie's session server-side, then clears the cookie (`Max-Age=0`) — all tabs die.
- **`ext.ConsoleSessionIssuer` gains the in-flight `http.ResponseWriter`** so the issuer sets the cookie at issue time. Same absorbed-signature-break precedent as the policy parameter (documented in the seam; no in-repo implementor).

## SPA

- With `sessionStorage` empty, `init()` **probes one cheap authenticated GET** (`/api/servers`, registry-only) before raising the sign-in gate; on 200 the tab proceeds cookie-only (`TOKEN` empty, no `Authorization` header — same-origin fetch attaches the cookie by itself). A raw fetch on purpose: a 401 there is the normal signed-out case and must not trigger the "session expired" chokepoint.
- `api()` now sends `Content-Type: application/json` on **every** non-GET request, body or not (body-less POSTs like logout/monitor-start included) — that is the CSRF marker; ext view/settings panels use this same helper. Every fetch site attaches `Authorization` only when a token exists.
- The `sessionStorage` flow is unchanged when no cookie is present.

## Docs

`docs/console.md`: cookie behavior, updated security-model bullet (Bearer-first + belt), and a `Secure`-and-loopback note for operators terminating TLS at a reverse proxy.

## Tests

New `internal/console/cookie_auth_test.go`: login/setup/password-change/ext-login set the cookie with the pinned attributes; cookie-only GET authenticates (`auth_kind: "session"`); cookie-only POST without the JSON marker → 403 (session untouched) and with it → 204; Bearer without Content-Type stays 204 (exemption); invalid Bearer + valid cookie → 401 (Bearer wins); garbage and expired cookies → 401; logout response clears the cookie and the revoked session stops authenticating. Existing auth tests untouched and green.

- `go test ./internal/console/ ./ext/ -race -count=1` — ok
- `go vet ./internal/console/` + `go vet -tags integration ./...` — clean
- `node --check internal/console/assets/app.js` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
