### PR TITLE
console: Undo reverses the event you clicked, not the last one in its second

### DIFF
--- a/internal/console/api.go
+++ b/internal/console/api.go
@@ -106,12 +106,28 @@ type recoverRequest struct {
 	// re-sorted ASC before generation. A client-supplied value has no effect.
 	Order string `json:"order"`
 	Limit int    `json:"limit"`
-	// LimitPerPK reverses only the latest N events for the matched row. It is
-	// the only filter that can isolate one event from another when both share
-	// a timestamp: `since`/`until` are second-granular, so a row INSERTed and
-	// DELETEd inside the same second cannot be split by time. Requires a PK
-	// (see buildOptions).
+	// LimitPerPK reverses only the latest N events for the matched row.
+	// Requires a PK (see buildOptions).
+	//
+	// It used to be described here as "the only filter that can isolate one
+	// event from another when both share a timestamp". That was true of the
+	// time filters and false as a general claim, and Undo relied on it: with
+	// `until` second-granular, latest-per-row=1 resolves to "the newest event
+	// in that second", which on a row INSERTed and DELETEd inside one second
+	// is not the event the operator clicked (#1411). Event is the filter that
+	// isolates one event; this one caps a row's history.
 	LimitPerPK int `json:"limit_per_pk"`
+	// Event names ONE event exactly, encoded `<RFC3339Nano>|<event_id>` — the
+	// same spelling as the ?after=/?before= cursors, parsed by the same
+	// parseEventCursor. It is what Undo sends: the operator clicked a row, so
+	// the client already holds its identity and does not need the server to
+	// re-derive it from a timestamp.
+	//
+	// Composable rather than exclusive with the filters above: an anchor
+	// admits at most one event, so anything else narrows a set of one. It is
+	// NOT rejected alongside LimitPerPK for that reason — but callers that
+	// have an anchor should not also send a cap, and Undo no longer does.
+	Event string `json:"event"`
 }
 
 type eventsResponse struct {
@@ -455,6 +471,19 @@ func (s *Server) handleRecover(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeJSONError(w, http.StatusBadRequest, err.Error())
 		return
+	}
+	if body.Event != "" {
+		// A 400 rather than a silent fall back to the unanchored window: a
+		// malformed anchor means the client asked to reverse ONE event and
+		// would instead get everything the remaining filters admit. Undo's
+		// other filters are deliberately wide (schema/table/pk and an `until`
+		// at the clicked second), so the unanchored result is not a near miss.
+		anchor, perr := parseEventCursor("event", body.Event)
+		if perr != nil {
+			writeJSONError(w, http.StatusBadRequest, perr.Error())
+			return
+		}
+		opts.EventAnchor = anchor
 	}
 	opts, err = s.applySessionProfile(r.Context(), r, b, opts)
 	if err != nil {

--- a/internal/console/api.go
+++ b/internal/console/api.go
@@ -311,6 +311,31 @@ func (s *Server) fetch(ctx context.Context, b *bundle, opts query.Options) ([]qu
 	})
 }
 
+// applyEventAnchor parses the `event` parameter onto opts, writing a 400 and
+// returning false when it is malformed.
+//
+// A 400 rather than a silent fall back to the unanchored request: the caller
+// asked for ONE event and would instead get everything the remaining filters
+// admit. Undo's other filters are deliberately wide — schema/table/pk and an
+// `until` at the clicked second — so the degraded result is not a near miss,
+// it is the row's whole history returned with a 200.
+//
+// Shared by /api/events and /api/recover so the preview and the script cannot
+// disagree about what the anchor means, or about whether it is honoured at
+// all. They diverged once already, in exactly that direction.
+func applyEventAnchor(w http.ResponseWriter, opts *query.Options, raw string) bool {
+	if raw == "" {
+		return true
+	}
+	anchor, err := parseEventCursor("event", raw)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return false
+	}
+	opts.EventAnchor = anchor
+	return true
+}
+
 // handleEvents serves GET /api/events — the events browser.
 func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	b := s.resolveOr(w, r)
