### PR TITLE
console: bring the site's tropical sunset into the brand moments (#1371)

### DIFF
--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -298,7 +298,10 @@ function showLoginOverlay(opts) {
   // dialog mounted in the same slot).
   clear(VIEW());
   const mount = document.getElementById("login-mount");
-  const scrim = el("div", { class: "modal-scrim show" });
+  // .login-gate marks THIS scrim as the full-screen brand canvas (#1371).
+  // showPasswordDialog() mounts its panel in the same slot but is a task modal
+  // over an authenticated workspace, so it keeps the ordinary translucent scrim.
+  const scrim = el("div", { class: "modal-scrim show login-gate" });
   const panel = el("div", { class: "modal login-panel", role: "dialog", "aria-label": opts.setup ? "Set up console" : "Sign in" });
   panel.append(el("h2", { class: "modal-title", text: "dbtrail console" }));
 

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -135,9 +135,11 @@
      dark ground would re-point --surface, not these rules. Alphas are the
      ceiling that keeps --ink-3 body text >=4.5:1 where BOTH washes overlap
      (4.59:1; --ink-3 on bare --surface is only 4.96:1, so a wash has little
-     room and these are deliberately faint). */
-  --brand-wash-sun:  oklch(0.879 0.163 91 / 0.12);   /* --sun at 12% */
-  --brand-wash-pink: oklch(0.635 0.18 348 / 0.03);   /* --brand-canvas-1 at 3% */
+     room and these are deliberately faint).
+     Derived with color-mix rather than re-typed as an oklch literal: a literal
+     would silently stop being "--sun at 12%" the day --sun moves. */
+  --brand-wash-sun:  color-mix(in srgb, var(--sun) 12%, transparent);
+  --brand-wash-pink: color-mix(in srgb, var(--brand-canvas-1) 3%, transparent);
   /* The nav's active rail EXTENDS the blue->violet accent gradient into the
      sunset instead of replacing it: product blue stays the interactive accent.
      A separate token on purpose — .timeline::before is a DATA surface and
@@ -855,7 +857,9 @@ button { font-family: inherit; }
    ============================================================ */
 /* An empty screen is where the console should be friendliest, so this is a
    brand moment: a faint sunrise wash over --surface and a sunset hairline on
-   the top edge. It stays a FRAME treatment — the wash never reaches a row, and
+   the top edge. (.empty-ic below stays muted ink — no construction site builds
+   one today, so branding it would be a change nothing renders.)
+   It stays a FRAME treatment — the wash never reaches a row, and
    .ev-empty (which doubles as an inline error line: "Could not load servers…")
    deliberately does NOT get it. Alphas are set by the --ink-3 body pair, which
    holds >=4.5:1 even where both washes overlap. */
@@ -876,7 +880,7 @@ button { font-family: inherit; }
   content: ""; position: absolute; inset: 0 0 auto; height: 3px;
   background: linear-gradient(90deg, var(--brand-canvas-1) 0%, var(--brand-canvas-2) 52%, var(--brand-canvas-3) 100%);
 }