@@ -353,6 +378,15 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	opts, err := s.buildOptions(p, eventsDefaultLimit, eventsMaxLimit)
 	if err != nil {
 		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	// The anchor is accepted here for exactly the reason stated above the cap,
+	// and it is the sharper case: unmirrored, the preview lists the row's whole
+	// history up to the clicked second while the script reverses one event of
+	// it. Review caught this wired on the client and missing here — with a
+	// guard that only checked the client half, so it was green over the broken
+	// promise.
+	if !applyEventAnchor(w, &opts, q.Get("event")) {
 		return
 	}
 	// Per-PK caps and keyset paging are mutually exclusive, and the reason is
@@ -472,18 +506,8 @@ func (s *Server) handleRecover(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if body.Event != "" {
-		// A 400 rather than a silent fall back to the unanchored window: a
-		// malformed anchor means the client asked to reverse ONE event and
-		// would instead get everything the remaining filters admit. Undo's
-		// other filters are deliberately wide (schema/table/pk and an `until`
-		// at the clicked second), so the unanchored result is not a near miss.
-		anchor, perr := parseEventCursor("event", body.Event)
-		if perr != nil {
-			writeJSONError(w, http.StatusBadRequest, perr.Error())
-			return
-		}
-		opts.EventAnchor = anchor
+	if !applyEventAnchor(w, &opts, body.Event) {
+		return
 	}
 	opts, err = s.applySessionProfile(r.Context(), r, b, opts)
 	if err != nil {

--- a/internal/console/api.go
+++ b/internal/console/api.go
@@ -336,6 +336,44 @@ func applyEventAnchor(w http.ResponseWriter, opts *query.Options, raw string) bo
 	return true
 }
 
+// anchorMissedWarning fires when a request named ONE event and the fetch
+// returned nothing.
+//
+// Before the anchor, an empty Undo meant exactly one thing: nothing happened in
+// the window. The anchor adds several causes that all render identically — a
+// 200 with `-- No events matched the specified criteria.`, no warnings, no
+// notes — and the operator has no way to tell them apart:
+//
+//   - the anchor is stale after a target edit (the client clears it on
+//     schema/table/pk changes, but that is a client-side mitigation of a
+//     server-side ambiguity, and it deliberately does NOT cover since/until);
+//   - since/until were narrowed past the anchored instant, which is an
+//     ordinary scope edit on a visible field and leaves the banner on screen
+//     still asserting the clicked event was reversed;
+//   - an access profile withholds the target table;
+//   - the event lives only in an archive source that failed under AllowGaps
+//     (these browsing endpoints keep a partially-failing source a log-only
+//     condition — a deliberate trade-off for BROWSING, and a reversal script
+//     naming one event is not browsing);
+//   - the anchor was minted against a different server's index (event_id is a
+//     per-index AUTO_INCREMENT, so the same id exists in several at once);
+//   - the index was rebuilt or renumbered under it.
+//
+// The server is the only layer that can see all of them, so this is where the
+// distinction is drawn. It is a WARNING, not an error: the empty result is a
+// legitimate answer, it just must not read as a finding.
+func anchorMissedWarning(opts query.Options, rowCount int) []string {
+	if opts.EventAnchor == nil || rowCount > 0 {
+		return nil
+	}
+	return []string{fmt.Sprintf(
+		"The selected event (id %d at %s UTC) was not found. It may fall outside the time range "+
+			"on this form, be withheld by your access profile, be held only in an archive this "+
+			"read did not reach, or belong to a different server — event ids are per-index. "+
+			"This is NOT evidence that the row has no history.",
+		opts.EventAnchor.EventID, opts.EventAnchor.Timestamp.UTC().Format("2006-01-02 15:04:05"))}
+}
+
 // handleEvents serves GET /api/events — the events browser.
 func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	b := s.resolveOr(w, r)
@@ -442,6 +480,9 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	// the archives went unread — but as an info NOTE (#1365): it is a benign
 	// audit fact, not an incident.
 	warnings, notes := responseAdvisories(plan, excl, diverged, archivesElided, archiveElisionNote())
+	// The preview mirrors the script, so it mirrors this too: an empty preview
+	// under an anchor is the same ambiguity, rendered as "0 affected event(s)".
+	warnings = append(anchorMissedWarning(opts, len(rows)), warnings...)
 	resp := eventsResponse{
 		Events:   toEventDTOs(rows),
 		Count:    len(rows),
@@ -551,6 +592,9 @@ func (s *Server) handleRecover(w http.ResponseWriter, r *http.Request) {
 	// an info note (#1365), since the skip is correctness-preserving —
 	// worded for this surface (a reversal has a window, not pages).
 	warnings, notes := responseAdvisories(plan, excl, diverged, archivesElided, recoverArchiveElisionNote())
+	// Prepended: on an empty anchored reversal this is the only thing the
+	// response says, and it has to be the first thing read.
+	warnings = append(anchorMissedWarning(opts, len(rows)), warnings...)
 
 	// The fetch above ran Order=DESC so the limit kept the newest suffix of
 	// the window (#981). Detect truncation on the FETCHED row count — before

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -2073,41 +2073,36 @@ function renderRecover(params) {
     const banner = el("div", { class: "ctx-banner", id: "undo-ctx-banner" });
     banner.append(el("span", { class: "badge " + badgeClass(ctx.type), text: ctx.type }));
     banner.append(el("div", { class: "ctx-main" },
-      // Scope, not target state — and the scope is a WINDOW OF TIME, not an
-      // event. The prefill sets `until` from ctx.time and never `since`;
-      // ctx.time is second-granular (consoleTSFormat) and the predicate is
-      // `event_timestamp <= ?`, so the ceiling is the END OF THAT SECOND, not
-      // the clicked event. Everything on the row up to there is reversed,
-      // including events that happened AFTER the clicked one inside the same
-      // second.
+      // Scope, and since #1411 the scope is an EVENT, not a window of time.
+      // The prefill sets form.elements.event from ctx.anchor — the server's own
+      // `<RFC3339Nano>|<event_id>` token for the clicked row — and the engine
+      // filters on that identity, so exactly one event is reversed and it is
+      // the one pointed at.
       //
-      // That is not a corner case, it is the case this wording exists for —
-      // and #1404 INVERTED its outcome, which this paragraph went on claiming
-      // the opposite of until review caught it. It used to read "undoing from
-      // EITHER event reverses both and leaves no row at all", which was true
-      // when it was written and was falsified by the prefill below, sixteen
-      // lines away, in the same file. What happens now: the cap keeps the LAST
-      // event in that second — the DELETE — so undoing from either event
-      // RE-CREATES the row. The banner says so; this comment used to say the
-      // reverse of it.
+      // What this block used to have to explain, kept because it is the reason
+      // the anchor exists rather than history for its own sake: with only
+      // `until` + latest-per-row = 1, the ceiling was the END OF A SECOND and
+      // the cap kept the last event inside it. On a row INSERTed and DELETEd
+      // within one second that is the DELETE whichever row was clicked, and
+      // reversing a DELETE re-creates the row — so Undo on the INSERT put the
+      // row BACK while the badge read INSERT. The banner disclosed it in
+      // words; disclosure was the right immediate move and a poor permanent
+      // one.
       //
-      // Worth knowing about the guard: it deliberately reads string literals
-      // only, so no test can ever see prose in this block. Stale comments here
-      // are a manual-review class, and this was a live instance of one.
+      // `until` stays prefilled and is still worth stating: it is how the
+      // operator reads WHEN, and it is what remains as the scope if they press
+      // Clear. It no longer decides WHICH.
       //
-      // The remaining imprecision is stated rather than smoothed over. Latest
-      // per row keeps the LATEST event at or before the ceiling, and the
-      // ceiling is a whole second, so on a row touched more than once inside
-      // that second the reversal lands on the last of them — which need not be
-      // the one the operator clicked. Since cannot fix it either: it parses at
-      // the same granularity. Naming a control without saying where it stops
-      // working is how an operator ends up believing they narrowed something
-      // they did not.
+      // Worth knowing about the guard: assets_recover_banner_test.go reads
+      // string literals only, so no test can see this prose. The same-second
+      // caveat it used to pin as REQUIRED text is now false and was removed in
+      // the same commit that made it false — dropping one without the other
+      // either fails the build or ships a lie.
       el("span", { class: "ctx-eyebrow", text: "Undoing one change" }),
-      el("span", { class: "ctx-title", text: ctx.schema + "." + ctx.table + " · pk " + ctx.pk }),
-      el("span", { class: "ctx-detail", text: "reverses the latest change to this row at or before the end of the second holding this "
-        + ctx.type + " (" + ctx.time + " UTC)" }),
-      el("span", { class: "ctx-detail", text: "Latest per row is set to 1 — clear it to reverse this row's whole history up to that point. If the row changed more than once inside that second, the last of them is the one reversed — not necessarily the one you clicked. A row created and deleted within one second comes back rather than going away." })));
+      el("span", { class: "ctx-title", text: ctx.schema + "." + ctx.table + " \u00b7 pk " + ctx.pk }),
+      el("span", { class: "ctx-detail", text: "reverses exactly this " + ctx.type
+        + ", the one you clicked (" + ctx.time + " UTC) — not the rest of the row's history, and not other changes sharing that second" }),
+      el("span", { class: "ctx-detail", text: "Clear to search this row freely instead; the time you clicked stays as the upper bound." })));
     banner.append(el("span", { class: "spacer" }));
     banner.append(el("button", { class: "btn btn-sm btn-ghost", type: "button", text: "Clear",
       onclick: () => { pendingRecover = null; navigate("recover"); } }));
@@ -2122,6 +2117,13 @@ function renderRecover(params) {
   // events are still indexed — a typed name must always submit.
   form.append(fieldTableCombo("Table", "table", "md", "orders"));
   form.append(fieldInput("PK", "pk", "sm", "42 or 42|7"));
+  // The undo anchor rides in the form rather than in a module variable so the
+  // two request builders pick it up the same way every other filter does (both
+  // read the form through FormData). That is what keeps "Preview rows" and
+  // "Generate undo SQL" showing the same events — the promise previewRecover
+  // makes. Hidden because it is an identity, not a filter an operator can
+  // usefully type: it is set by Undo and removed by the banner's Clear.
+  form.append(el("input", { type: "hidden", name: "event" }));
   // Latest-per-row sits beside PK because it is meaningless without one (the
   // server refuses the pair). It is the only filter that can separate events
   // sharing a timestamp: Since/Until are second-granular, so a row created and
@@ -2152,16 +2154,20 @@ function renderRecover(params) {
       form.elements.table.value = ctx.table;
       form.elements.pk.value = ctx.pk;
       if (ctx.time) form.elements.until.value = ctx.time;
-      // Undo means "undo THIS change", and until #1404 it did not: with only
-      // `until` set, the window ran from the beginning of time and the script
-      // reversed the row's ENTIRE history up to that second. On a row touched
-      // five times, undoing the third put it back to before the first.
+      // Undo means "undo THIS change", and it now says which one. #1404 got
+      // the scope down to a single event with `until` + latest-per-row = 1,
+      // which is one event but not necessarily the CLICKED one: both filters
+      // are second-granular between them, so a row INSERTed and DELETEd inside
+      // one second resolved to the DELETE whichever of the two was clicked —
+      // and reversing a DELETE re-creates the row, inverting the outcome
+      // (#1411). The anchor names the event itself, so no cap is needed and
+      // none is set: two mechanisms narrowing the same scope is how they drift.
       //
-      // Prefilled rather than hardcoded: it lands in a visible, editable field
-      // and the banner states it, so widening the scope is one edit away and
-      // narrowing it was never a silent act. Clearing the field restores the
-      // old whole-history behaviour exactly.
-      form.elements.limit_per_pk.value = "1";
+      // `until` is left prefilled even though the anchor makes it redundant for
+      // membership. It is what the operator reads to know WHEN, it bounds the
+      // engine's partition scan, and clearing the anchor (banner → Clear) must
+      // leave a sane window behind rather than the whole index.
+      if (ctx.anchor) form.elements.event.value = ctx.anchor;
       generateUndo(form);
     });
   }
@@ -2371,9 +2377,12 @@ async function previewRecover(form) {
   const warns = $("#recover-warnings", VIEW());
   const f = Object.fromEntries(new FormData(form).entries());
   const params = {};
-  ["schema", "table", "pk", "since", "until"].forEach((k) => { if (f[k] && f[k].trim()) params[k] = f[k].trim(); });
+  ["schema", "table", "pk", "since", "until", "event"].forEach((k) => { if (f[k] && f[k].trim()) params[k] = f[k].trim(); });
   // Part of mirroring recover's effective window (see below): without this the
-  // preview would list events the generated script will not touch.
+  // preview would list events the generated script will not touch. The anchor
+  // above is here for the same reason and matters more — unmirrored, the
+  // preview would list every event in the clicked second while the script
+  // reverses exactly one of them.
   const plpp = parseLatestPerRow(f.limit_per_pk);
   if (plpp === null) { renderError(container, "Latest per row must be a whole number, 0 or more."); return; }
   if (plpp > 0) params.limit_per_pk = String(plpp);
@@ -2465,7 +2474,7 @@ async function generateUndo(form) {
   const out = $("#recover-out", VIEW());
   const f = Object.fromEntries(new FormData(form).entries());
   const body = {};
-  ["schema", "table", "pk", "since", "until"].forEach((k) => { if (f[k] && f[k].trim()) body[k] = f[k].trim(); });
+  ["schema", "table", "pk", "since", "until", "event"].forEach((k) => { if (f[k] && f[k].trim()) body[k] = f[k].trim(); });
   if (!body.schema) { renderError(out, "Choose at least a schema to search."); return; }
   // Sent as a NUMBER: the field is an int on the wire, and a string would be
   // rejected by the decoder rather than silently ignored. Only when > 0 —
@@ -2576,6 +2585,11 @@ function undoEvent(e) {
   pendingRecover = {
     schema: e.schema_name, table: e.table_name, pk: e.pk_values,
     type: e.event_type, time: e.event_timestamp,
+    // The server's own identity token for this row, echoed back verbatim
+    // (eventDTO.Anchor). Never rebuilt from `time`: that one is second-
+    // granular and offset-less, which is exactly the ambiguity the anchor
+    // exists to remove (#1411).
+    anchor: e.anchor,
   };
   navigate("recover");
 }
@@ -2713,6 +2727,12 @@ function aimUndoAtInstant(form, at) {
   // reverse only the newest of them and land it somewhere else entirely,
   // silently, with the button still naming the state it did not produce.
   form.elements.limit_per_pk.value = "";
+  // The undo anchor goes for the strongest version of the same reason: it
+  // names ONE event, and this action reverses every change after `at`. Left
+  // set, the generated script would reverse exactly the event the operator
+  // clicked minutes ago in Events and nothing else, while the button that
+  // produced it named a completely different outcome.
+  form.elements.event.value = "";
   // …and retire the banner that describes the scope just replaced. It states
   // "Latest per row is set to 1" as a fact about this form, and the line above
   // makes that false: the operator would read a one-change scope over a script

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -2125,9 +2125,11 @@ function renderRecover(params) {
   // usefully type: it is set by Undo and removed by the banner's Clear.
   form.append(el("input", { type: "hidden", name: "event" }));
   // Latest-per-row sits beside PK because it is meaningless without one (the
-  // server refuses the pair). It is the only filter that can separate events
-  // sharing a timestamp: Since/Until are second-granular, so a row created and
-  // deleted inside the same second cannot be split by time.
+  // server refuses the pair). It caps a row's HISTORY — it does not name an
+  // event: this comment used to claim it was "the only filter that can
+  // separate events sharing a timestamp", which was true of the time filters
+  // and false as a general claim, and Undo relied on it (#1411). The hidden
+  // `event` field above is what separates events sharing a second.
   form.append(fieldInput("Latest per row", "limit_per_pk", "sm", "all"));
   form.append(fieldDateInput("Since (UTC)", "since", "md", "YYYY-MM-DD HH:MM:SS"));
   form.append(fieldDateInput("Until (UTC)", "until", "md", "YYYY-MM-DD HH:MM:SS"));
@@ -2145,6 +2147,24 @@ function renderRecover(params) {
   v.append(el("div", { id: "recover-out" }));
 
   form.addEventListener("submit", (e) => { e.preventDefault(); generateUndo(form); });
+  // Editing the target retires the anchor, and the banner with it.
+  //
+  // The anchor names one event of one row. Retype the PK and it still names
+  // the OLD row's event, so the request comes back empty — a 200 with no
+  // statements, which reads as "this row has no history to undo". It fails
+  // closed rather than producing wrong SQL, but the narrowing moved from a
+  // VISIBLE field the banner named ("Latest per row is set to 1 — clear it
+  // to…") into a hidden one nothing names, so an operator has nothing to
+  // notice. Retiring it on a target edit is what keeps the form's visible
+  // state and its actual scope the same thing.
+  //
+  // Bound to `change`, not `input`: a keystroke-by-keystroke clear would drop
+  // the anchor while the operator is still typing over a value they mean to
+  // restore.
+  for (const name of ["schema", "table", "pk"]) {
+    const field = form.elements[name];
+    if (field) field.addEventListener("change", () => clearUndoAnchor(form));
+  }
   wireSchemaCascade(form);
   populateSchemas(form);
 
@@ -2256,6 +2276,12 @@ function recoverBusyFacts(f) {
   // Both call sites pass their own request object — generateUndo a number,
   // previewRecover a string — so stringify rather than assume either.
   if (f.limit_per_pk) facts.push(["latest per row", String(f.limit_per_pk)]);
+  // The anchor is the filter that most determines the scope and the only one
+  // with no visible field, so the busy modal is where an operator can see it
+  // at all. Shown as the event id rather than the raw token: the timestamp is
+  // already on the `until` line above, and the id is what the Events view
+  // shows beside the row they clicked.
+  if (f.event) facts.push(["single event", String(f.event).split("|").pop()]);
   return facts;
 }
 
@@ -2699,6 +2725,21 @@ async function runState(form, history) {
     });
     renderError(dlg.body, err);
   }
+}
+
+// clearUndoAnchor retires the single-event selection and the banner that
+// describes it, leaving the visible filters untouched.
+//
+// Shared by the target-edit listeners and available to anything else that
+// widens the scope. It does NOT touch `until`: that is the scope the operator
+// is left with, and blanking it here would silently widen a retargeted search
+// to the whole index.
+function clearUndoAnchor(form) {
+  if (!form.elements.event || !form.elements.event.value) return;
+  form.elements.event.value = "";
+  pendingRecover = null;
+  const banner = document.getElementById("undo-ctx-banner");
+  if (banner) banner.remove();
 }
 
 // aimUndoAtInstant points the undo window at the state as of `at`: reverse

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -2104,8 +2104,17 @@ function renderRecover(params) {
         + ", the one you clicked (" + ctx.time + " UTC) — not the rest of the row's history, and not other changes sharing that second" }),
       el("span", { class: "ctx-detail", text: "Clear to search this row freely instead; the time you clicked stays as the upper bound." })));
     banner.append(el("span", { class: "spacer" }));
+    // Clear retires the SELECTION, not the form.
+    //
+    // It used to `navigate("recover")`, which re-renders the route and builds a
+    // fresh EMPTY form — so the one control labelled Clear wiped the target and
+    // the upper bound, while the sentence above it promised the opposite
+    // ("search this row freely… the time you clicked stays as the upper
+    // bound"). The mechanism that sentence describes already existed, as
+    // clearUndoAnchor; it just had no name in the UI. Calling it here is what
+    // makes the copy true.
     banner.append(el("button", { class: "btn btn-sm btn-ghost", type: "button", text: "Clear",
-      onclick: () => { pendingRecover = null; navigate("recover"); } }));
+      onclick: () => clearUndoAnchor(form) }));
     v.append(banner);
   }
 
@@ -2774,11 +2783,12 @@ function aimUndoAtInstant(form, at) {
   // clicked minutes ago in Events and nothing else, while the button that
   // produced it named a completely different outcome.
   form.elements.event.value = "";
-  // …and retire the banner that describes the scope just replaced. It states
-  // "Latest per row is set to 1" as a fact about this form, and the line above
-  // makes that false: the operator would read a one-change scope over a script
-  // that reverses everything after `at`. The stale-label half of the same bug
-  // the comment above describes, one level up from the fields.
+  // …and retire the banner that describes the scope just replaced. It asserts
+  // that exactly the clicked event is reversed, and the lines above make that
+  // false: this action reverses EVERYTHING after `at`. (Before #1411 the same
+  // contradiction ran through the cap — the banner then read "Latest per row is
+  // set to 1", which the clear above falsified.) The stale-label half of the
+  // same bug, one level up from the fields.
   //
   // By ID, not by `.ctx-banner`: generateUndo appends a second node with that
   // class into #recover-out for the cascade notice, and an unscoped remove

--- a/internal/console/assets_recover_banner_test.go
+++ b/internal/console/assets_recover_banner_test.go
@@ -7,40 +7,55 @@ import (
 )
 
 // The Restore "Undo" banner must describe exactly what the generated script
-// reverses — and since #1404 that is ONE change, not a window.
+// reverses — and since #1411 that is ONE NAMED EVENT, not a window and not
+// "the last change in a second".
 //
-// The history is the point of the guard. renderRecover's prefill sets `until`
-// from the clicked event and never `since`, so the window ran from the
-// beginning of time: undoing the third of five changes to a row put it back to
-// before the FIRST. #1388 fixed the WORDING to match that behaviour; #1404
-// changed the behaviour instead, prefilling `limit_per_pk = 1` so the script
-// reverses the latest change at or before the ceiling.
+// The history is the point of the guard, and it has three layers. renderRecover
+// used to set `until` from the clicked event and never `since`, so the window
+// ran from the beginning of time: undoing the third of five changes to a row
+// put it back to before the FIRST. #1388 fixed the WORDING to match that.
+// #1404 changed the BEHAVIOUR instead, prefilling `limit_per_pk = 1`.
 //
-// What did not change is the ceiling. `ctx.time` is second-granular
-// (consoleTSFormat) and the predicate is `event_timestamp <= ?`, so it is the
-// END of that second. On a row touched more than once inside it — a row
-// INSERTed and DELETEd in the same second, like WordPress
-// `_transient_doing_cron` — the reversal lands on the LAST of them, which need
-// not be the one the operator clicked. `since` is no remedy: it parses at the
-// same granularity. The banner has to say so.
+// That left one event but not necessarily the CLICKED one. `ctx.time` is
+// second-granular and the predicate was `event_timestamp <= ?`, so the cap kept
+// the last event in that whole second. On a row INSERTed and DELETEd inside one
+// second — WordPress `_transient_doing_cron` is the everyday case — that is the
+// DELETE whichever row was clicked, and reversing a DELETE re-creates the row:
+// clicking Undo on the INSERT put the row BACK, with the badge still reading
+// INSERT. The banner disclosed it in words, which is why the previous version
+// of this guard REQUIRED the caveat.
 //
-// Three drafts got this wrong in the same direction before the behaviour was
-// fixed: "Reverting this row to before this point" named a target state,
-// "Undoing every change up to this point" named the clicked event as the
-// boundary, and "Undoing every change in this window" was accurate only while
-// the whole history really was reversed. Hence a guard.
+// #1411 removed the ambiguity instead: the prefill carries the server's own
+// `<RFC3339Nano>|<event_id>` token for the clicked row, the engine filters on
+// that identity, and the caveat became false. So the sentences this guard used
+// to require are now BANNED, and the guard asserts the opposite claim. That
+// inversion is the reason it is spelled out here: a reader finding the old
+// caveat in git history must be able to see it was retired deliberately, not
+// lost.
+//
+// Four drafts got the wording wrong before the behaviour was fixed:
+// "Reverting this row to before this point" named a target state, "Undoing
+// every change up to this point" named the clicked event as the boundary,
+// "Undoing every change in this window" was accurate only while the whole
+// history was reversed, and the same-second caveat was accurate only while the
+// scope was a second. Hence a guard.
 func TestAppJSUndoBannerStatesWhatIsReversed(t *testing.T) {
 	eyebrow, detail := undoBannerText(t)
 	all := eyebrow + detail
 
-	// (a) Retired phrasings, including the one that was correct until the
-	// behaviour changed under it. Checked against the banner text ONLY — see
-	// undoBannerText: a needle in a comment can neither satisfy nor trip these.
+	// (a) Retired phrasings, each of which was correct when written and was
+	// falsified by a later change to the behaviour. Checked against the banner
+	// text ONLY — see undoBannerText: a needle in a comment can neither satisfy
+	// nor trip these, which is what lets the paragraphs above quote them.
 	for _, banned := range []struct{ text, why string }{
 		{"Reverting this row to before this point", "names a target state the script does not produce"},
-		{"up to this point", "names the clicked event as the ceiling; the ceiling is its whole second"},
-		{"Undoing every change", "the prefill reverses ONE change now, not every change on the row"},
-		{"not only that one", "was the whole-history caveat; with limit_per_pk=1 it is simply false"},
+		{"up to this point", "names the clicked event as the ceiling; the ceiling was its whole second"},
+		{"Undoing every change", "the prefill reverses ONE change, not every change on the row"},
+		{"not only that one", "was the whole-history caveat; false since the scope became one event"},
+		{"more than once inside that second", "was the same-second caveat; the anchor names the event, so the second no longer decides"},
+		{"not necessarily the one you clicked", "was true of the second-granular ceiling and is now the exact opposite of what happens"},
+		{"comes back rather than going away", "described the inverted outcome the anchor removed"},
+		{"Latest per row is set to 1", "the prefill no longer sets it; a banner naming a control it did not touch sends the operator to clear the wrong field"},
 	} {
 		if strings.Contains(all, banned.text) {
 			t.Errorf("the Undo banner reintroduces %q — %s.\nBanner was: %s", banned.text, banned.why, all)
@@ -49,54 +64,47 @@ func TestAppJSUndoBannerStatesWhatIsReversed(t *testing.T) {
 
 	// (b) The eyebrow states the singular scope.
 	if !strings.Contains(eyebrow, "one change") {
-		t.Errorf("the Undo banner eyebrow no longer says it undoes ONE change (%q). With "+
-			"limit_per_pk prefilled to 1 that is what the script does, and an eyebrow promising a "+
-			"window would over-state the blast radius in the safe direction — which still teaches "+
-			"the operator to distrust the banner.", eyebrow)
+		t.Errorf("the Undo banner eyebrow no longer says it undoes ONE change (%q). That is what "+
+			"the script does, and an eyebrow promising a window would over-state the blast radius "+
+			"in the safe direction — which still teaches the operator to distrust the banner.", eyebrow)
 	}
 
-	// (c) The ceiling is stated. Asserted as source fragments: the sentence is
-	// concatenated around ctx.type/ctx.time, so the rendered sentence never
-	// appears contiguously in the source.
-	for _, want := range []string{"latest change to this row", "end of the second"} {
+	// (c) The detail makes the IDENTITY claim, which is the one thing the
+	// operator cannot verify by reading the form: `until` is visible and says
+	// "that second", so without this sentence the visible fields under-describe
+	// the actual scope and the banner reads as the looser of the two.
+	//
+	// Asserted as source fragments: the sentence is concatenated around
+	// ctx.type/ctx.time, so the rendered sentence never appears contiguously.
+	for _, want := range []string{"exactly this", "the one you clicked"} {
 		if !strings.Contains(detail, want) {
 			t.Errorf("the Undo banner detail dropped %q.\nDetail was: %s\n"+
-				"Without it a reader cannot tell which change is reversed, or how far the ceiling reaches.", want, detail)
+				"Without it the banner does not distinguish the clicked event from everything "+
+				"else in its second, which is the distinction #1411 exists to make.", want, detail)
 		}
 	}
 
-	// (d) The control is named AND its escape hatch is offered. A prefill the
-	// banner does not mention is a silent narrowing — the thing #1388 was
-	// about not doing.
-	if !strings.Contains(detail, "Latest per row is set to 1") {
-		t.Error("the Undo banner no longer states that Latest per row was prefilled. The prefill " +
-			"changes what the button reverses; leaving it unsaid makes it a silent narrowing.")
-	}
-	if !strings.Contains(detail, "clear it") {
-		t.Error("the Undo banner states the prefill without saying how to undo it. The old " +
-			"whole-history behaviour is one cleared field away and the operator has to know that.")
-	}
-
-	// (e) The residual imprecision, which no control fixes.
-	if !strings.Contains(detail, "more than once inside that second") {
-		t.Error("the Undo banner dropped the same-second caveat. With a one-second ceiling the " +
-			"reversal lands on the LAST change in that second, which need not be the clicked one — " +
-			"that is exactly the case this banner exists for, so the caveat is not optional.")
-	}
-
-	// (f) …and the OUTCOME of that imprecision, not only its mechanism. Stating
-	// "the last of them is the one reversed" is true and still leaves the
-	// reader to derive the inversion: on a row INSERTed and DELETEd inside one
-	// second the cap keeps the DELETE, so clicking Undo on the INSERT
-	// RE-CREATES the row instead of removing it — the opposite of the intent,
-	// with the badge above still reading INSERT. Review found this riding along
-	// undisclosed; deriving it is not the operator's job.
-	for _, want := range []string{"not necessarily the one you clicked", "comes back"} {
+	// (d) …and it says what is NOT reversed. "One change" alone is ambiguous
+	// between "one change of this row's history" and "one change among those
+	// sharing this second", and the two differ on exactly the shape that used
+	// to invert.
+	for _, want := range []string{"history", "that second"} {
 		if !strings.Contains(detail, want) {
-			t.Errorf("the Undo banner dropped %q.\nDetail was: %s\n"+
-				"Without it the same-second caveat names a mechanism and hides the one outcome "+
-				"that is inverted from what the operator asked for.", want, detail)
+			t.Errorf("the Undo banner detail dropped %q.\nDetail was: %s\n"+
+				"The scope is stated by exclusion — neither the rest of the row's history nor "+
+				"the other changes in the clicked second — and dropping half of that leaves the "+
+				"remaining half readable as the wrong one.", want, detail)
 		}
+	}
+
+	// (e) The escape hatch is offered. An anchor the banner does not mention is
+	// a silent narrowing — the thing #1388 was about not doing — and it is
+	// narrower than any control visible in the form, so an operator who wants
+	// the row's history has no field to clear and no way to guess.
+	if !strings.Contains(detail, "Clear") {
+		t.Error("the Undo banner no longer points at Clear. The anchor is not a visible form " +
+			"field, so an operator who wants to widen the scope has nothing to edit and no way " +
+			"to learn that the button beside the banner is the way out.")
 	}
 }
 
@@ -134,33 +142,88 @@ func TestUndoBannerCarriesTheIdItIsRetiredBy(t *testing.T) {
 // The banner is prose; this pins the behaviour it describes. They fail to
 // different edits — dropping the prefill leaves a banner promising something
 // the script no longer does, and nothing throws either way.
-func TestUndoPrefillsLatestPerRow(t *testing.T) {
+func TestUndoPrefillsTheEventAnchor(t *testing.T) {
+	fn := functionSource(t, "renderRecover")
+
+	if !strings.Contains(fn, "form.elements.event.value = ctx.anchor;") {
+		t.Error("renderRecover's Undo prefill no longer carries the event anchor. Without it the " +
+			"request falls back to `until` alone — the window has no lower bound and no per-row " +
+			"cap, so the script reverses the row's ENTIRE history up to the clicked second (the " +
+			"#1404 defect) while the banner says one change.")
+	}
+	// The ceiling has to survive alongside it, for two reasons that outlive the
+	// anchor: it is what the operator reads to know WHEN, and it is the scope
+	// left behind when they press Clear. Without it, Clear widens to the whole
+	// index in one click.
+	if !strings.Contains(fn, "form.elements.until.value = ctx.time;") {
+		t.Error("renderRecover's Undo prefill no longer sets `until`. It is what the operator " +
+			"reads to know when, and what bounds the scope after Clear removes the anchor.")
+	}
+	// And the cap must NOT come back. Two mechanisms narrowing the same scope
+	// is how they drift: the anchor already admits one event, so a cap of 1
+	// changes nothing until someone clears the anchor — at which point it
+	// silently reinstates the #1404 behaviour under a banner that no longer
+	// mentions it.
+	if strings.Contains(fn, `form.elements.limit_per_pk.value = "1";`) {
+		t.Error("renderRecover's Undo prefill sets limit_per_pk again. The anchor already names " +
+			"one event; a second narrowing mechanism is invisible in the banner and reappears " +
+			"the moment the anchor is cleared.")
+	}
+}
+
+// The anchor is only as good as the identity it carries, and the failure mode
+// is silent in the worst way: `e.anchor` reaching the bridge as undefined
+// leaves the hidden field empty, the request unanchored, and the script back to
+// reversing the row's whole history up to the clicked second — with the new
+// banner claiming it reversed exactly one event.
+//
+// Pinned as the FIELD, not the value: rebuilding the token client-side from
+// `e.event_timestamp` is the specific mistake this guards. That timestamp is
+// second-granular and offset-less, so a reconstruction guesses a location, and
+// guessing wrong does not fail — it names a different row.
+func TestUndoBridgeCarriesTheServersAnchorToken(t *testing.T) {
+	fn := functionSource(t, "undoEvent")
+	if !strings.Contains(fn, "anchor: e.anchor") {
+		t.Error("undoEvent no longer copies the server's anchor token onto pendingRecover. " +
+			"Without it the prefill has nothing to set, the request is unanchored, and the " +
+			"banner's identity claim becomes false with nothing reporting it.")
+	}
+}
+
+// Both request builders must send the anchor, and the second one is the easy
+// half to forget: previewRecover promises the preview lists the events the
+// script will reverse. Unmirrored, the preview shows every event in the clicked
+// second while the script reverses one of them — the operator reviews a list
+// that is not what they are about to apply.
+func TestBothRecoverRequestsCarryTheAnchor(t *testing.T) {
+	for _, fnName := range []string{"generateUndo", "previewRecover"} {
+		fn := functionSource(t, fnName)
+		if !strings.Contains(fn, `"event"`) {
+			t.Errorf("%s no longer sends the event anchor. The preview and the generated script "+
+				"read the same form and must apply the same filters, or the list the operator "+
+				"reviews is not the one the script acts on.", fnName)
+		}
+	}
+}
+
+// functionSource returns the body of a top-level function in app.js with
+// whole-line comments stripped, bounded to that function.
+func functionSource(t *testing.T, name string) string {
+	t.Helper()
 	data, err := os.ReadFile("assets/app.js")
 	if err != nil {
 		t.Fatal(err)
 	}
 	js := string(data)
-	start := strings.Index(js, "function renderRecover(")
+	start := strings.Index(js, "function "+name+"(")
 	if start < 0 {
-		t.Fatal("renderRecover is gone from assets/app.js — this guard covers nothing")
+		t.Fatalf("%s is gone from assets/app.js — this guard covers nothing", name)
 	}
 	end := strings.Index(js[start:], "\nfunction ")
 	if end < 0 {
 		end = len(js) - start
 	}
-	fn := stripJSCommentLines(js[start : start+end])
-
-	if !strings.Contains(fn, `form.elements.limit_per_pk.value = "1";`) {
-		t.Error("renderRecover's Undo prefill no longer sets limit_per_pk. Without it the window " +
-			"has no lower bound and no per-row cap, so the script reverses the row's ENTIRE history " +
-			"up to the clicked second — the #1404 defect — while the banner still says one change.")
-	}
-	// The ceiling has to survive alongside it: limit_per_pk without `until`
-	// would reverse the row's most recent change, not the clicked one.
-	if !strings.Contains(fn, "form.elements.until.value = ctx.time;") {
-		t.Error("renderRecover's Undo prefill no longer sets `until`. Paired with limit_per_pk=1 " +
-			"that reverses the row's LATEST change instead of the one the operator clicked.")
-	}
+	return stripJSCommentLines(js[start : start+end])
 }
 
 // undoBannerText returns the eyebrow text and the concatenated detail source
@@ -357,6 +420,13 @@ func TestRestoreToStateClearsTheUndoBridgesPerRowCap(t *testing.T) {
 	for _, want := range []struct{ line, why string }{
 		{`form.elements.limit_per_pk.value = "";`,
 			"a cap inherited from the Undo bridge reverses only the newest change after the instant, so the row does not land on the state shown"},
+		// The strongest version of the same class, and the one that fails
+		// hardest: an anchor names ONE event, while this action reverses every
+		// change after the instant. Left set, the script reverses the event the
+		// operator clicked in Events minutes ago and nothing else, under a
+		// button naming a completely different outcome.
+		{`form.elements.event.value = "";`,
+			"an anchor inherited from the Undo bridge pins the script to one old event instead of everything after the instant"},
 		{`form.elements.until.value = "";`,
 			"a leftover upper bound silently drops the newest damage from the window"},
 		// The label, not a field — and it is a claim about the fields above.

--- a/internal/console/assets_recover_banner_test.go
+++ b/internal/console/assets_recover_banner_test.go
@@ -244,6 +244,30 @@ func TestEditingTheTargetRetiresTheUndoAnchor(t *testing.T) {
 	}
 }
 
+// The banner's Clear button must retire the SELECTION, not rebuild the form.
+//
+// It used to navigate("recover"), which re-renders the route into a fresh empty
+// form — so the one control labelled Clear wiped the target and the upper bound
+// while the sentence beside it promised "search this row freely… the time you
+// clicked stays as the upper bound". The mechanism that sentence describes
+// existed as clearUndoAnchor and had no name in the UI.
+//
+// Pinned as the handler, because the copy guard cannot see this: it only
+// requires the substring "Clear" in the detail, which the false sentence
+// satisfied perfectly.
+func TestBannerClearRetiresTheSelectionNotTheForm(t *testing.T) {
+	fn := functionSource(t, "renderRecover")
+	if !strings.Contains(fn, "onclick: () => clearUndoAnchor(form)") {
+		t.Error("the banner's Clear button no longer calls clearUndoAnchor. Any handler that " +
+			"re-renders the route builds a NEW empty form, which contradicts the banner's own " +
+			"promise that the target and the upper bound survive.")
+	}
+	if strings.Contains(fn, `pendingRecover = null; navigate("recover")`) {
+		t.Error("the banner's Clear button navigates again, wiping the target and the upper " +
+			"bound the banner says it keeps.")
+	}
+}
+
 // The busy modal is the only place an operator can see the anchor, because it
 // has no visible field. Itemising every other filter and omitting the one that
 // most determines the scope is how a request becomes unreviewable.
@@ -480,10 +504,13 @@ func TestRestoreToStateClearsTheUndoBridgesPerRowCap(t *testing.T) {
 		{`form.elements.until.value = "";`,
 			"a leftover upper bound silently drops the newest damage from the window"},
 		// The label, not a field — and it is a claim about the fields above.
-		// The banner states "Latest per row is set to 1" as a fact about this
-		// form; the first clear in this list makes that false, so leaving it up
-		// shows a one-change scope over a script that reverses everything after
-		// the instant.
+		// The banner asserts that exactly the clicked event is reversed; the
+		// clears in this list make that false, so leaving it up shows a
+		// one-event scope over a script that reverses everything after the
+		// instant. (The same contradiction ran through the cap before #1411,
+		// when the banner read "Latest per row is set to 1" — a string this
+		// file now BANS at the top, which is why it is described in the past
+		// tense here rather than quoted as current.)
 		{`pendingRecover = null;`,
 			"renderRecover rebuilds the banner from pendingRecover, so leaving it set puts the contradicting banner back on the next render"},
 		{`document.getElementById("undo-ctx-banner")`,

--- a/internal/console/assets_recover_banner_test.go
+++ b/internal/console/assets_recover_banner_test.go
@@ -206,6 +206,56 @@ func TestBothRecoverRequestsCarryTheAnchor(t *testing.T) {
 	}
 }
 
+// Editing the target must retire the anchor. It names one event of one row, so
+// after a PK change it names the wrong row's event and the request comes back
+// empty — a 200 with no statements, which reads as "this row has no history".
+//
+// Pinned because the narrowing is invisible: it moved from a field the banner
+// named into a hidden one nothing names, so nothing on screen contradicts a
+// stale anchor and no error is produced.
+func TestEditingTheTargetRetiresTheUndoAnchor(t *testing.T) {
+	fn := functionSource(t, "renderRecover")
+	for _, want := range []string{`["schema", "table", "pk"]`, "clearUndoAnchor(form)"} {
+		if !strings.Contains(fn, want) {
+			t.Errorf("renderRecover no longer retires the anchor when the target changes: missing %q.\n"+
+				"A stale anchor names the previous row's event, and the empty result reads as "+
+				"'nothing to undo' rather than as a leftover filter.", want)
+		}
+	}
+	// The retirement itself must clear the field AND the banner. Clearing only
+	// the field leaves a banner claiming a single-event scope over a form that
+	// no longer has one; clearing only the banner leaves the scope in place
+	// with nothing describing it.
+	clear := functionSource(t, "clearUndoAnchor")
+	for _, want := range []struct{ line, why string }{
+		{`form.elements.event.value = "";`, "the anchor stays on the wire"},
+		{"pendingRecover = null;", "renderRecover rebuilds the banner from it on the next render"},
+		{`document.getElementById("undo-ctx-banner")`, "the banner outlives the scope it describes"},
+	} {
+		if !strings.Contains(clear, want.line) {
+			t.Errorf("clearUndoAnchor is missing %q — %s", want.line, want.why)
+		}
+	}
+	// …and it must NOT clear `until`: that is the scope the operator is left
+	// with, and blanking it widens a retargeted search to the whole index.
+	if strings.Contains(clear, `form.elements.until.value = ""`) {
+		t.Error("clearUndoAnchor blanks `until`. Retiring the single-event selection should leave " +
+			"the visible window standing, not widen the search to the whole index.")
+	}
+}
+
+// The busy modal is the only place an operator can see the anchor, because it
+// has no visible field. Itemising every other filter and omitting the one that
+// most determines the scope is how a request becomes unreviewable.
+func TestBusyFactsItemiseTheAnchor(t *testing.T) {
+	fn := functionSource(t, "recoverBusyFacts")
+	if !strings.Contains(fn, "f.event") {
+		t.Error("recoverBusyFacts omits the event anchor. It is the narrowest filter on the " +
+			"request and the only one with no field on screen, so the busy modal is the only " +
+			"place it can be reviewed before the script is generated.")
+	}
+}
+
 // functionSource returns the body of a top-level function in app.js with
 // whole-line comments stripped, bounded to that function.
 func functionSource(t *testing.T, name string) string {

--- a/internal/console/coverage_warnings.go
+++ b/internal/console/coverage_warnings.go
@@ -90,8 +90,17 @@ func appendDivergenceWarning(w []string, diverged int) []string {
 func archiveElisionNote() string {
 	return "This page was answered from the live index; the registered archives were not read. " +
 		"Nothing they hold could have survived this request's filters, so nothing is missing here. " +
-		"Widening the time range, or clearing a per-row limit, reads them."
+		"Widening the time range, clearing a per-row limit, or clearing a single-event " +
+		"selection, reads them."
 }
+
+// The third remedy is not padding. anchorSatisfiedLive (#1411) is the
+// short-circuit that fires on an ordinary Undo, and neither of the first two
+// reaches it: the Undo prefill no longer sets a per-row limit, and widening the
+// time range cannot make a one-event membership filter admit anything else. The
+// only way to the archives from there is the banner's Clear, which is what
+// "clearing a single-event selection" names. Review found the note listing two
+// remedies that both did nothing on the path most likely to show it.
 
 // recoverArchiveElisionNote is archiveElisionNote in the recover surface's own
 // words: a reversal request has a window and a limit, not pages, so "this
@@ -101,7 +110,8 @@ func archiveElisionNote() string {
 func recoverArchiveElisionNote() string {
 	return "This reversal was built from the live index; the registered archives were not read. " +
 		"Nothing they hold could have survived this request's filters, so nothing is missing here. " +
-		"Widening the time range, or clearing the per-row limit, reads them."
+		"Widening the time range, clearing the per-row limit, or clearing a single-event " +
+		"selection, reads them."
 }
 
 // archiveElisionNotes returns the response Notes list for a fetch that

--- a/internal/console/coverage_warnings.go
+++ b/internal/console/coverage_warnings.go
@@ -66,10 +66,10 @@ func appendDivergenceWarning(w []string, diverged int) []string {
 
 // archiveElisionNote is the response-level record of the newest-first
 // short-circuit (#1353): registered archives were deliberately not read
-// because they provably could not change this page. There are now TWO proofs
-// that reach here — the live index filled a newest-first page from a
-// contiguous live range, or every named PK already held its latest N live
-// (#1403) — and the flag does not say which.
+// because they provably could not change this page. THREE proofs reach here —
+// the live index filled a newest-first page from a contiguous live range, every
+// named PK already held its latest N live (#1403), or the one event the request
+// anchored on came back live (#1411) — and the flag does not say which.
 //
 // That is why the wording below states the FACT and not the reason, which it
 // used to. Inferring the reason from the request is wrong: the newest-first

--- a/internal/console/coverage_warnings_test.go
+++ b/internal/console/coverage_warnings_test.go
@@ -88,10 +88,12 @@ func TestArchiveElisionNote(t *testing.T) {
 	}
 	const wantEvents = "This page was answered from the live index; the registered archives were not read. " +
 		"Nothing they hold could have survived this request's filters, so nothing is missing here. " +
-		"Widening the time range, or clearing a per-row limit, reads them."
+		"Widening the time range, clearing a per-row limit, or clearing a single-event " +
+		"selection, reads them."
 	const wantRecover = "This reversal was built from the live index; the registered archives were not read. " +
 		"Nothing they hold could have survived this request's filters, so nothing is missing here. " +
-		"Widening the time range, or clearing the per-row limit, reads them."
+		"Widening the time range, clearing the per-row limit, or clearing a single-event " +
+		"selection, reads them."
 	if got := archiveElisionNote(); got != wantEvents {
 		t.Errorf("events elision note drifted from the pinned copy:\ngot:  %s\nwant: %s", got, wantEvents)
 	}
@@ -106,7 +108,10 @@ func TestArchiveElisionNote(t *testing.T) {
 		// The audit fact survives the rewrite on BOTH surfaces: the note says
 		// the archives went unread, why that loses nothing, and how to reach
 		// them.
-		for _, want := range []string{"live index", "were not read", "nothing is missing", "time range"} {
+		// "single-event" is in this list for the same reason "time range" is:
+		// the note must name a remedy that applies on the path that actually
+		// elides. An Undo elides via the anchor, where the other two are inert.
+		for _, want := range []string{"live index", "were not read", "nothing is missing", "time range", "single-event"} {
 			if !strings.Contains(strings.ToLower(s), strings.ToLower(want)) {
 				t.Errorf("%s note lost the audit fact %q: %s", name, want, s)
 			}

--- a/internal/console/dto.go
+++ b/internal/console/dto.go
@@ -22,11 +22,27 @@ const consoleTSFormat = "2006-01-02 15:04:05"
 // never grown a consumer for statement text. Do not add them here without a
 // surface that actually reads them.
 type eventDTO struct {
-	EventID        uint64         `json:"event_id"`
-	BinlogFile     string         `json:"binlog_file"`
-	StartPos       uint64         `json:"start_pos"`
-	EndPos         uint64         `json:"end_pos"`
-	EventTimestamp string         `json:"event_timestamp"`
+	EventID        uint64 `json:"event_id"`
+	BinlogFile     string `json:"binlog_file"`
+	StartPos       uint64 `json:"start_pos"`
+	EndPos         uint64 `json:"end_pos"`
+	EventTimestamp string `json:"event_timestamp"`
+	// Anchor is this row's identity on the wire, `<RFC3339Nano>|<event_id>` —
+	// the same token the ?before=/?after= cursors use, produced by the same
+	// formatEventCursor.
+	//
+	// It exists because EventTimestamp above cannot name an event: it is
+	// second-granular, so a client holding only it can ask for "that second"
+	// and no finer. Undo needs finer — a row INSERTed and DELETEd inside one
+	// second yields two events a timestamp cannot tell apart, and reversing
+	// the wrong one of that pair inverts the outcome (#1411).
+	//
+	// Emitted rather than reassembled client-side on purpose. The bare
+	// timestamp has no offset, so rebuilding an RFC 3339 instant from it in JS
+	// means guessing a location, and guessing wrong does not fail — it names a
+	// different row. The server already has the instant; echoing its own token
+	// back is the only spelling both ends agree on by construction.
+	Anchor         string         `json:"anchor"`
 	GTID           *string        `json:"gtid"`
 	ConnectionID   *uint32        `json:"connection_id"`
 	SchemaName     string         `json:"schema_name"`
@@ -48,6 +64,7 @@ func toEventDTO(r query.ResultRow) eventDTO {
 		StartPos:       r.StartPos,
 		EndPos:         r.EndPos,
 		EventTimestamp: r.EventTimestamp.Format(consoleTSFormat),
+		Anchor:         formatEventCursor(r),
 		GTID:           r.GTID,
 		ConnectionID:   r.ConnectionID,
 		SchemaName:     r.SchemaName,

--- a/internal/console/dto_test.go
+++ b/internal/console/dto_test.go
@@ -131,7 +131,11 @@ func TestEventDTOFieldAllowlist(t *testing.T) {
 	sort.Strings(got)
 
 	want := []string{
-		"binlog_file", "changed_columns", "connection_id", "end_pos", "event_id",
+		// "anchor" is (event_timestamp, event_id) re-spelled — both are already
+		// on this list, so it exposes nothing new; it is here because Undo
+		// needs to name one event and a second-granular timestamp cannot
+		// (#1411).
+		"anchor", "binlog_file", "changed_columns", "connection_id", "end_pos", "event_id",
 		"event_timestamp", "event_type", "gtid", "pk_values",
 		"row_after", "row_before", "schema_name", "start_pos", "table_name",
 	}

--- a/internal/console/recover_anchor_test.go
+++ b/internal/console/recover_anchor_test.go
@@ -1,0 +1,124 @@
+package console
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/dbtrail/dbtrail/internal/parser"
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// The anchor has to reach the SQL. Accepting the field and dropping it is the
+// failure this pins, and it is invisible from the response: the handler still
+// answers 200 with a plausible script, just one built from the remaining
+// filters — for Undo that is the row's whole history up to the clicked second,
+// the exact behaviour #1411 removed.
+//
+// Asserted through sqlmock's query matcher rather than by reading opts, so the
+// path from JSON to WHERE clause is exercised end to end.
+func TestRecoverAppliesTheEventAnchorToTheQuery(t *testing.T) {
+	db, mock, closeDB := newSQLMock(t)
+	defer closeDB()
+
+	cols := []string{
+		"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
+		"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
+		"changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash",
+		"commit_ts_us",
+	}
+	ts := time.Date(2026, 8, 21, 20, 8, 36, 0, time.UTC)
+	rows := sqlmock.NewRows(cols).AddRow(
+		int64(403440), "bin.000001", int64(4), int64(40), ts,
+		nil, nil, "wordpress", "dbt_options", int64(parser.EventInsert), "94057",
+		nil, nil, []byte(`{"option_id":94057}`), int64(0),
+		nil, nil, nil,
+	)
+	// The matcher is the assertion: sqlmock fails the expectation if the SQL
+	// the handler builds does not carry the anchor equality.
+	mock.ExpectQuery("event_timestamp = \\? AND event_id = \\?").WillReturnRows(rows)
+
+	s := newBootServer(db)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/recover", strings.NewReader(
+		`{"schema":"wordpress","table":"dbt_options","pk":"94057","event":"2026-08-21T20:08:36Z|403440"}`))
+	s.handleRecover(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("recover status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("the anchor never reached the query: %v", err)
+	}
+	var resp recoverResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v (body=%s)", err, rec.Body.String())
+	}
+	if resp.StatementCount != 1 {
+		t.Errorf("StatementCount = %d, want 1 — an anchored request reverses exactly one event", resp.StatementCount)
+	}
+}
+
+// A malformed anchor is a 400, never a silent fall back to the unanchored
+// window. The client asked to reverse ONE event; the remaining filters admit
+// the row's whole history, so the degraded result is not a near miss — it is a
+// much larger script the operator did not ask for, returned with a 200.
+func TestRecoverRefusesAMalformedAnchor(t *testing.T) {
+	db, _, closeDB := newSQLMock(t)
+	defer closeDB()
+	s := newBootServer(db)
+
+	for _, tc := range []struct{ name, event string }{
+		{"no separator", "2026-08-21T20:08:36Z"},
+		{"unparseable timestamp", "yesterday|403440"},
+		{"non-numeric id", "2026-08-21T20:08:36Z|abc"},
+		{"bare console timestamp", "2026-08-21 20:08:36|403440"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			body := `{"schema":"wordpress","table":"dbt_options","event":"` + tc.event + `"}`
+			req := httptest.NewRequest("POST", "/api/recover", strings.NewReader(body))
+			s.handleRecover(rec, req)
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400 — a malformed anchor must not degrade into an "+
+					"unanchored reversal of the row's whole history.\nBody: %s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+// The events surface must hand the client an identity it can send back. Undo
+// reads eventDTO.anchor; without it the bridge has nothing to carry and every
+// reversal silently reverts to the second-granular window.
+//
+// Checked as the DTO's own output rather than as a string in app.js, because
+// the two ends have to agree on ONE spelling: the token is produced by
+// formatEventCursor and parsed by parseEventCursor, and this is the assertion
+// that the round trip closes.
+func TestEventDTOAnchorRoundTripsThroughTheCursorParser(t *testing.T) {
+	ts := time.Date(2026, 8, 21, 20, 8, 36, 0, time.UTC)
+	dto := toEventDTO(query.ResultRow{EventID: 403440, EventTimestamp: ts})
+	if dto.Anchor == "" {
+		t.Fatal("eventDTO.anchor is empty — the Undo bridge has no identity to carry")
+	}
+	cur, err := parseEventCursor("event", dto.Anchor)
+	if err != nil {
+		t.Fatalf("the server cannot parse its own anchor token %q: %v", dto.Anchor, err)
+	}
+	if cur.EventID != 403440 || !cur.Timestamp.Equal(ts) {
+		t.Errorf("anchor round trip changed the event: got (%v, %d), want (%v, %d)",
+			cur.Timestamp, cur.EventID, ts, 403440)
+	}
+	// The bare DTO timestamp must NOT be mistaken for the token. It is the
+	// reconstruction this field exists to make unnecessary, and it does not
+	// parse — which is what keeps a client that tries it failing loudly.
+	if _, err := parseEventCursor("event", dto.EventTimestamp+"|403440"); err == nil {
+		t.Error("the bare event_timestamp parses as an anchor. It carries no offset, so a client " +
+			"rebuilding the token from it would name an instant that depends on where the parse " +
+			"happens — the ambiguity anchor exists to remove.")
+	}
+}

--- a/internal/console/recover_anchor_test.go
+++ b/internal/console/recover_anchor_test.go
@@ -121,6 +121,114 @@ func TestEventsRefusesAMalformedAnchor(t *testing.T) {
 	}
 }
 
+// An anchored request that matches nothing must SAY so. Before the anchor,
+// an empty Undo meant one thing — nothing happened in the window. The anchor
+// adds several causes that render identically, and the operator cannot tell
+// them apart from a 200 with an empty script.
+//
+// Both surfaces, because the preview mirrors the script: a silent empty
+// preview is the same ambiguity one click earlier.
+func TestAnchoredEmptyResultIsExplained(t *testing.T) {
+	cols := []string{
+		"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
+		"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
+		"changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash",
+		"commit_ts_us",
+	}
+
+	t.Run("recover", func(t *testing.T) {
+		db, mock, closeDB := newSQLMock(t)
+		defer closeDB()
+		mock.ExpectQuery("FROM binlog_events").WillReturnRows(sqlmock.NewRows(cols))
+		s := newBootServer(db)
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/api/recover", strings.NewReader(
+			`{"schema":"wordpress","table":"dbt_options","pk":"94057","event":"2026-08-21T20:08:36Z|403440"}`))
+		s.handleRecover(rec, req)
+		if rec.Code != 200 {
+			t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+		}
+		var resp recoverResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		assertAnchorMissWarning(t, resp.Warnings)
+	})
+
+	t.Run("events", func(t *testing.T) {
+		db, mock, closeDB := newSQLMock(t)
+		defer closeDB()
+		mock.ExpectQuery("FROM binlog_events").WillReturnRows(sqlmock.NewRows(cols))
+		s := newBootServer(db)
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("GET",
+			"/api/events?schema=wordpress&table=dbt_options&event=2026-08-21T20%3A08%3A36Z%7C403440", nil)
+		s.handleEvents(rec, req)
+		if rec.Code != 200 {
+			t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+		}
+		var resp eventsResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		assertAnchorMissWarning(t, resp.Warnings)
+	})
+}
+
+func assertAnchorMissWarning(t *testing.T, warnings []string) {
+	t.Helper()
+	if len(warnings) == 0 {
+		t.Fatal("an anchored request that matched nothing returned no warnings. The response is " +
+			"then byte-identical to 'this row has no history', which is a finding the read did " +
+			"not make.")
+	}
+	joined := strings.Join(warnings, " ")
+	// The id, so the operator can tell WHICH selection missed — the stale-anchor
+	// case is only diagnosable if the id is visible.
+	if !strings.Contains(joined, "403440") {
+		t.Errorf("the warning does not name the event id: %q", joined)
+	}
+	// …and the disclaimer, which is the whole point: without it the sentence
+	// reads as a description of the empty result rather than a refusal to
+	// treat it as evidence.
+	if !strings.Contains(joined, "NOT evidence") {
+		t.Errorf("the warning does not refuse the finding: %q", joined)
+	}
+}
+
+// The mirror: a matching anchored request must NOT carry the warning. Without
+// this the fix could be an unconditional warning on every anchored read, which
+// would train the operator to ignore it.
+func TestAnchoredHitCarriesNoMissWarning(t *testing.T) {
+	db, mock, closeDB := newSQLMock(t)
+	defer closeDB()
+	ts := time.Date(2026, 8, 21, 20, 8, 36, 0, time.UTC)
+	rows := sqlmock.NewRows([]string{
+		"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
+		"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
+		"changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash",
+		"commit_ts_us",
+	}).AddRow(
+		int64(403440), "bin.000001", int64(4), int64(40), ts,
+		nil, nil, "wordpress", "dbt_options", int64(parser.EventInsert), "94057",
+		nil, nil, []byte(`{"option_id":94057}`), int64(0), nil, nil, nil,
+	)
+	mock.ExpectQuery("FROM binlog_events").WillReturnRows(rows)
+	s := newBootServer(db)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/recover", strings.NewReader(
+		`{"schema":"wordpress","table":"dbt_options","pk":"94057","event":"2026-08-21T20:08:36Z|403440"}`))
+	s.handleRecover(rec, req)
+	var resp recoverResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if strings.Contains(strings.Join(resp.Warnings, " "), "was not found") {
+		t.Errorf("a matching anchored request carried the miss warning: %v. A warning on every "+
+			"anchored read is a warning the operator learns to skip.", resp.Warnings)
+	}
+}
+
 // A malformed anchor is a 400, never a silent fall back to the unanchored
 // window. The client asked to reverse ONE event; the remaining filters admit
 // the row's whole history, so the degraded result is not a near miss — it is a

--- a/internal/console/recover_anchor_test.go
+++ b/internal/console/recover_anchor_test.go
@@ -63,6 +63,64 @@ func TestRecoverAppliesTheEventAnchorToTheQuery(t *testing.T) {
 	}
 }
 
+// The preview and the script must apply the SAME anchor. previewRecover
+// promises the preview lists the events the undo script will reverse, and
+// /api/events is where that promise is kept or broken.
+//
+// This is the assertion the JS-side guard could not make. That one checks the
+// literal "event" appears in both request builders; the client half was wired
+// and the server half was not, so it stayed green while the preview listed the
+// row's whole history against a script that reversed one event of it. A guard
+// that reads one end of a wire cannot see the other.
+func TestEventsAppliesTheEventAnchorToTheQuery(t *testing.T) {
+	db, mock, closeDB := newSQLMock(t)
+	defer closeDB()
+
+	ts := time.Date(2026, 8, 21, 20, 8, 36, 0, time.UTC)
+	rows := sqlmock.NewRows([]string{
+		"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
+		"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
+		"changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash",
+		"commit_ts_us",
+	}).AddRow(
+		int64(403440), "bin.000001", int64(4), int64(40), ts,
+		nil, nil, "wordpress", "dbt_options", int64(parser.EventInsert), "94057",
+		nil, nil, []byte(`{"option_id":94057}`), int64(0),
+		nil, nil, nil,
+	)
+	mock.ExpectQuery("event_timestamp = \\? AND event_id = \\?").WillReturnRows(rows)
+
+	s := newBootServer(db)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET",
+		"/api/events?schema=wordpress&table=dbt_options&pk=94057&event=2026-08-21T20%3A08%3A36Z%7C403440", nil)
+	s.handleEvents(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("events status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("the anchor never reached the events query, so the preview does not mirror the "+
+			"script it is supposed to preview: %v", err)
+	}
+}
+
+// The refusal is shared too. A malformed anchor that 400s on one surface and
+// is ignored on the other is the same divergence one step later.
+func TestEventsRefusesAMalformedAnchor(t *testing.T) {
+	db, _, closeDB := newSQLMock(t)
+	defer closeDB()
+	s := newBootServer(db)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/events?schema=wordpress&event=yesterday", nil)
+	s.handleEvents(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 — a malformed anchor must not degrade into an unanchored "+
+			"listing of the row's whole history.\nBody: %s", rec.Code, rec.Body.String())
+	}
+}
+
 // A malformed anchor is a 400, never a silent fall back to the unanchored
 // window. The client asked to reverse ONE event; the remaining filters admit
 // the row's whole history, so the degraded result is not a near miss — it is a

--- a/internal/parquetquery/anchor_1411_test.go
+++ b/internal/parquetquery/anchor_1411_test.go
@@ -1,0 +1,62 @@
+package parquetquery
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// The archive mirror of the anchor filter (#1411), and the one path the live
+// short-circuit deliberately cannot cover.
+//
+// anchorSatisfiedLive elides the archives only when the anchored event came
+// back from the live index. When it did not — it aged into an archived
+// partition — the archives ARE read, and this filter is the only thing that
+// keeps that read scoped to the one event. Without it every archived event for
+// the row up to `until` enters MergeAndTrimReport and gets reversed, under a
+// banner claiming exactly one change. Deleting the whole block left every
+// suite in the repo green, which is why this exists.
+func TestBuildFilters_eventAnchor(t *testing.T) {
+	ts := time.Date(2026, 8, 21, 20, 8, 36, 0, time.UTC)
+	where, args := buildFilters(query.Options{
+		Schema:      "wordpress",
+		Table:       "dbt_options",
+		EventAnchor: &query.EventCursor{Timestamp: ts, EventID: 403440},
+	}, nil)
+
+	found := false
+	for _, w := range where {
+		if w == "event_timestamp = ? AND event_id = ?" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("missing the anchor equality, so an anchored read that reaches the archives "+
+			"returns every event for the row in the window instead of the one named: %v", where)
+	}
+	// Positions, not membership: the two binds have different types on the
+	// live side but both are opaque `any` here, so a swap would compare
+	// event_timestamp against the id and event_id against the timestamp —
+	// zero rows, HTTP 200, an undo script that found nothing.
+	if len(args) != 4 {
+		t.Fatalf("args = %v, want 4 (schema, table, ts, event_id)", args)
+	}
+	if args[2] != ts {
+		t.Errorf("args[2] = %v, want the anchor timestamp %v — the binds are out of order", args[2], ts)
+	}
+	if args[3] != uint64(403440) {
+		t.Errorf("args[3] = %v, want the anchor event_id 403440 — the binds are out of order", args[3])
+	}
+}
+
+// No anchor emits no anchor predicate. Without this the test above passes over
+// an unconditional filter that would break every other archive read.
+func TestBuildFilters_noEventAnchor(t *testing.T) {
+	where, _ := buildFilters(query.Options{Schema: "wordpress"}, nil)
+	for _, w := range where {
+		if w == "event_timestamp = ? AND event_id = ?" {
+			t.Errorf("an unanchored read emitted the anchor equality: %v", where)
+		}
+	}
+}

--- a/internal/parquetquery/parquetquery.go
+++ b/internal/parquetquery/parquetquery.go
@@ -1072,6 +1072,16 @@ func buildFilters(opts query.Options, cols map[string]bool) ([]string, []any) {
 			" OR (binlog_file = ? AND end_pos <= ?))")
 		args = append(args, opts.UntilPos.File, opts.UntilPos.File, opts.UntilPos.File, opts.UntilPos.File, posArg(opts.UntilPos.Pos))
 	}
+	if opts.EventAnchor != nil {
+		// The archive mirror of buildQuery's anchor block (#1411). No coarse
+		// hint is emitted: file/date scoping on this side is driven by
+		// Since/Until, and DuckDB prunes Parquet row groups from the equality
+		// below via their event_timestamp statistics. Carrying the timestamp
+		// alongside the unique event_id keeps a stale anchor returning nothing
+		// rather than a different row.
+		where = append(where, "event_timestamp = ? AND event_id = ?")
+		args = append(args, opts.EventAnchor.Timestamp, opts.EventAnchor.EventID)
+	}
 	if opts.AfterEvent != nil {
 		// Keyset cut on the composite sort key, mirroring internal/query's
 		// buildQuery (#1097). No separate coarse hint is emitted here: the

--- a/internal/query/anchor_skip_test.go
+++ b/internal/query/anchor_skip_test.go
@@ -1,0 +1,233 @@
+package query
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestAnchorSatisfiedLive(t *testing.T) {
+	ts := time.Date(2026, 8, 21, 20, 8, 36, 0, time.UTC)
+	rows := []ResultRow{
+		{EventID: 403440, EventTimestamp: ts},
+		{EventID: 403445, EventTimestamp: ts},
+	}
+
+	tests := []struct {
+		name string
+		opts Options
+		rows []ResultRow
+		want bool
+		why  string
+	}{
+		{
+			name: "the anchored event came back live",
+			opts: Options{EventAnchor: &EventCursor{Timestamp: ts, EventID: 403440}},
+			rows: rows,
+			want: true,
+			why:  "event_id is the merge dedup key, so an archive can only hold a copy of it or nothing",
+		},
+		{
+			name: "the anchored event is the other one in the same second",
+			opts: Options{EventAnchor: &EventCursor{Timestamp: ts, EventID: 403445}},
+			rows: rows,
+			want: true,
+			why:  "the anchor names an id, not a second — both events in a shared second resolve",
+		},
+		{
+			name: "no anchor",
+			opts: Options{PKValues: "42"},
+			rows: rows,
+			want: false,
+			why:  "an unanchored request has no identity to prove anything about",
+		},
+		{
+			name: "anchored event absent from the live page",
+			opts: Options{EventAnchor: &EventCursor{Timestamp: ts, EventID: 999999}},
+			rows: rows,
+			want: false,
+			why: "aged out into an archived partition; falling through to the archives is how it " +
+				"is found, so this must NOT elide",
+		},
+		{
+			name: "anchored event absent and the live page is empty",
+			opts: Options{EventAnchor: &EventCursor{Timestamp: ts, EventID: 403440}},
+			rows: nil,
+			want: false,
+			why:  "an empty live page proves nothing; the event may be entirely archived",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := anchorSatisfiedLive(tc.opts, tc.rows); got != tc.want {
+				t.Errorf("anchorSatisfiedLive = %v, want %v — %s", got, tc.want, tc.why)
+			}
+		})
+	}
+}
+
+// The predicate deliberately needs no QueryPlan: unlike its two siblings its
+// proof is the anchor itself, not the layout of the index. Pinned because the
+// obvious "consistency" edit is to add the same plan guards the others carry,
+// and that would silently disable the skip on exactly the indexes this exists
+// for — a nil plan is what fetchPage passes when archive coverage could not be
+// evaluated, and the anchor's proof holds there anyway.
+func TestAnchorSkipNeedsNoPlan(t *testing.T) {
+	ts := time.Date(2026, 8, 21, 20, 8, 36, 0, time.UTC)
+	opts := Options{EventAnchor: &EventCursor{Timestamp: ts, EventID: 7}}
+	if !anchorSatisfiedLive(opts, []ResultRow{{EventID: 7, EventTimestamp: ts}}) {
+		t.Error("anchorSatisfiedLive refused with no plan in sight. The anchor's proof does not " +
+			"rest on ArchivesBelowLive or on a contiguous live range, and requiring one would " +
+			"turn the skip off wherever archive coverage is unevaluable.")
+	}
+}
+
+func TestFetchPageSkipsArchivesWhenTheAnchoredEventIsLive(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	live := sqlmock.NewRows([]string{
+		"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
+		"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
+		"changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash",
+		"commit_ts_us",
+	})
+	anchorTS := now.Add(-2 * time.Hour)
+	live.AddRow(uint64(7), "mysql-bin.000001", 100, 200, anchorTS,
+		nil, nil, "shop", "orders", 3, "93921",
+		nil, nil, nil, 1, nil, nil, nil)
+	mock.ExpectQuery("SELECT").WillReturnRows(live)
+
+	var archiveCalls int
+	src := mergeSources{
+		archSources: []string{"s3://bucket/bintrail_id=x"},
+		// Deliberately the layout the OTHER two predicates refuse: archives are
+		// NOT known to sit below live and there is no contiguous range. The
+		// anchor skip must fire anyway, or it collapses into perPKSatisfiedLive.
+		plan: nil,
+	}
+	o := FetchMergedOptions{
+		// The shape the console's Undo sends since #1411: one named event, no
+		// per-PK cap.
+		Opts: Options{
+			Schema: "shop", Table: "orders", PKValues: "93921",
+			EventAnchor: &EventCursor{Timestamp: anchorTS, EventID: 7},
+			Limit:       1000, Order: "DESC",
+		},
+		AllowGaps: true,
+		ArchiveFetcher: func(context.Context, Options, string) ([]ResultRow, error) {
+			archiveCalls++
+			return []ResultRow{{EventID: 999, PKValues: "93921", EventTimestamp: now.Add(-72 * time.Hour)}}, nil
+		},
+	}
+
+	rows, _, _, _, elided, err := fetchPage(context.Background(), New(db), o, src)
+	if err != nil {
+		t.Fatalf("fetchPage: %v", err)
+	}
+	if archiveCalls != 0 {
+		t.Errorf("archive fetcher called %d time(s); the request named one event and the live "+
+			"index returned it, so no archive can change the result", archiveCalls)
+	}
+	if !elided {
+		t.Error("archivesElided is false after skipping the archive sources — the surface " +
+			"rendering this has no way to say the archives went unread (#1353)")
+	}
+	if len(rows) != 1 || rows[0].EventID != 7 {
+		t.Errorf("rows = %+v, want just the anchored live event", rows)
+	}
+}
+
+// The negative control the sibling predicates gained late: an anchor whose
+// event is NOT live must read the archives. Without this the skip could be
+// written as "anchor set ⇒ elide", which is fast, green on the test above, and
+// silently returns an empty reversal for any event old enough to have been
+// rotated out.
+func TestFetchPageReadsArchivesWhenTheAnchoredEventIsNotLive(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	anchorTS := now.Add(-72 * time.Hour)
+	mock.ExpectQuery("SELECT").WillReturnRows(sqlmock.NewRows([]string{
+		"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
+		"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
+		"changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash",
+		"commit_ts_us",
+	}))
+
+	var archiveCalls int
+	src := mergeSources{
+		archSources: []string{"s3://bucket/bintrail_id=x"},
+		plan:        &QueryPlan{ArchivesBelowLive: true, MySQLRanges: []TimeRange{{Start: now.Add(-24 * time.Hour), End: now.Add(time.Hour)}}},
+	}
+	o := FetchMergedOptions{
+		Opts: Options{
+			Schema: "shop", Table: "orders",
+			EventAnchor: &EventCursor{Timestamp: anchorTS, EventID: 999},
+			Limit:       1000, Order: "DESC",
+		},
+		AllowGaps: true,
+		ArchiveFetcher: func(context.Context, Options, string) ([]ResultRow, error) {
+			archiveCalls++
+			return []ResultRow{{EventID: 999, PKValues: "93921", EventTimestamp: anchorTS}}, nil
+		},
+	}
+
+	rows, _, _, _, elided, err := fetchPage(context.Background(), New(db), o, src)
+	if err != nil {
+		t.Fatalf("fetchPage: %v", err)
+	}
+	if archiveCalls != 1 {
+		t.Errorf("archive fetcher called %d time(s), want 1 — the anchored event was not in the "+
+			"live index, so the archives are the only place it can be found", archiveCalls)
+	}
+	if elided {
+		t.Error("archivesElided is true on a read that DID read the archives")
+	}
+	if len(rows) != 1 || rows[0].EventID != 999 {
+		t.Errorf("rows = %+v, want the archived event", rows)
+	}
+}
+
+// The engine has to filter on the anchor, not merely accept it. Without the
+// predicate the request degrades to its remaining filters — for Undo that is
+// schema/table/pk plus a second-granular `until`, i.e. the whole row history —
+// and the short-circuit above would then hand back that wider set as if it
+// were the one event asked for. Fast and wrong.
+func TestBuildQueryFiltersOnTheAnchor(t *testing.T) {
+	ts := time.Date(2026, 8, 21, 20, 8, 36, 0, time.UTC)
+	q, args := buildQuery(Options{
+		Schema: "shop", Table: "orders",
+		EventAnchor: &EventCursor{Timestamp: ts, EventID: 403440},
+	})
+	if !strings.Contains(q, "event_timestamp = ? AND event_id = ?") {
+		t.Errorf("buildQuery emitted no anchor equality.\nSQL: %s", q)
+	}
+	// The partition-pruning bracket. An id-only predicate is correct and scans
+	// every partition of binlog_events, which on the index this was written for
+	// is the difference the anchor was supposed to make.
+	if !strings.Contains(q, "TO_SECONDS(event_timestamp) >=") || !strings.Contains(q, "TO_SECONDS(event_timestamp) <") {
+		t.Errorf("buildQuery emitted no hour bracket around the anchor, so MySQL prunes no "+
+			"partitions and the anchored read scans the whole table.\nSQL: %s", q)
+	}
+	var sawID bool
+	for _, a := range args {
+		if id, ok := a.(uint64); ok && id == 403440 {
+			sawID = true
+		}
+	}
+	if !sawID {
+		t.Errorf("the anchor's event_id never reached the bind args: %v", args)
+	}
+}

--- a/internal/query/anchor_skip_test.go
+++ b/internal/query/anchor_skip_test.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -51,6 +52,14 @@ func TestAnchorSatisfiedLive(t *testing.T) {
 			want: false,
 			why: "aged out into an archived partition; falling through to the archives is how it " +
 				"is found, so this must NOT elide",
+		},
+		{
+			name: "right id, wrong timestamp",
+			opts: Options{EventAnchor: &EventCursor{Timestamp: ts.Add(time.Hour), EventID: 403440}},
+			rows: rows,
+			want: false,
+			why: "the predicate must be self-sufficient rather than trusting the caller to have " +
+				"applied the anchor: a row that is not the anchored event proves nothing about it",
 		},
 		{
 			name: "anchored event absent and the live page is empty",
@@ -214,20 +223,34 @@ func TestBuildQueryFiltersOnTheAnchor(t *testing.T) {
 	if !strings.Contains(q, "event_timestamp = ? AND event_id = ?") {
 		t.Errorf("buildQuery emitted no anchor equality.\nSQL: %s", q)
 	}
-	// The partition-pruning bracket. An id-only predicate is correct and scans
-	// every partition of binlog_events, which on the index this was written for
-	// is the difference the anchor was supposed to make.
-	if !strings.Contains(q, "TO_SECONDS(event_timestamp) >=") || !strings.Contains(q, "TO_SECONDS(event_timestamp) <") {
-		t.Errorf("buildQuery emitted no hour bracket around the anchor, so MySQL prunes no "+
-			"partitions and the anchored read scans the whole table.\nSQL: %s", q)
+	// The partition-pruning bracket, asserted as LITERAL BOUNDS.
+	//
+	// Checking only that the operators appear is what an earlier version did,
+	// and review killed it with one mutation: flooring `lo` to the hour AFTER
+	// the anchor's still prints "TO_SECONDS(event_timestamp) >=", so a bracket
+	// that excludes the anchor's own partition read as present. That lands as
+	// zero rows → HTTP 200 → `statement_count: 0`, which the console renders
+	// as a completed undo that found nothing.
+	wantLo := mysqlToSeconds(ts.Truncate(time.Hour))
+	wantHi := mysqlToSeconds(ts.Truncate(time.Hour).Add(time.Hour))
+	if !strings.Contains(q, fmt.Sprintf("TO_SECONDS(event_timestamp) >= %d", wantLo)) {
+		t.Errorf("the anchor's lower bracket is not the floor of its own hour (want %d). A bracket "+
+			"that excludes the anchor's partition prunes away the row it names.\nSQL: %s", wantLo, q)
 	}
-	var sawID bool
-	for _, a := range args {
-		if id, ok := a.(uint64); ok && id == 403440 {
-			sawID = true
-		}
+	if !strings.Contains(q, fmt.Sprintf("TO_SECONDS(event_timestamp) < %d", wantHi)) {
+		t.Errorf("the anchor's upper bracket is not the next hour boundary (want %d).\nSQL: %s", wantHi, q)
 	}
-	if !sawID {
-		t.Errorf("the anchor's event_id never reached the bind args: %v", args)
+	// Bind POSITIONS, not membership. Scanning args for "a uint64 equal to the
+	// id anywhere" survives a swapped pair, and a swap makes MySQL compare
+	// event_timestamp against 403440 — again zero rows under a 200. sqlmock
+	// never executes SQL, so no handler test can catch this either.
+	if len(args) != 4 {
+		t.Fatalf("args = %v, want 4 (schema, table, ts, event_id)", args)
+	}
+	if args[2] != ts {
+		t.Errorf("args[2] = %v, want the anchor timestamp %v — the binds are out of order", args[2], ts)
+	}
+	if args[3] != uint64(403440) {
+		t.Errorf("args[3] = %v, want the anchor event_id 403440 — the binds are out of order", args[3])
 	}
 }

--- a/internal/query/fetchmerged.go
+++ b/internal/query/fetchmerged.go
@@ -198,9 +198,12 @@ const DiscoveryFailedSource = "(archive source discovery failed)"
 // the skipped sources and the diverging events.
 //
 // archivesElided reports that resolved archive sources were deliberately NOT
-// read because they provably could not change the result — the newest-first
-// short-circuit (topNSatisfiedLive: the live index filled a DESC page whose
-// span is live-covered from the cutoff upward). It is a completeness-
+// read because they provably could not change the result. Three short-circuits
+// can set it, in ascending order of how much they must prove: anchorSatisfiedLive
+// (the live index already returned the one event Options.EventAnchor names),
+// perPKSatisfiedLive (every named PK already has its latest LimitPerPK live),
+// and topNSatisfiedLive (the live index filled a DESC page whose span is
+// live-covered from the cutoff upward). It is a completeness-
 // preserving optimization, never a scope reduction, but a caller rendering
 // the result to a human must still be able to SAY the archives went unread
 // (#1353's audit requirement) — which is why it is a return value and not a
@@ -228,6 +231,35 @@ func FetchMergedFull(
 		skipped = append(skipped, DiscoveryFailedSource)
 	}
 	return rows, src.plan, skipped, diverged, elided, nil
+}
+
+// anchorSatisfiedLive reports that the live index already returned the exact
+// event Options.EventAnchor names, which makes every resolved archive source
+// redundant for this request.
+//
+// It is the cheapest of the three short-circuits and the only one that needs
+// no QueryPlan: no contiguous-range check, no ArchivesBelowLive premise, no
+// boundary comparison. The proof is the anchor itself. An anchor admits at
+// most one event, event_id is unique, and it is the key MergeResults dedupes
+// on — so an archive can hold either a byte-copy of the event already in hand
+// (which the merge would drop, warning if the copies disagree) or nothing at
+// all. Neither outcome can change the result, so reading the archives cannot
+// either.
+//
+// The converse is deliberately NOT a refusal: an anchor whose event is absent
+// from the live index — aged out into an archived partition — falls through to
+// the normal archive path and is found there. This predicate accelerates the
+// common case; it never decides membership.
+func anchorSatisfiedLive(opts Options, rows []ResultRow) bool {
+	if opts.EventAnchor == nil {
+		return false
+	}
+	for i := range rows {
+		if rows[i].EventID == opts.EventAnchor.EventID {
+			return true
+		}
+	}
+	return false
 }
 
 // topNSatisfiedLive reports whether the live partitions alone already hold the
@@ -752,8 +784,9 @@ func resolveMergeSources(ctx context.Context, db *sql.DB, o FetchMergedOptions) 
 // retired from the walk entirely. diverged counts the duplicate event_ids
 // whose two merged copies disagreed (#1325); zero on every path that reads a
 // single source, since no duplicate can exist there. archivesElided reports
-// the topNSatisfiedLive short-circuit fired — resolved archives went unread
-// because they provably could not change this page (see FetchMergedFull).
+// that one of the three short-circuits below fired — resolved archives went
+// unread because they provably could not change this page (see FetchMergedFull
+// for which, and for why the signal is returned rather than logged).
 func fetchPage(
 	ctx context.Context,
 	engine *Engine,
@@ -783,6 +816,11 @@ func fetchPage(
 		rows = r
 	}
 
+	if anchorSatisfiedLive(o.Opts, rows) {
+		slog.Debug("planner: skipping archive sources (the anchored event is already live)",
+			"event_id", o.Opts.EventAnchor.EventID, "sources", len(src.archSources))
+		return rows, nil, nil, 0, true, nil
+	}
 	if topNSatisfiedLive(o.Opts, rows, src.plan) {
 		slog.Debug("planner: skipping archive sources (newest-first page filled from contiguous live coverage)",
 			"limit", o.Opts.Limit, "sources", len(src.archSources))

--- a/internal/query/fetchmerged.go
+++ b/internal/query/fetchmerged.go
@@ -255,7 +255,16 @@ func anchorSatisfiedLive(opts Options, rows []ResultRow) bool {
 		return false
 	}
 	for i := range rows {
-		if rows[i].EventID == opts.EventAnchor.EventID {
+		// The whole key, not the id alone. event_id is unique on its own, so
+		// matching it would be enough GIVEN that the live fetch applied the
+		// anchor — which fetchPage does, passing the same Options to
+		// engine.Fetch. That proof is contextual rather than local, and
+		// internal/buffer.Fetch is an existing Options consumer that filters by
+		// hand and would ignore an anchor entirely. Comparing the timestamp too
+		// costs nothing and makes the predicate self-sufficient: it can only
+		// answer true about a row that IS the anchored event.
+		if rows[i].EventID == opts.EventAnchor.EventID &&
+			rows[i].EventTimestamp.Equal(opts.EventAnchor.Timestamp) {
 			return true
 		}
 	}

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -250,6 +250,26 @@ type Options struct {
 	//
 	// nil = no cursor (fetch from the start of the window).
 	AfterEvent *EventCursor
+	// EventAnchor names ONE event exactly: the (event_timestamp, event_id)
+	// pair identifying a single row of binlog_events. It is a membership
+	// filter, not a cursor — unlike AfterEvent/BeforeEvent it admits exactly
+	// one event rather than a half-open range, and so composes with any Order.
+	//
+	// Why a pair when event_id alone identifies the row: event_id carries no
+	// partition information, so an id-only predicate would scan every
+	// partition of binlog_events (and every Parquet file of every archive).
+	// The timestamp is what lets both engines prune to the one hour that can
+	// hold the row. Callers that have an event in hand always have both — the
+	// console's Undo bridge reads them off the row the operator clicked.
+	//
+	// It exists because a timestamp alone cannot name an event: the column has
+	// one-second resolution, so an Until bound plus LimitPerPK=1 resolves to
+	// "the newest event in that second", which on a row INSERTed and DELETEd
+	// within one second is not the event the operator pointed at — and
+	// reversing the wrong one of that pair inverts the outcome (#1411).
+	//
+	// nil = no anchor.
+	EventAnchor *EventCursor
 	// BeforeEvent is AfterEvent's mirror: it restricts results to events
 	// strictly BEFORE this point in the (event_timestamp, event_id) sort
 	// order, which is what a DESCENDING (newest-first) surface needs to reach
@@ -697,6 +717,24 @@ func buildQuery(opts Options) (string, []any) {
 			" OR (CHAR_LENGTH(binlog_file) = CHAR_LENGTH(?) AND binlog_file < ?)"+
 			" OR (binlog_file = ? AND end_pos <= ?))")
 		args = append(args, opts.UntilPos.File, opts.UntilPos.File, opts.UntilPos.File, opts.UntilPos.File, opts.UntilPos.Pos)
+	}
+	if opts.EventAnchor != nil {
+		// Hour-aligned TO_SECONDS bracket so MySQL prunes to the single
+		// partition that can hold this event, for the same reason the
+		// cursor blocks below emit one: a parameterised datetime comparison
+		// prunes nothing at parse time. The bracket is exact here rather than
+		// deliberately over-inclusive — an anchor names one event, and that
+		// event's own hour is the only partition it can live in.
+		lo := mysqlToSeconds(opts.EventAnchor.Timestamp.Truncate(time.Hour))
+		hi := mysqlToSeconds(opts.EventAnchor.Timestamp.Truncate(time.Hour).Add(time.Hour))
+		where = append(where, fmt.Sprintf("TO_SECONDS(event_timestamp) >= %d", lo))
+		where = append(where, fmt.Sprintf("TO_SECONDS(event_timestamp) < %d", hi))
+		// The exact identity. event_timestamp is carried alongside event_id
+		// (which is unique on its own) so a stale anchor whose timestamp no
+		// longer matches the stored row returns nothing instead of silently
+		// resolving to a different moment than the caller named.
+		where = append(where, "event_timestamp = ? AND event_id = ?")
+		args = append(args, opts.EventAnchor.Timestamp, opts.EventAnchor.EventID)
 	}
 	if opts.AfterEvent != nil {
 		// Hour-aligned TO_SECONDS literal so MySQL can prune partitions at parse

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -1358,10 +1358,10 @@ try {
     : bad("restore: the Undo banner claims the clicked event, and no longer carries the retired same-second caveat", JSON.stringify(undoBridge));
   // The two bridges collide one level above the fields. With the Undo banner
   // on screen — the only place in the run where it really is — driving
-  // "Restore to this state" must retire it: the banner states "Latest per row
-  // is set to 1" as a fact about this form, and that action clears the field.
-  // Left up, the operator reads a one-change scope over a script that reverses
-  // everything after the instant.
+  // "Restore to this state" must retire it: the banner asserts that exactly the
+  // clicked event is reversed, and that action clears the anchor. Left up, the
+  // operator reads a one-event scope over a script that reverses everything
+  // after the instant.
   const staleBanner = await page.evaluate(async () => {
     const f = document.getElementById("recover-form");
     const before = !!document.getElementById("undo-ctx-banner");
@@ -1384,9 +1384,10 @@ try {
   }
 
   // Leave the page as this scenario found it. pendingRecover survives a
-  // re-render, and the prefilled cap makes every later generate 400 with
-  // "the latest-per-row filter needs a PK" the moment a scenario clears the PK
-  // — which is a correct server refusal and a wrong reason for fourteen
+  // re-render, and a leftover Undo prefill makes later scenarios answer the
+  // wrong question — historically the cap 400'd every generate that cleared
+  // the PK, and since #1411 a leftover anchor pins them all to one old event.
+  // Either way: a correct server response, and a wrong reason for fourteen
   // unrelated checks to go red.
   const undoRestore = await page.evaluate(async (fixSchema) => {
     pendingRecover = null;

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -1240,6 +1240,12 @@ try {
     // #1404: arrive carrying the Undo bridge's per-row cap, which is what an
     // operator who used Undo first would have in the field.
     f.elements.limit_per_pk.value = "1";
+    // #1411: …and its event anchor, which is the stronger half of the same
+    // hazard. The cap reverses the newest change after the instant; a leftover
+    // anchor reverses ONE event chosen minutes ago in Events and nothing else,
+    // under a button naming the state as of `at`. Set to a well-formed token so
+    // a clear is the only thing that can empty it.
+    f.elements.event.value = "2026-08-21T20:08:36Z|403440";
     // #1405: previewRecover is stubbed for the duration of the click, and that
     // is the whole assertion rather than a convenience. aimUndoAtInstant calls
     // it synchronously, previewRecover opens the busy dialog, and openBusyModal
@@ -1252,7 +1258,8 @@ try {
     const stillOpen = !!document.querySelector("#modal .state-modal");
     previewRecover = realPreview;
     return { since: f.elements.since.value, until: f.elements.until.value,
-             cap: f.elements.limit_per_pk.value, at, inline, stillOpen };
+             cap: f.elements.limit_per_pk.value, anchor: f.elements.event.value,
+             at, inline, stillOpen };
   });
   {
     const m = /as of (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})/.exec(bridge.at || "");
@@ -1276,6 +1283,9 @@ try {
     bridge.cap === ""
       ? ok("restore: 'Restore to this state' clears the Undo bridge's per-row cap")
       : bad("restore: 'Restore to this state' clears the Undo bridge's per-row cap", `limit_per_pk=${bridge.cap}`);
+    bridge.anchor === ""
+      ? ok("restore: 'Restore to this state' clears the Undo bridge's event anchor")
+      : bad("restore: 'Restore to this state' clears the Undo bridge's event anchor", `event=${bridge.anchor}`);
   }
 
   // The other direction: arriving through Undo must land the cap in the field,
@@ -1303,11 +1313,12 @@ try {
     {
       const f0 = document.getElementById("recover-form");
       window.__preUndo = {};
-      if (f0) for (const n of ["schema", "table", "pk", "limit_per_pk", "since", "until"]) {
+      if (f0) for (const n of ["schema", "table", "pk", "limit_per_pk", "since", "until", "event"]) {
         window.__preUndo[n] = f0.elements[n] ? f0.elements[n].value : "";
       }
     }
-    pendingRecover = { schema: fixSchema, table: "orders", pk: "1", type: "update", time: "2026-01-01 00:00:00" };
+    pendingRecover = { schema: fixSchema, table: "orders", pk: "1", type: "update",
+                       time: "2026-01-01 00:00:00", anchor: "2026-01-01T00:00:00Z|4242" };
     navigate("recover");
     for (let i = 0; i < 40; i++) {
       const f = document.getElementById("recover-form");
@@ -1318,27 +1329,33 @@ try {
     if (!f) return { err: "no recover form" };
     const eyebrow = (document.querySelector(".ctx-banner .ctx-eyebrow") || {}).textContent || "";
     const detail = Array.from(document.querySelectorAll(".ctx-banner .ctx-detail")).map((n) => n.textContent).join(" ");
-    return { cap: f.elements.limit_per_pk.value, until: f.elements.until.value, eyebrow, detail };
+    return { cap: f.elements.limit_per_pk.value, anchor: f.elements.event.value,
+             until: f.elements.until.value, eyebrow, detail };
   }, FIX);
-  (undoBridge.cap === "1" && undoBridge.until === "2026-01-01 00:00:00")
-    ? ok("restore: the Undo bridge prefills a per-row cap of 1 alongside the ceiling")
-    : bad("restore: the Undo bridge prefills a per-row cap of 1 alongside the ceiling", JSON.stringify(undoBridge));
+  // #1411: the anchor is what the bridge prefills now, and the cap must NOT
+  // come back with it — two mechanisms narrowing one scope drift, and the cap
+  // is the one the banner no longer mentions.
+  (undoBridge.anchor === "2026-01-01T00:00:00Z|4242" && undoBridge.cap === "" && undoBridge.until === "2026-01-01 00:00:00")
+    ? ok("restore: the Undo bridge prefills the event anchor alongside the ceiling, and no per-row cap")
+    : bad("restore: the Undo bridge prefills the event anchor alongside the ceiling, and no per-row cap", JSON.stringify(undoBridge));
   // Give the generate its POST, then stop intercepting.
   for (let i = 0; i < 40 && !sentBodies.length; i++) await new Promise((r) => setTimeout(r, 100));
   await page.unroute("**/api/recover");
   {
     const parsed = sentBodies.map((b) => { try { return JSON.parse(b); } catch { return {}; } });
-    const capped = parsed.filter((b) => b.limit_per_pk === 1);
-    (sentBodies.length > 0 && capped.length === parsed.length)
-      ? ok("restore: the Undo bridge's generate SENDS limit_per_pk — the cap is on the wire, not just in the field")
-      : bad("restore: the Undo bridge's generate SENDS limit_per_pk — the cap is on the wire, not just in the field",
+    const anchored = parsed.filter((b) => b.event === "2026-01-01T00:00:00Z|4242");
+    (sentBodies.length > 0 && anchored.length === parsed.length)
+      ? ok("restore: the Undo bridge's generate SENDS the anchor — the identity is on the wire, not just in the field")
+      : bad("restore: the Undo bridge's generate SENDS the anchor — the identity is on the wire, not just in the field",
             JSON.stringify({ sent: sentBodies }));
   }
   // The prefill changes what the button reverses, so the banner has to say it.
   // A prefill the banner does not mention is a silent narrowing.
-  (/one change/.test(undoBridge.eyebrow) && /Latest per row is set to 1/.test(undoBridge.detail) && /clear it/.test(undoBridge.detail))
-    ? ok("restore: the Undo banner states the cap it prefilled and how to clear it")
-    : bad("restore: the Undo banner states the cap it prefilled and how to clear it", JSON.stringify(undoBridge));
+  (/one change/.test(undoBridge.eyebrow) && /exactly this/.test(undoBridge.detail)
+    && /the one you clicked/.test(undoBridge.detail) && /Clear/.test(undoBridge.detail)
+    && !/not necessarily the one you clicked/.test(undoBridge.detail))
+    ? ok("restore: the Undo banner claims the clicked event, and no longer carries the retired same-second caveat")
+    : bad("restore: the Undo banner claims the clicked event, and no longer carries the retired same-second caveat", JSON.stringify(undoBridge));
   // The two bridges collide one level above the fields. With the Undo banner
   // on screen — the only place in the run where it really is — driving
   // "Restore to this state" must retire it: the banner states "Latest per row


### PR DESCRIPTION
console: Undo reverses the event you clicked, not the last one in its second (#1411)

The Undo bridge carried the clicked event to Restore as a TIME, not an
identity: `pendingRecover.time` is second-granular and became `until`, and
since #1404 the request also sent `limit_per_pk = 1`. Together those resolve
to "the newest event at or before the end of that second" — which inside one
second is not necessarily the event the operator pointed at, and on one shape
inverts the outcome. A row INSERTed and DELETEd in the same second (WordPress
`_transient_doing_cron`) yields two events sharing a timestamp; the cap keeps
the DELETE; reversing a DELETE re-INSERTs. So clicking Undo on the INSERT put
the row BACK while the badge still read INSERT.

#1404's banner disclosed this in words. This names the event instead.

  - query.Options.EventAnchor: one (event_timestamp, event_id) pair, a
    membership filter rather than a cursor, mirrored in buildQuery and
    parquetquery. The pair, not the bare id: event_id carries no partition
    information, so an id-only predicate scans every partition and every
    Parquet file — the timestamp is what prunes.

  - eventDTO.anchor carries the token the client sends back, produced by the
    same formatEventCursor the ?before=/?after= cursors use. Emitted rather
    than rebuilt client-side: event_timestamp is second-granular and
    offset-less, so reconstructing an instant from it in JS means guessing a
    location, and guessing wrong does not fail — it names a different row.

  - The prefill sets the anchor and NO cap. Two mechanisms narrowing one scope
    is how they drift, and the cap is the one the banner no longer mentions.
    `until` stays: it is how the operator reads WHEN, and it is the scope left
    behind after Clear.

  - anchorSatisfiedLive joins the two existing archive short-circuits and is
    the cheapest of them — no plan, no ArchivesBelowLive, no boundary check.
    An anchor admits one event, event_id is MergeResults' own dedup key, so an
    archive can hold a copy of the event already in hand or nothing. The
    converse is deliberately not a refusal: an anchor absent from the live
    index falls through and is found in the archives.

The banner's same-second caveat is now false and is removed in this commit,
which is also the one that makes it false — assets_recover_banner_test.go
pinned it as REQUIRED text, so the two could not move apart. That guard now
asserts the opposite claim and BANS the retired sentences.

Also fixes two stale doc comments in fetchmerged.go that still named
topNSatisfiedLive as the only short-circuit; perPKSatisfiedLive joined it in
#1403.

Mutation-tested, 14/14 caught, with the original defect as mutation #1 (revert
the prefill to `until` + `limit_per_pk = 1`) — red in both the Go guards and
the console e2e, whose failure output shows the wire body losing `event` and
regaining `limit_per_pk`. Console e2e 267/267.

Cascade is out of scope: recover-cascade derives its parent set from the
filtered base rows, so an anchor narrows it to one root — probably right, but
a decision rather than a side effect. #1410 tracks the MCP surface, which
builds its own merge loop and takes none of these short-circuits.

Closes #1411