-.empty-ic { color: var(--brand-warm-b); }
+.empty-ic { color: var(--ink-4); }
 .empty h3 { font-family: var(--title-font); font-weight: 600; color: var(--ink-2); margin: 0; font-size: 17px; letter-spacing: -0.01em; }
 .empty p { margin: 0; max-width: 42ch; font-size: 13.5px; }
 

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -5,7 +5,9 @@
    (blue / mint / red), mapped by ROLE — site hue+chroma at the console's
    lightness steps, so WCAG AA holds where the marketing values would not
    (the site's muted ink is ~3.1:1 on white; a console cannot ship that).
-   Brand accents (sun, violet) appear only in brand moments, never on data.
+   Brand accents (the site's tropical sunset — pink/peach/violet/sun) appear
+   only in brand moments: the sign-in gate, empty states, the busy indicator,
+   text selection, the nav rail's tail. Never on data.
    Three directions via [data-dir="paper" | "studio" | "trail"].
    ============================================================ */
 
@@ -103,6 +105,44 @@
      site; violet lives inside the accent gradient via --accent-b. */
   --sun: oklch(0.879 0.163 91);
   --scrim: oklch(0.3 0.03 305 / 0.33);
+
+  /* ---- the site's tropical sunset, at console lightness ----
+     dbtrail.com's hero canvas and headline/CTA stops, translated to oklch and
+     mapped the same way #1359 mapped the ink ramp: the site's HUE + CHROMA are
+     kept exactly, the LIGHTNESS is lowered, because the marketing values do not
+     survive a console's contrast floors. The binding pair is the white panel
+     that floats ON the canvas: at site lightness the peach stop leaves it at
+     2.05:1, below the 3:1 a UI surface needs to be identifiable, so all three
+     hero stops drop a uniform ΔL ≈ -0.12 (relationships preserved, ordering
+     preserved) which puts the BRIGHTEST stop at 3.26:1 and the others above it.
+     Every canvas layer is built from these three stops, so the canvas can never
+     be brighter than --brand-canvas-2 anywhere.
+     Reserved for brand moments — the sign-in gate, empty states, the busy
+     indicator, the nav rail's tail. They never encode data: the semantic
+     INSERT/UPDATE/DELETE tokens above and the diff colors are untouched, and
+     pink never lands on a surface that carries a row. */
+  --brand-canvas-1: oklch(0.635 0.18 348);  /* site hero pink   #FF7AC3 */
+  --brand-canvas-2: oklch(0.66 0.142 53);   /* site hero peach  #FF9D5C */
+  --brand-canvas-3: oklch(0.555 0.19 293);  /* site hero violet #9D7AFF */
+  --brand-warm-a:   oklch(0.63 0.218 3);    /* site CTA pink    #FF4D8D */
+  --brand-warm-b:   oklch(0.63 0.155 51);   /* site CTA orange  #FF8A3D */
+  --brand-canvas: linear-gradient(160deg, var(--brand-canvas-1) 0%, var(--brand-canvas-2) 52%, var(--brand-canvas-3) 100%);
+  --brand-headline: linear-gradient(135deg, var(--brand-warm-a) 0%, var(--brand-warm-b) 55%, var(--brand-canvas-3) 100%);
+  --brand-warm: linear-gradient(135deg, var(--brand-warm-a), var(--brand-warm-b));
+  /* The empty-state washes are the brand colors at low ALPHA over whatever
+     surface is under them, never a baked-in light value — the composite
+     follows the ground, so the pairs below hold by construction and a future
+     dark ground would re-point --surface, not these rules. Alphas are the
+     ceiling that keeps --ink-3 body text >=4.5:1 where BOTH washes overlap
+     (4.59:1; --ink-3 on bare --surface is only 4.96:1, so a wash has little
+     room and these are deliberately faint). */
+  --brand-wash-sun:  oklch(0.879 0.163 91 / 0.12);   /* --sun at 12% */
+  --brand-wash-pink: oklch(0.635 0.18 348 / 0.03);   /* --brand-canvas-1 at 3% */
+  /* The nav's active rail EXTENDS the blue->violet accent gradient into the
+     sunset instead of replacing it: product blue stays the interactive accent.
+     A separate token on purpose — .timeline::before is a DATA surface and
+     keeps the plain accent gradient. */
+  --brand-rail: linear-gradient(var(--accent-a) 0%, var(--accent-b) 55%, var(--brand-warm-a) 100%);
 
   /* fonts */
   --f-display: "Bricolage Grotesque", system-ui, sans-serif;
@@ -347,16 +387,18 @@ button { font-family: inherit; }
 .nav-item.active { color: var(--ink); font-weight: 600; background: var(--accent-bg); }
 .nav-item.active .ni-icon { color: var(--accent); }
 .nav-item.active .ni-icon { transform: translateX(1px); }
-/* active rail accent */
+/* active rail accent — blue -> violet -> sunset pink (--brand-rail): the
+   accent gradient extended into the brand family, not replaced by it. The
+   timeline rail keeps the plain accent gradient; it reads data. */
 .nav-item.active::before {
   content: ""; position: absolute; left: -18px; top: 50%; transform: translateY(-50%);
   width: 3px; height: 18px; border-radius: 0 3px 3px 0;
-  background: linear-gradient(var(--accent-a), var(--accent-b));
+  background: var(--brand-rail);
   animation: railpop .3s var(--ease-out);
 }
 [data-dir="trail"] .nav-item.active::before {
   height: 26px; width: 4px;
-  background: linear-gradient(var(--accent-a), var(--accent-b));
+  background: var(--brand-rail);
 }
 [data-dir="paper"] .nav-item.active { background: transparent; }
 [data-dir="paper"] .nav-item.active::before { left: -2px; }
@@ -811,13 +853,30 @@ button { font-family: inherit; }
 /* ============================================================
    empty / placeholder states
    ============================================================ */
+/* An empty screen is where the console should be friendliest, so this is a
+   brand moment: a faint sunrise wash over --surface and a sunset hairline on
+   the top edge. It stays a FRAME treatment — the wash never reaches a row, and
+   .ev-empty (which doubles as an inline error line: "Could not load servers…")
+   deliberately does NOT get it. Alphas are set by the --ink-3 body pair, which
+   holds >=4.5:1 even where both washes overlap. */
 .empty {
+  position: relative; overflow: hidden;
   display: flex; flex-direction: column; align-items: center; justify-content: center;
   text-align: center; padding: 64px 24px; gap: 14px;
-  border: 1px dashed var(--line); border-radius: var(--radius);
-  color: var(--ink-3); background: var(--surface);
+  border: 1px dashed color-mix(in srgb, var(--brand-canvas-2) 26%, var(--line));
+  border-radius: var(--radius);
+  color: var(--ink-3);
+  background:
+    radial-gradient(128% 104% at 50% -14%, var(--brand-wash-sun), transparent 64%),
+    radial-gradient(84% 78% at 104% 112%, var(--brand-wash-pink), transparent 70%),
+    var(--surface);
 }
-.empty-ic { color: var(--ink-4); }
+/* Absolute, so the flex column above never gets a fourth item. */
+.empty::before {
+  content: ""; position: absolute; inset: 0 0 auto; height: 3px;
+  background: linear-gradient(90deg, var(--brand-canvas-1) 0%, var(--brand-canvas-2) 52%, var(--brand-canvas-3) 100%);
+}
+.empty-ic { color: var(--brand-warm-b); }
 .empty h3 { font-family: var(--title-font); font-weight: 600; color: var(--ink-2); margin: 0; font-size: 17px; letter-spacing: -0.01em; }
 .empty p { margin: 0; max-width: 42ch; font-size: 13.5px; }
 
@@ -995,8 +1054,10 @@ button { font-family: inherit; }
 /* ============================================================
    busy modal — Restore actions (#1363)
    ============================================================ */
-/* Pure-CSS loading animation on the brand accent (--accent-a/--accent-b) —
-   the semantic insert/update/delete colors are data, never decoration.
+/* Pure-CSS loading animation on the brand's pink->orange arm (--brand-warm) —
+   the semantic insert/update/delete colors are data, never decoration, and a
+   modal that is WORKING is chrome, so the sunset belongs here (#1371). Both
+   stops clear 3:1 on the modal surface (3.94 / 3.70).
    Reduced-motion rule mirrors the #1353 event skeletons: the animation only
    exists under no-preference; otherwise the static .busy-static note shows. */
 .busy-modal { max-width: 480px; text-align: center; }
@@ -1004,7 +1065,7 @@ button { font-family: inherit; }
 .busy-anim { display: none; gap: 11px; justify-content: center; padding: 22px 0 4px; }
 .busy-anim span {
   width: 12px; height: 12px; border-radius: 50%;
-  background: linear-gradient(135deg, var(--accent-a), var(--accent-b));
+  background: var(--brand-warm);
 }
 .busy-static { display: block; color: var(--ink-2); font-size: 13.5px; margin: 16px 0 4px; }
 @media (prefers-reduced-motion: no-preference) {
@@ -1366,6 +1427,42 @@ button { font-family: inherit; }
    overflow:hidden clips the text against the edges. */
 .login-panel { max-width: 400px; padding: 30px 32px; }
 .login-panel .modal-title { margin-bottom: 12px; }
+/* The sign-in gate is the console's one full-screen brand canvas: the site's
+   hero sunset with the panel floating on it, the way dbtrail.com floats its
+   terminal block. Scoped to .login-gate — showPasswordDialog() mounts in the
+   same slot and is an ordinary task modal over the workspace, so it keeps the
+   shared translucent --scrim. Every layer here is one of the canvas stops, so
+   the brightest point of the whole screen is --brand-canvas-2 (white panel on
+   it: 3.26:1). Static by design: nothing to collapse under reduced motion. */
+.modal-scrim.login-gate {
+  background:
+    radial-gradient(72% 58% at 82% 2%, var(--brand-canvas-2), transparent 62%),
+    radial-gradient(96% 76% at 2% 106%, var(--brand-canvas-3), transparent 68%),
+    var(--brand-canvas);
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+  /* Near-centered on a tall viewport without flex centering: an overflowing
+     panel must still be scrollable to its top, which align-items:center inside
+     an overflow-y:auto scrim would clip away. */
+  padding: clamp(48px, 15vh, 150px) 24px 56px;
+}
+.modal-scrim.login-gate .login-panel {
+  box-shadow: 0 40px 90px -30px oklch(0.2 0.06 300 / 0.55), 0 1px 0 oklch(1 0 0 / 0.5) inset;
+}
+/* The panel's own title takes the site's headline gradient — the same
+   pink->orange->violet as dbtrail.com's H1. 22px/600 is WCAG "large text", and
+   all three stops clear the 3:1 large floor on the white panel (3.94 / 3.70 /
+   5.15). @supports so a browser without background-clip:text keeps solid ink
+   instead of a transparent fill. */
+@supports (background-clip: text) or (-webkit-background-clip: text) {
+  .modal-scrim.login-gate .login-panel .modal-title {
+    background: var(--brand-headline);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    width: fit-content;
+  }
+}
 .login-panel .modal-desc { max-width: none; }
 .login-panel .modal-desc + .modal-desc { margin-top: 10px; }
 .login-form { display: flex; flex-direction: column; gap: 14px; margin-top: 18px; }
@@ -1569,8 +1666,17 @@ button { font-family: inherit; }
 .stg-hint { margin-bottom: 0; }
 .stg-cardfoot { margin-top: 12px; }
 
-/* Storage empty states: lead + short steps, not paragraphs */
-.stg-empty { padding: 14px 4px; display: flex; flex-direction: column; gap: 7px; }
+/* Storage empty states: lead + short steps, not paragraphs. Same brand-moment
+   treatment as .empty (these are the onboarding surfaces), lighter-weight
+   because they sit inside a panel rather than standing alone. */
+.stg-empty {
+  padding: 15px 16px 17px; display: flex; flex-direction: column; gap: 7px;
+  border: 1px solid color-mix(in srgb, var(--brand-canvas-2) 22%, var(--line));
+  border-radius: var(--radius);
+  background:
+    radial-gradient(118% 128% at 100% -10%, var(--brand-wash-sun), transparent 66%),
+    var(--surface);
+}
 .stg-empty-lead { margin: 0; font-size: 13.5px; font-weight: 600; color: var(--ink-2); }
 .stg-empty-sub { margin: 0; font-size: 12.5px; color: var(--ink-3); max-width: 52ch; }
 


### PR DESCRIPTION
## Summary

Closes #1371.

#1359 adopted dbtrail.com's ink ramp, typography and product accents, and — following #1355's guardrail — kept brand color to two micro-moments. Correct, and chromatically shy: what defines the site's first impression is its tropical hero sunset, and none of it reached the console. This brings the warmth in, **in the frame only**.

### The stops, translated

The site's values are mapped the way #1359 mapped the ink ramp: **hue and chroma kept exactly, lightness lowered**, because the marketing values do not survive a console's floors. The binding pair is the white panel that floats *on* the canvas — on the site's peach it sits at **2.05:1**, below the 3:1 a UI surface needs to be identifiable. A uniform **ΔL ≈ -0.12** across the three hero stops (relationships and ordering preserved) puts the brightest at 3.26:1.

| Token | Site value | oklch (measured) | Console token | ΔL |
|---|---|---|---|---|
| `--brand-canvas-1` | hero pink `#FF7AC3` | `oklch(0.755 0.180 348.2)` | `oklch(0.635 0.18 348)` | -0.120 |
| `--brand-canvas-2` | hero peach `#FF9D5C` | `oklch(0.784 0.142 52.7)` | `oklch(0.66 0.142 53)` | -0.124 |
| `--brand-canvas-3` | hero violet `#9D7AFF` | `oklch(0.674 0.190 292.7)` | `oklch(0.555 0.19 293)` | -0.119 |
| `--brand-warm-a` | CTA pink `#FF4D8D` | `oklch(0.686 0.218 3.1)` | `oklch(0.63 0.218 3)` | -0.056 |
| `--brand-warm-b` | CTA orange `#FF8A3D` | `oklch(0.750 0.167 50.5)` | `oklch(0.63 0.155 51)` | -0.120 |

Plus the composed tokens: `--brand-canvas` (160° hero gradient), `--brand-headline` (135° site H1/CTA gradient), `--brand-warm` (pink→orange), `--brand-rail` (blue→violet→sunset), and two washes expressed as the brand colors at low **alpha over `--surface`** — `--brand-wash-sun` (`--sun` at 12%) and `--brand-wash-pink` (`--brand-canvas-1` at 3%) — never baked light values, so the composite follows the ground. Both are `color-mix` over `transparent` (the file's existing idiom), not re-typed oklch literals: a literal would silently stop being "`--sun` at 12%" the day `--sun` moves. Verified in Chrome that the `color-mix` form composites byte-identically (`#fffae8`) to the value the table below was computed from. Hex→oklch and every ratio below were computed by the same script (round-tripping each oklch pick back to sRGB against the issue's hex), not hand-transcribed.

## Brand moments delivered (1–4 of the issue's five)

1. **The sign-in gate** — the console's one full-screen brand canvas: the hero gradient with the panel floating on it, plus the panel title in the site's headline gradient. Scoped to a new `.login-gate` class on the gate's scrim, because `showPasswordDialog()` mounts in the same `#login-mount` slot and is an ordinary task modal over an authenticated workspace, not a gate — it keeps the shared translucent `--scrim`.
2. **Empty states** — `.empty` (the big zero-state, incl. the 1049 onboarding wall) and `.stg-empty` (the storage onboarding blocks) get a faint sunrise wash, a 3px sunset hairline on the top edge and a warm border. `.empty-ic` was deliberately **left on `--ink-4`**: no construction site in `app.js` builds one, so branding it would be a change nothing renders.
3. **The busy-modal dots** (#1363) — the pink→orange arm.
4. **The nav's active rail** — `--brand-rail` **extends** the blue→violet accent gradient into the sunset. Product blue stays the interactive accent; `.timeline::before` keeps the plain accent gradient because it reads data, which is exactly why this is a separate token.

**Deliberately left: #5, the full-page error/404/refused canvas.** There is no full-page error container to treat — `renderError` injects `.empty` / `.error-box` into whatever view container is mounted, so "same canvas treatment as login" would mean building a page shell first. Out of proportion to the win, and #2 already covers the friendly half of that surface (the 1049 state *is* an `.empty`).

## Guardrails

- **Semantic tokens byte-identical.** Verified at runtime, not by reading the diff — the driver dumps them from the live page: `--insert` `--update` `--delete` `--diff-add` `--diff-del` `--diff-*-bg` `--*-bg` all unchanged. Pink never lands on a surface that carries a row, so it is never adjacent to delete-red on data.
- **Data surfaces quiet.** `.ev-row`, `.ev-head`, `.badge`, `.filters`, the diff table and the time-travel rail were read from the rendered fixture: no gradient, no new background. `.btn-primary` still resolves to `linear-gradient(135deg, oklch(0.54 0.17 260), oklch(0.575 0.17 286))`. `.ev-empty` deliberately got **nothing** — it doubles as an inline error line ("Could not load servers: …") and a tropical wash behind that would be wrong.
- **oklch throughout**, added in `:root` per the file's own guard comment; alpha washes follow the existing `--scrim` / `--diff-*-bg` idiom.
- **`prefers-reduced-motion`**: the canvas is static by design, so there is nothing to collapse — confirmed by rendering the gate in a reduced-motion context (`animation-name: none` on both the scrim and the panel; identical `background-image`).

## Contrast — 21/21 pass

Floors: **4.5:1** body text, **3:1** large text (the gate title is 22px/600) and non-text UI.

| Foreground | Background | Used as | Ratio | Floor | |
|---|---|---|---|---|---|
| `--surface` (panel) | `--brand-canvas-1` | panel edge on canvas | **3.76** | 3:1 | ✓ |
| `--surface` (panel) | `--brand-canvas-2` | panel edge, canvas's brightest point | **3.26** | 3:1 | ✓ |
| `--surface` (panel) | `--brand-canvas-3` | panel edge on canvas | **5.15** | 3:1 | ✓ |
| `--ink` | `--surface` (panel) | gate body/labels | **16.01** | 4.5:1 | ✓ |
| `--ink-2` | `--surface` (panel) | gate description | **7.33** | 4.5:1 | ✓ |
| `--ink-3` | `--surface` (panel) | gate "or" divider | **4.96** | 4.5:1 | ✓ |
| `--brand-warm-a` | `--surface` (panel) | gate title, gradient stop 1 | **3.94** | 3:1 | ✓ |
| `--brand-warm-b` | `--surface` (panel) | gate title, gradient stop 2 | **3.70** | 3:1 | ✓ |
| `--brand-canvas-3` | `--surface` (panel) | gate title, gradient stop 3 | **5.15** | 3:1 | ✓ |
| `--ink` | sun wash @ full | empty-state bold | **15.32** | 4.5:1 | ✓ |
| `--ink-2` | sun wash @ full | empty-state heading | **7.02** | 4.5:1 | ✓ |
| `--ink-3` | sun wash @ full | empty-state body | **4.75** | 4.5:1 | ✓ |
| `--ink-2` | pink wash @ full | empty-state heading | **7.09** | 4.5:1 | ✓ |
| `--ink-3` | pink wash @ full | empty-state body | **4.80** | 4.5:1 | ✓ |
| `--ink-2` | both washes overlapping | empty-state heading | **6.78** | 4.5:1 | ✓ |
| `--ink-3` | both washes overlapping | empty-state body | **4.59** | 4.5:1 | ✓ |
| `--brand-warm-a` | `--surface` (modal) | busy dot | **3.94** | 3:1 | ✓ |
| `--brand-warm-b` | `--surface` (modal) | busy dot | **3.70** | 3:1 | ✓ |
| `--brand-warm-a` | studio sidebar | nav rail, sunset tail | **3.82** | 3:1 | ✓ |
| `--accent-a` (unchanged) | studio sidebar | nav rail, head | **5.01** | 3:1 | ✓ |
| `--accent-b` (unchanged) | studio sidebar | nav rail, mid | **4.50** | 3:1 | ✓ |

Two things worth naming. First, the canvas's *brightest point* is bounded by construction: every layer over the linear gradient is one of the three stops (a peach bloom top-right, a violet deepening bottom-left), so no composite can be lighter than `--brand-canvas-2` anywhere — the 3.26:1 row is the whole screen's worst case, not a sample. Second, the wash alphas are set by the tightest pair, not by taste: `--ink-3` on bare `--surface` is only **4.96:1**, so a wash has ~0.4 of headroom, and 12% / 3% is what keeps the **overlap** of both washes at 4.59:1. The washes are deliberately faint for that reason; the visible brand in the empty state is the hairline and the border.

## Themes

The console **ships no dark theme** — there is no `prefers-color-scheme`, no `data-theme`, no dark token arm anywhere in the tree (repo-wide grep over `*.css`/`*.js`/`*.html`/`*.go`). Its theme axes are `data-dir` (`paper`/`studio`/`trail`), `data-accent` and `data-density`, and `index.html` pins `studio`/`blue`.

So a dark arm was **not invented**: re-picking L/C against a ground that doesn't exist would produce a dark-tuned canvas behind a white panel on an otherwise white app — reviewable as neither right nor wrong. What was honored instead is the underlying concern, structurally: the washes are alpha over `--surface` rather than baked light values, so a future dark arm re-points the ground plus an L/C re-pick on five stops, not every brand rule. The "both themes" verification is over the axes that do exist — `studio` (shipped), `paper` and `trail`.

## Verification

- `go vet ./internal/console/` and `go test ./internal/console/ ./consoleapp/ -count=1 -race` — pass.
- **`test/console-e2e/run.sh` unmodified: 217/217 passed** (run again after the follow-up commit), including the geometry/cascade assertions the empty-state padding change could have disturbed and the `.btn-primary` gradient-on-hover guard.
- A separate headless-Chrome pass (throwaway driver, suite untouched) rendered against both a fresh install and run.sh's seeded fixture, capturing screenshots and computed styles for: the sign-in gate and the first-run setup gate; the `.empty` 1049 state; the `.stg-empty` storage onboarding; the busy modal; and the events view over 6 real indexed rows with a diff expanded — in `studio`, `paper` and `trail`, plus the gate under `reducedMotion: "reduce"`. No page errors in any pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
