### PR TITLE
verify: split the inconclusive bucket — a clean recover-inputs run read as 20 warnings

### DIFF
--- a/consoleapp/verify.go
+++ b/consoleapp/verify.go
@@ -791,7 +791,8 @@ func toWireResult(res verify.TableResult, explainable bool) console.VerifyTableR
 	return console.VerifyTableResult{
 		Schema: res.Schema, Table: res.Table, Status: string(status),
 		Reason: reason, Detail: reason,
-		SourceRows: res.SourceRows, ReconstructRows: res.ReconstructRows, Anchor: res.Anchor,
+		InconclusiveKind: res.InconclusiveKind,
+		SourceRows:       res.SourceRows, ReconstructRows: res.ReconstructRows, Anchor: res.Anchor,
 		Explainable: explainable,
 	}
 }
@@ -812,7 +813,7 @@ func (s *verifySupervisor) appendResult(serverID string, tr console.VerifyTableR
 	// The round-trip struct conversion is the drift guard: it stops compiling
 	// the moment console.VerifySummary and verify.Summary diverge.
 	sum := verify.Summary(j.status.Summary)
-	sum.Count(verify.Status(tr.Status))
+	sum.CountWithKind(verify.Status(tr.Status), tr.InconclusiveKind)
 	j.status.Summary = console.VerifySummary(sum)
 }
 

--- a/consoleapp/verify_test.go
+++ b/consoleapp/verify_test.go
@@ -48,6 +48,19 @@ func TestToWireResult(t *testing.T) {
 	if got != want {
 		t.Errorf("toWireResult = %+v, want %+v", got, want)
 	}
+
+	// The kind must survive the engine→wire copy (#1416). Pinned with a value
+	// set, not by the zero struct: the walk and the report each had their own
+	// tests, and the engine-side copy stayed green with the field deleted —
+	// this is the console's instance of the same seam.
+	quiet := toWireResult(verify.TableResult{
+		Schema: "wp", Table: "quiet", Status: verify.StatusInconclusive,
+		Detail: "no changes in the window", InconclusiveKind: verify.InconclusiveNoActivity,
+	}, false)
+	if quiet.InconclusiveKind != string(verify.InconclusiveNoActivity) {
+		t.Errorf("InconclusiveKind = %q, want %q — the console renders every quiet table as attention without it",
+			quiet.InconclusiveKind, verify.InconclusiveNoActivity)
+	}
 	if got := toWireResult(res, false); got.Explainable {
 		t.Error("explainable must be exactly what the caller passed, not re-derived from Status")
 	}
@@ -118,13 +131,17 @@ func TestVerifySupervisor_appendResult_accumulatesSummary(t *testing.T) {
 	s.appendResult("srv1", console.VerifyTableResult{Schema: "wp", Table: "posts", Status: "match"})
 	s.appendResult("srv1", console.VerifyTableResult{Schema: "wp", Table: "users", Status: "mismatch"})
 	s.appendResult("srv1", console.VerifyTableResult{Schema: "wp", Table: "opts", Status: "inconclusive"})
+	s.appendResult("srv1", console.VerifyTableResult{Schema: "wp", Table: "logs", Status: "inconclusive", InconclusiveKind: "no-activity"})
 	s.appendResult("srv1", console.VerifyTableResult{Schema: "wp", Table: "bad", Status: "something-unrecognized"})
 
 	got := s.Status("srv1")
-	if len(got.Results) != 4 || got.Results[0].Table != "posts" || got.Results[3].Table != "bad" {
-		t.Fatalf("Results = %+v, want 4 entries in append order", got.Results)
+	if len(got.Results) != 5 || got.Results[0].Table != "posts" || got.Results[4].Table != "bad" {
+		t.Fatalf("Results = %+v, want 5 entries in append order", got.Results)
 	}
-	want := console.VerifySummary{Match: 1, Mismatch: 1, Inconclusive: 1, Error: 1, Total: 4}
+	// The kind-less inconclusive counts on the attention side and the benign
+	// one in the split — the tally must go through CountWithKind, or every
+	// quiet table renders amber in the console summary (#1416).
+	want := console.VerifySummary{Match: 1, Mismatch: 1, Inconclusive: 2, InconclusiveNothingToCheck: 1, Error: 1, Total: 5}
 	if got.Summary != want {
 		t.Errorf("Summary = %+v, want %+v (an unrecognized status must fall through to Error)", got.Summary, want)
 	}

--- a/docs/console.md
+++ b/docs/console.md
@@ -516,7 +516,10 @@ straight from the **Protect → Baselines** page, and it only runs on the `watch
   [verify.md](verify.md)'s own warning). It only appears in the mode selector
   when the server has a source DSN configured.
 - Per-table results are colored match / mismatch / inconclusive / error, the
-  same four outcomes `bintrail verify` reports. A mismatch found by a
+  same four outcomes `bintrail verify` reports — except that a recover-inputs
+  inconclusive whose kind is benign (`no-activity` / `nothing-to-assert`)
+  renders as a neutral grey note instead of amber, and the summary splits
+  those out as "nothing to check". A mismatch found by a
   baseline-anchored run gets an **Explain** button — an on-demand,
   never-precomputed row-level drill-down (`--explain`'s console equivalent),
   re-run only when clicked. Live-source mismatches have no explain support

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -226,6 +226,17 @@ Results are **per table**, one of:
   (regenerate the baseline — see below), or a value class this version cannot yet
   compare.
 
+  Under `--check recover`, inconclusive is subdivided by `inconclusive_kind`
+  so a summary can be read: `no-activity` (nothing changed in the window),
+  `nothing-to-assert` (every chain is a single INSERT — an append-only shape
+  where zero assertions is the expected outcome, in every window), and
+  `unproven` (there was content the walk could not prove: chains beginning
+  mid-history, unresolvable values, or a truncated window). The first two are
+  benign and counted in `summary.inconclusive_nothing_to_check`; the remainder
+  — including an inconclusive with **no** kind, from a content mode or an
+  older producer — is the slice worth a look. The exit contract is unchanged:
+  an all-inconclusive run still exits non-zero, whatever the kinds.
+
 ## Machine-readable output (`--format json`)
 
 `--format json` (default `text`) emits the whole run as one JSON document, so a
@@ -255,7 +266,8 @@ bintrail verify --index-dsn "$IDX" --baseline-dir /data/baselines --format json
       "reason": "content digest differs"
     }
   ],
-  "summary": { "match": 8, "mismatch": 1, "inconclusive": 2, "error": 0, "total": 11 }
+  "summary": { "match": 8, "mismatch": 1, "inconclusive": 2,
+               "inconclusive_nothing_to_check": 1, "error": 0, "total": 11 }
 }
 ```
 
@@ -268,6 +280,12 @@ bintrail verify --index-dsn "$IDX" --baseline-dir /data/baselines --format json
   to (a GTID set in MySQL live-source mode, a `file:pos` binlog coordinate in
   MySQL baseline-anchored mode, an `LSN:` WAL position for a PostgreSQL
   source); `reason` is the detail behind the verdict.
+- `tables[].inconclusive_kind` — only on `status: "inconclusive"` rows and
+  only under `--check recover` (omitted otherwise, mirroring the counters
+  below): `no-activity`, `nothing-to-assert`, or `unproven` — see the
+  taxonomy above. `summary.inconclusive_nothing_to_check` is always present
+  and counts the benign kinds; it is a subdivision of `summary.inconclusive`,
+  not a fifth bucket.
 - `tables[].events_checked` / `chains_checked` / `chains_inconclusive` —
   present only under `--check recover` (omitted entirely otherwise, so a
   content-mode document is unchanged): how many events the chain walk visited,

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -712,6 +712,17 @@ func writeVerifyText(out io.Writer, rep *verify.Report) {
 			r.Schema, r.Table, r.Status, r.SourceRows, r.ReconstructRows, r.Reason)
 	}
 	w.Flush()
+	// The inconclusive split (#1416): "20 inconclusive" was unreadable when
+	// 18 of them were quiet or append-only tables where zero assertions is
+	// the expected outcome. The parenthetical names the slice that deserves
+	// attention — and it is the REMAINDER, so an unclassified inconclusive
+	// (content modes, older producers) lands on the attention side.
+	if n := rep.Summary.InconclusiveNothingToCheck; n > 0 {
+		fmt.Fprintf(out, "\n%d match, %d mismatch, %d inconclusive (%d nothing to check — quiet or append-only; %d unproven), %d error\n",
+			rep.Summary.Match, rep.Summary.Mismatch, rep.Summary.Inconclusive,
+			n, rep.Summary.Inconclusive-n, rep.Summary.Error)
+		return
+	}
 	fmt.Fprintf(out, "\n%d match, %d mismatch, %d inconclusive, %d error\n",
 		rep.Summary.Match, rep.Summary.Mismatch, rep.Summary.Inconclusive, rep.Summary.Error)
 }

--- a/internal/cli/verify_format_test.go
+++ b/internal/cli/verify_format_test.go
@@ -229,6 +229,34 @@ func TestVerifyTextFormatUnchanged(t *testing.T) {
 	}
 }
 
+// TestVerifyTextSummarySplit: with a benign inconclusive present, the summary
+// line names the slice and the remainder (#1416) — mutation-proven gap: the
+// whole split block deleted left this package green, so the split existed
+// only as prose until this pinned it.
+func TestVerifyTextSummarySplit(t *testing.T) {
+	setVerifyFormat(t, "text")
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	rep := verify.NewReport(verify.ModeRecoverInputs, []verify.TableResult{
+		{Schema: "mydb", Table: "orders", Status: verify.StatusMatch},
+		{Schema: "mydb", Table: "logs", Status: verify.StatusInconclusive, InconclusiveKind: verify.InconclusiveNoActivity},
+		{Schema: "mydb", Table: "hard", Status: verify.StatusInconclusive, InconclusiveKind: verify.InconclusiveUnproven},
+		{Schema: "mydb", Table: "old", Status: verify.StatusInconclusive}, // unclassified: attention side
+	})
+	if err := emitVerifyReport(cmd, rep); err != nil {
+		t.Fatalf("emitVerifyReport: %v", err)
+	}
+	s := out.String()
+	// The arithmetic is the point: 3 inconclusive, 1 benign, remainder 2
+	// (the unproven one AND the unclassified one — rounding the unknown
+	// toward benign is the direction this feature must never take).
+	want := "1 match, 0 mismatch, 3 inconclusive (1 nothing to check — quiet or append-only; 2 unproven), 0 error"
+	if !strings.Contains(s, want) {
+		t.Errorf("text summary missing %q:\n%s", want, s)
+	}
+}
+
 // TestVerifyFormatIsCaseSensitive: `--format JSON` renders TEXT, exactly like
 // every other --format command in the repo (status.go:118, query, recover,
 // rotate, recover-cascade, telemetry all compare exactly) — and, load-bearing,

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -4186,7 +4186,48 @@ async function pollVerify(id, onTick) {
 }
 
 const VFY_STATUS_CLASS = { match: "pass", mismatch: "fail", error: "fail", inconclusive: "warn" };
-const VFY_STATUS_MARK = { pass: "✓", fail: "✗", warn: "!" };
+
+// The benign inconclusive kinds (#1416): quiet or append-only tables, where
+// zero assertions is the expected and PERMANENT outcome — not a finding. They
+// render neutral, never amber: 20 warning-coloured rows on a healthy server is
+// how operators learn to stop reading this page. The mapping is by KIND, not by
+// status — an inconclusive with no kind (content modes, older runs) stays
+// amber, because defaulting the unknown to benign is the direction a verify
+// surface must never round.
+const VFY_BENIGN_KINDS = { "no-activity": true, "nothing-to-assert": true };
+function vfyCardClass(r) {
+  if (r.status === "inconclusive" && VFY_BENIGN_KINDS[r.inconclusive_kind]) return "note";
+  return VFY_STATUS_CLASS[r.status] || "fail";
+}
+const VFY_STATUS_MARK = { pass: "✓", fail: "✗", warn: "!", note: "–" };
+// vfySummaryText renders the summary counts, splitting the inconclusive
+// bucket when the split exists (#1416): "20 inconclusive" was unreadable when
+// 18 were quiet or append-only tables. The attention-worthy number is the
+// REMAINDER, so an unclassified inconclusive lands on the attention side.
+function vfySummaryText(s) {
+  let inc = s.inconclusive + " inconclusive";
+  if (s.inconclusive_nothing_to_check > 0) {
+    inc = s.inconclusive + " inconclusive (" + s.inconclusive_nothing_to_check
+      + " nothing to check · " + (s.inconclusive - s.inconclusive_nothing_to_check) + " unproven)";
+  }
+  return s.match + " match · " + s.mismatch + " mismatch · " + inc + " · " + s.error + " error";
+}
+
+// vfyVerdictSentence answers "is my restore sound?" in words. It never claims
+// more than was proven: benign inconclusives are named as not-applicable, and
+// any unproven remainder is called out rather than absorbed.
+function vfyVerdictSentence(s) {
+  const unproven = s.inconclusive - (s.inconclusive_nothing_to_check || 0);
+  if (s.mismatch > 0) return s.mismatch + " table(s) failed verification — read those rows first.";
+  if (s.error > 0) return s.error + " table(s) could not be verified due to errors.";
+  const parts = [];
+  if (s.match > 0) parts.push(s.match + " table(s) verified clean");
+  if (s.inconclusive_nothing_to_check > 0) parts.push(s.inconclusive_nothing_to_check + " had nothing to check (no activity in the window, or append-only — expected)");
+  if (unproven > 0) parts.push(unproven + " had content that could not be proven — worth a look");
+  if (!parts.length) return "Nothing was verified.";
+  return parts.join("; ") + ".";
+}
+
 const VFY_MODE_LABEL = { "baseline-anchored": "compared two saved snapshots", "live-source": "compared against the live database", "recover-inputs": "checked recovery inputs in the index" };
 
 // loadVerifyHistory renders the persisted run history into box: a "last
@@ -4248,10 +4289,15 @@ function renderVerifyResults(container, status, id) {
   if (status.mode) summaryRow.append(el("span", { class: "stg-age", text: VFY_MODE_LABEL[status.mode] || status.mode }));
   const s = status.summary || {};
   if (status.results && status.results.length) {
-    summaryRow.append(el("span", { class: "stg-age", text:
-      s.match + " match · " + s.mismatch + " mismatch · " + s.inconclusive + " inconclusive · " + s.error + " error" }));
+    summaryRow.append(el("span", { class: "stg-age", text: vfySummaryText(s) }));
   }
   container.append(summaryRow);
+  // The verdict sentence (#1416): the answer to the operator's question in
+  // words, so it does not have to be derived from 28 rows. Only on a FINISHED
+  // run — a partial tally must not be read as a verdict (#1420).
+  if (status.state === "succeeded") {
+    container.append(el("p", { class: "form-hint", text: vfyVerdictSentence(s) }));
+  }
   if (status.note) container.append(el("p", { class: "form-hint", text: status.note }));
   if (status.last_error) container.append(el("p", { class: "form-msg err", text: status.last_error }));
 
@@ -4259,7 +4305,7 @@ function renderVerifyResults(container, status, id) {
   (status.results || []).forEach((r) => {
     // Statuses are normalized server-side (verify.NormalizeStatus), so only
     // the four keys above can arrive; if that ever breaks, fail — never reassure.
-    const cls = VFY_STATUS_CLASS[r.status] || "fail";
+    const cls = vfyCardClass(r);
     const card = el("div", { class: "doctor-card " + cls });
     card.append(el("span", { class: "dc-mark", text: VFY_STATUS_MARK[cls] || "?" }));
     const body = el("div", { class: "dc-body" },

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -4147,8 +4147,7 @@ async function createVerify(id, mode, btn, resultsEl) {
   if (histBox) loadVerifyHistory(id, histBox);
   if (done && done.state === "succeeded") {
     const s = done.summary || {};
-    toast(done.note || ("Verification complete: " + s.match + " match, " + s.mismatch + " mismatch, " +
-      s.inconclusive + " inconclusive, " + s.error + " error"));
+    toast(done.note || ("Verification complete: " + vfySummaryText(s)));
   } else if (done) {
     toastError("Verification failed: " + (done.last_error || "unknown error"));
   } else {
@@ -4263,7 +4262,7 @@ async function loadVerifyHistory(id, box) {
     let outcome;
     if (r.state === "skipped") outcome = "skipped — " + (r.skip_reason || "");
     else if (r.state === "failed") outcome = "failed — " + (r.last_error || "unknown error");
-    else outcome = s.match + " match · " + s.mismatch + " mismatch · " + s.inconclusive + " inconclusive · " + s.error + " error";
+    else outcome = vfySummaryText(s);
     const when = utcLabel(r.finished_at || r.since || "");
     const row = el("div", { class: "stg-row" });
     row.append(

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1758,6 +1758,11 @@ button { font-family: inherit; }
 .doctor-card.pass { border-color: var(--insert); }
 .doctor-card.fail { border-color: var(--delete); }
 .doctor-card.warn { border-color: var(--ochre); }
+/* "note" is the benign-inconclusive treatment (#1416): a table with nothing
+   to check is stated, not warned about. Neutral border, muted mark — visually
+   quieter than pass, never amber. */
+.doctor-card.note { border-color: var(--line); }
+.doctor-card.note .dc-mark { color: var(--ink-4); }
 .dc-mark { font-family: var(--f-mono); font-weight: 700; line-height: 1.4; flex: none; }
 .doctor-card.pass .dc-mark { color: var(--insert); }
 .doctor-card.fail .dc-mark { color: var(--delete); }

--- a/internal/console/verify_trigger.go
+++ b/internal/console/verify_trigger.go
@@ -119,10 +119,13 @@ type VerifyTableResult struct {
 	Reason string `json:"reason,omitempty"`
 	// Detail is the legacy alias for Reason, kept for consumers of the
 	// original #677 wire shape. Always carries the same value as Reason.
-	Detail          string `json:"detail,omitempty"`
-	SourceRows      int64  `json:"source_rows,omitempty"`
-	ReconstructRows int64  `json:"reconstruct_rows,omitempty"`
-	Anchor          string `json:"anchor,omitempty"`
+	Detail string `json:"detail,omitempty"`
+	// InconclusiveKind subdivides an inconclusive verdict (#1416):
+	// no-activity | nothing-to-assert | unproven. Empty otherwise.
+	InconclusiveKind string `json:"inconclusive_kind,omitempty"`
+	SourceRows       int64  `json:"source_rows,omitempty"`
+	ReconstructRows  int64  `json:"reconstruct_rows,omitempty"`
+	Anchor           string `json:"anchor,omitempty"`
 	// Explainable is true only for a baseline-anchored mismatch whose pair is
 	// still cached from the run that produced this result — the precondition
 	// for calling Explain on it.
@@ -144,7 +147,11 @@ type VerifySummary struct {
 	Match        int `json:"match"`
 	Mismatch     int `json:"mismatch"`
 	Inconclusive int `json:"inconclusive"`
-	Error        int `json:"error"`
+	// InconclusiveNothingToCheck mirrors verify.Summary's benign slice of
+	// Inconclusive (#1416): quiet or append-only tables where zero assertions
+	// is the expected outcome. Always <= Inconclusive.
+	InconclusiveNothingToCheck int `json:"inconclusive_nothing_to_check"`
+	Error                      int `json:"error"`
 	// Total is the number of results tallied — the same `total` the CLI's
 	// `verify --format json` summary carries.
 	Total int `json:"total"`

--- a/internal/verify/recover_inconclusive_kind_test.go
+++ b/internal/verify/recover_inconclusive_kind_test.go
@@ -107,16 +107,24 @@ func TestSummaryCountsBenignInconclusive(t *testing.T) {
 	s.CountWithKind(StatusInconclusive, InconclusiveUnproven)
 	s.CountWithKind(StatusInconclusive, "") // unclassified: content modes, older producers
 	s.CountWithKind(StatusMatch, "")
+	// A benign kind riding on a NON-inconclusive status must not bump the
+	// benign counter — the kind subdivides inconclusive only, and the wire
+	// can carry any pairing (pass 2 proved the status conjunct deletable
+	// with every test green).
+	s.CountWithKind(StatusMatch, InconclusiveNoActivity)
 
 	if s.Inconclusive != 4 {
 		t.Errorf("Inconclusive = %d, want 4 — the split is a subdivision, not a fifth bucket", s.Inconclusive)
+	}
+	if s.Match != 2 {
+		t.Errorf("Match = %d, want 2", s.Match)
 	}
 	if s.InconclusiveNothingToCheck != 2 {
 		t.Errorf("InconclusiveNothingToCheck = %d, want 2 — unproven and unclassified must both "+
 			"land on the attention side", s.InconclusiveNothingToCheck)
 	}
-	if s.Total != 5 {
-		t.Errorf("Total = %d, want 5", s.Total)
+	if s.Total != 6 {
+		t.Errorf("Total = %d, want 6", s.Total)
 	}
 }
 

--- a/internal/verify/recover_inconclusive_kind_test.go
+++ b/internal/verify/recover_inconclusive_kind_test.go
@@ -1,0 +1,132 @@
+package verify
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// The three inconclusive kinds (#1416), each driven through the REAL walk. One
+// bucket carried three meanings and rendered them identically, so a healthy
+// run over a server full of log tables read as a page of warnings. The split
+// exists so a summary can be read; these pin which shape lands where.
+func TestRecoverInconclusiveKinds(t *testing.T) {
+	tests := []struct {
+		name     string
+		events   []query.ResultRow
+		wantKind string
+		why      string
+	}{
+		{
+			name:     "no activity",
+			events:   nil,
+			wantKind: InconclusiveNoActivity,
+			why:      "an empty window is the quiet-table case, not a finding",
+		},
+		{
+			name: "true append-only: single INSERTs",
+			events: []query.ResultRow{
+				riEvent(1, event.EventInsert, "1", nil, riRow(1, "a", 1)),
+				riEvent(2, event.EventInsert, "2", nil, riRow(2, "b", 1)),
+			},
+			wantKind: InconclusiveNothingToAssert,
+			why: "every chain is a single INSERT — zero assertions is this shape's only " +
+				"possible outcome, in every window, forever",
+		},
+		{
+			name: "single mid-history UPDATE is NOT append-only",
+			events: []query.ResultRow{
+				riEvent(9, event.EventUpdate, "7", riRow(7, "w", 1), riRow(7, "w", 5)),
+			},
+			wantKind: InconclusiveUnproven,
+			why: "the row has prior history the window cannot see; widening the lookback " +
+				"makes it assertable, so 'does not apply' would over-claim benignity",
+		},
+		{
+			name: "drift rows are activity, not quiet",
+			events: []query.ResultRow{
+				riEvent(1, event.EventUpdate, "", riRow(1, "a", 1), riRow(1, "a", 2)),
+			},
+			wantKind: InconclusiveUnproven,
+			why: "Events counts what was WALKED, so a drift-only table also has Events==0 — " +
+				"reporting it as 'no changes in the window' is false",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out := checkRecoverChains(riInput(tc.events))
+			if out.Status != StatusInconclusive {
+				t.Fatalf("Status = %s (%s), want inconclusive", out.Status, out.Detail)
+			}
+			if out.InconclusiveKind != tc.wantKind {
+				t.Errorf("kind = %q, want %q — %s\ndetail: %s", out.InconclusiveKind, tc.wantKind, tc.why, out.Detail)
+			}
+		})
+	}
+}
+
+// A proven or diverged table carries NO kind: the field subdivides
+// inconclusive only, and a stray value on a match would let a summary count a
+// verified table as "nothing to check".
+func TestRecoverKindEmptyOffInconclusive(t *testing.T) {
+	out := checkRecoverChains(riInput([]query.ResultRow{
+		riEvent(1, event.EventInsert, "1", nil, riRow(1, "a", 1)),
+		riEvent(2, event.EventUpdate, "1", riRow(1, "a", 1), riRow(1, "a", 2)),
+	}))
+	if out.Status != StatusMatch {
+		t.Fatalf("Status = %s (%s), want match", out.Status, out.Detail)
+	}
+	if out.InconclusiveKind != "" {
+		t.Errorf("kind = %q on a match, want empty", out.InconclusiveKind)
+	}
+}
+
+// The summary split. The benign counter follows the KIND, and an inconclusive
+// with no kind counts on the attention side — defaulting the unknown to benign
+// is the direction a verify tool must never round.
+func TestSummaryCountsBenignInconclusive(t *testing.T) {
+	var s Summary
+	s.CountWithKind(StatusInconclusive, InconclusiveNoActivity)
+	s.CountWithKind(StatusInconclusive, InconclusiveNothingToAssert)
+	s.CountWithKind(StatusInconclusive, InconclusiveUnproven)
+	s.CountWithKind(StatusInconclusive, "") // unclassified: content modes, older producers
+	s.CountWithKind(StatusMatch, "")
+
+	if s.Inconclusive != 4 {
+		t.Errorf("Inconclusive = %d, want 4 — the split is a subdivision, not a fifth bucket", s.Inconclusive)
+	}
+	if s.InconclusiveNothingToCheck != 2 {
+		t.Errorf("InconclusiveNothingToCheck = %d, want 2 — unproven and unclassified must both "+
+			"land on the attention side", s.InconclusiveNothingToCheck)
+	}
+	if s.Total != 5 {
+		t.Errorf("Total = %d, want 5", s.Total)
+	}
+}
+
+// The report carries the kind to JSON consumers and the exit message carries
+// the split — a CI failure reading "20 inconclusive" with no hint that 18 had
+// nothing to check sends someone debugging a healthy server.
+func TestReportCarriesKindAndSplitExitMessage(t *testing.T) {
+	rep := NewReport(ModeRecoverInputs, []TableResult{
+		{Schema: "s", Table: "quiet", Status: StatusInconclusive, InconclusiveKind: InconclusiveNoActivity},
+		{Schema: "s", Table: "log", Status: StatusInconclusive, InconclusiveKind: InconclusiveNothingToAssert},
+		{Schema: "s", Table: "hard", Status: StatusInconclusive, InconclusiveKind: InconclusiveUnproven},
+	})
+	if rep.Summary.InconclusiveNothingToCheck != 2 {
+		t.Fatalf("summary split = %d, want 2", rep.Summary.InconclusiveNothingToCheck)
+	}
+	if got := rep.Tables[2].InconclusiveKind; got != InconclusiveNoActivity {
+		t.Errorf("table kind lost in NewReport: %q", got) // tables sorted by name: hard, log, quiet
+	}
+	err := rep.ExitError()
+	if err == nil {
+		t.Fatal("an all-inconclusive run must still exit non-zero — a CI gate must not read " +
+			"'nothing proven' as success, however benign the reasons")
+	}
+	if !strings.Contains(err.Error(), "nothing to check") {
+		t.Errorf("exit message = %q, want the benign split named", err.Error())
+	}
+}

--- a/internal/verify/recover_inconclusive_kind_test.go
+++ b/internal/verify/recover_inconclusive_kind_test.go
@@ -14,10 +14,11 @@ import (
 // exists so a summary can be read; these pin which shape lands where.
 func TestRecoverInconclusiveKinds(t *testing.T) {
 	tests := []struct {
-		name     string
-		events   []query.ResultRow
-		wantKind string
-		why      string
+		name      string
+		events    []query.ResultRow
+		truncated bool
+		wantKind  string
+		why       string
 	}{
 		{
 			name:     "no activity",
@@ -45,6 +46,17 @@ func TestRecoverInconclusiveKinds(t *testing.T) {
 				"makes it assertable, so 'does not apply' would over-claim benignity",
 		},
 		{
+			name: "a truncated window is unproven even over a benign shape",
+			events: []query.ResultRow{
+				riEvent(1, event.EventInsert, "1", nil, riRow(1, "a", 1)),
+			},
+			truncated: true,
+			wantKind:  InconclusiveUnproven,
+			why: "the tail of the window was never loaded, so nothing about its shape is " +
+				"known — rounding truncation toward 'nothing to check' hides exactly the " +
+				"runs that most need a narrower window",
+		},
+		{
 			name: "drift rows are activity, not quiet",
 			events: []query.ResultRow{
 				riEvent(1, event.EventUpdate, "", riRow(1, "a", 1), riRow(1, "a", 2)),
@@ -56,7 +68,9 @@ func TestRecoverInconclusiveKinds(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			out := checkRecoverChains(riInput(tc.events))
+			in := riInput(tc.events)
+			in.Truncated = tc.truncated
+			out := checkRecoverChains(in)
 			if out.Status != StatusInconclusive {
 				t.Fatalf("Status = %s (%s), want inconclusive", out.Status, out.Detail)
 			}

--- a/internal/verify/recover_inputs.go
+++ b/internal/verify/recover_inputs.go
@@ -176,6 +176,7 @@ func VerifyRecoverInputs(ctx context.Context, cfg RecoverInputsConfig, schema, t
 
 	res.Status = out.Status
 	res.Detail = out.Detail
+	res.InconclusiveKind = out.InconclusiveKind
 	res.EventsChecked = out.Events
 	res.ChainsChecked = out.Chains
 	res.ChainsInconclusive = out.ChainsNoPredecessor
@@ -385,6 +386,11 @@ type recoverChainOutcome struct {
 	// see the PKValues=="" guard in checkRecoverChains). They belong to no
 	// chain and are counted as unproven, never folded together.
 	UnwalkableEvents int
+	// InconclusiveKind subdivides StatusInconclusive (#1416). One bucket was
+	// carrying three meanings and rendering them identically, so a healthy
+	// run over a server full of append-only tables read as a page of
+	// warnings. Empty unless Status is StatusInconclusive.
+	InconclusiveKind string
 }
 
 // chainState is one PK's reconstructed state between events.
@@ -545,7 +551,7 @@ func checkRecoverChains(in recoverChainInput) recoverChainOutcome {
 	// rows must not report events "checked" that were never walked.
 	out.Events = len(in.Events) - out.UnwalkableEvents
 	out.ChainsNoPredecessor = len(noPredecessor)
-	out.Status, out.Detail = recoverChainVerdict(out, mismatchCount, firstMismatch, unresolved, firstUnresolved, in.Truncated)
+	out.Status, out.Detail, out.InconclusiveKind = recoverChainVerdict(out, mismatchCount, firstMismatch, unresolved, firstUnresolved, in.Truncated)
 	return out
 }
 
@@ -566,7 +572,7 @@ func checkRecoverChains(in recoverChainInput) recoverChainOutcome {
 // Truncation is the one exception that still collapses the table: there the
 // unchecked part is not a handful of values but the entire TAIL of the window,
 // which was never loaded at all.
-func recoverChainVerdict(out recoverChainOutcome, mismatchCount int, firstMismatch string, unresolved int, firstUnresolved string, truncated bool) (Status, string) {
+func recoverChainVerdict(out recoverChainOutcome, mismatchCount int, firstMismatch string, unresolved int, firstUnresolved string, truncated bool) (Status, string, string) {
 	scope := fmt.Sprintf("%d event(s), %d chain(s), %d before-image assertion(s)", out.Events, out.Chains, out.Assertions)
 
 	// A mismatch is conclusive regardless of what else could not be checked:
@@ -576,10 +582,12 @@ func recoverChainVerdict(out recoverChainOutcome, mismatchCount int, firstMismat
 		if mismatchCount > 1 {
 			detail += fmt.Sprintf(" (and %d more)", mismatchCount-1)
 		}
-		return StatusMismatch, detail
+		return StatusMismatch, detail, ""
 	}
 	if truncated {
-		return StatusInconclusive, fmt.Sprintf("checked %s with no inconsistency, but the window exceeded the event budget and only its oldest events were walked; narrow --since/--lookback or raise --max-events to verify it whole", scope)
+		// Truncation is category-"unproven" by definition: the whole tail of
+		// the window held assertable content that was never loaded.
+		return StatusInconclusive, fmt.Sprintf("checked %s with no inconsistency, but the window exceeded the event budget and only its oldest events were walked; narrow --since/--lookback or raise --max-events to verify it whole", scope), InconclusiveUnproven
 	}
 
 	var notes []string
@@ -594,17 +602,48 @@ func recoverChainVerdict(out recoverChainOutcome, mismatchCount int, firstMismat
 	}
 
 	if out.Assertions == 0 {
-		detail := fmt.Sprintf("walked %s: nothing was proven — no before-image comparison in this window was conclusive", scope)
-		if len(notes) > 0 {
-			detail += "; " + strings.Join(notes, "; ")
+		// Three shapes used to share one sentence here, and the first two are
+		// the ordinary state of a healthy server, not findings (#1416). The
+		// wording is written from the operator's question ("is my restore
+		// sound?"), not from the walk's internals — but none of them renders
+		// as a match: a table with nothing to assert must never read as "its
+		// before-images were checked", because nobody looked.
+		switch {
+		case out.Events == 0 && out.UnwalkableEvents == 0:
+			// The UnwalkableEvents guard is load-bearing: Events counts what
+			// the walk VISITED, so a table of nothing but drift rows also has
+			// Events==0 — and "no changes in the window" would be false there.
+			// Existing tests caught exactly that misclassification.
+			return StatusInconclusive, "no changes to this table in the window — nothing to check", InconclusiveNoActivity
+		case out.Events == out.Chains && out.ChainsNoPredecessor == 0 && unresolved == 0 && out.UnwalkableEvents == 0:
+			// Every chain is a single INSERT: true append-only. Zero
+			// assertions is the only possible outcome for this shape, in
+			// every window, forever — a fact about the table, not a gap in
+			// the run.
+			//
+			// The ChainsNoPredecessor == 0 condition is what keeps this
+			// honest, and the first draft lacked it: a single mid-history
+			// UPDATE or DELETE also makes events == chains, but that row HAS
+			// prior history the window cannot see — widen the lookback and
+			// it becomes assertable. Calling that "does not apply" would
+			// over-claim benignity; it belongs below, with the hint.
+			return StatusInconclusive, fmt.Sprintf("%d change(s), each a row's only change and all inserts (append-only shape) — consecutive-change cross-checks do not apply here", out.Events), InconclusiveNothingToAssert
+		default:
+			detail := fmt.Sprintf("walked %s: nothing was proven — the window held changes that could not be cross-checked", scope)
+			if len(notes) > 0 {
+				detail += "; " + strings.Join(notes, "; ")
+			}
+			if out.ChainsNoPredecessor > 0 {
+				detail += "; widening --lookback/--since can give mid-history chains their predecessors"
+			}
+			return StatusInconclusive, detail, InconclusiveUnproven
 		}
-		return StatusInconclusive, detail
 	}
 	detail := fmt.Sprintf("checked %s", scope)
 	if len(notes) > 0 {
 		detail += "; " + strings.Join(notes, "; ")
 	}
-	return StatusMatch, detail
+	return StatusMatch, detail, ""
 }
 
 // emptyImagePairMarker is compareImages' out-of-band signal that BOTH images

--- a/internal/verify/recover_inputs_integration_test.go
+++ b/internal/verify/recover_inputs_integration_test.go
@@ -195,3 +195,55 @@ func TestVerifyRecoverInputs_WindowPredatingIndexHistorySaysSo(t *testing.T) {
 		t.Errorf("detail should carry the actionable remedy, got: %s", res.Detail)
 	}
 }
+
+// TestVerifyRecoverInputs_KindReachesTheTableResult pins the seam between the
+// chain walk and the report (#1416): checkRecoverChains classifies the
+// inconclusive, and VerifyRecoverInputs must COPY that classification onto the
+// TableResult it returns. The walk and the report each had their own tests and
+// both stayed green with the copy deleted — the summary then counted every
+// quiet table as attention-worthy, which is the exact misreading the kind
+// exists to end. Driven through the real fetch path against a real index.
+func TestVerifyRecoverInputs_KindReachesTheTableResult(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+		(snapshot_id, snapshot_time, schema_name, table_name, column_name,
+		 ordinal_position, column_key, data_type, column_type, is_nullable, is_generated)
+		VALUES (1, UTC_TIMESTAMP(), ?, 'orders', 'id', 1, 'PRI', 'int', 'int', 'NO', 0)`, dbName)
+
+	now := time.Now().UTC()
+	curHour := now.Truncate(time.Hour)
+	h1, h2 := curHour.Add(-time.Hour), curHour
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h1, h2})
+
+	resolver, err := metadata.NewResolver(db, 1)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	res, err := VerifyRecoverInputs(context.Background(), RecoverInputsConfig{
+		IndexDB:     db,
+		Resolver:    resolver,
+		IndexDBName: dbName,
+		ArchiveFetcher: func(context.Context, query.Options, string) ([]query.ResultRow, error) {
+			return nil, nil
+		},
+		// A window the live partitions fully cover, over a table with no
+		// events: the walk classifies it no-activity.
+		Since: h1,
+		Until: now,
+	}, dbName, "orders")
+	if err != nil {
+		t.Fatalf("VerifyRecoverInputs: %v", err)
+	}
+	if res.Status != StatusInconclusive {
+		t.Fatalf("an empty covered window is inconclusive, got %s (%s)", res.Status, res.Detail)
+	}
+	if res.InconclusiveKind != InconclusiveNoActivity {
+		t.Errorf("TableResult.InconclusiveKind = %q, want %q — the walk classified it and the "+
+			"copy onto the result was lost, so every summary downstream counts this quiet table "+
+			"as attention-worthy", res.InconclusiveKind, InconclusiveNoActivity)
+	}
+}

--- a/internal/verify/report.go
+++ b/internal/verify/report.go
@@ -111,6 +111,10 @@ type TableReport struct {
 	// nil-image/unresolved-TOAST/unknown-type finding. All are legitimately
 	// unverifiable rather than divergent.
 	ChainsInconclusive int `json:"chains_inconclusive,omitempty"`
+	// InconclusiveKind subdivides an inconclusive verdict (#1416): no-activity
+	// | nothing-to-assert | unproven. Empty on other statuses and on modes
+	// that do not classify.
+	InconclusiveKind string `json:"inconclusive_kind,omitempty"`
 }
 
 // Summary is the run's per-status counts. The console's VerifySummary mirrors
@@ -120,16 +124,32 @@ type Summary struct {
 	Match        int `json:"match"`
 	Mismatch     int `json:"mismatch"`
 	Inconclusive int `json:"inconclusive"`
-	Error        int `json:"error"`
-	Total        int `json:"total"`
+	// InconclusiveNothingToCheck is the benign slice of Inconclusive — tables
+	// with no activity or an append-only shape, where zero assertions is the
+	// expected and permanent outcome (#1416). Always <= Inconclusive; the
+	// difference is the slice that deserves attention. A subdivision, not a
+	// fifth bucket: Total still sums the four statuses.
+	InconclusiveNothingToCheck int `json:"inconclusive_nothing_to_check"`
+	Error                      int `json:"error"`
+	Total                      int `json:"total"`
 }
 
 // Count files one table's status under its summary bucket and bumps Total.
 // The status is normalized first, so an unrecognized value lands in Error —
 // every summary, CLI or console, applies the default-to-failure rule from the
 // one place that owns it (NormalizeStatus) instead of re-deciding it locally.
-func (s *Summary) Count(status Status) {
+func (s *Summary) Count(status Status) { s.CountWithKind(status, "") }
+
+// CountWithKind is Count carrying the inconclusive subdivision (#1416). The
+// kind only matters for StatusInconclusive and only when it is one of the two
+// benign values; anything else — including empty, the unclassified case —
+// counts as attention-worthy, because defaulting the unknown to benign is the
+// direction a verify tool must never round.
+func (s *Summary) CountWithKind(status Status, kind string) {
 	normalized, _ := NormalizeStatus(status, "")
+	if normalized == StatusInconclusive && InconclusiveKindBenign(kind) {
+		s.InconclusiveNothingToCheck++
+	}
 	switch normalized {
 	case StatusMatch:
 		s.Match++
@@ -197,7 +217,7 @@ func NewReport(mode string, results []TableResult) *Report {
 	rep := &Report{Mode: mode, Tables: make([]TableReport, 0, len(sorted))}
 	for _, r := range sorted {
 		status, reason := NormalizeStatus(r.Status, r.Detail)
-		rep.Summary.Count(status)
+		rep.Summary.CountWithKind(status, r.InconclusiveKind)
 		rep.Tables = append(rep.Tables, TableReport{
 			Schema:            r.Schema,
 			Table:             r.Table,
@@ -212,6 +232,7 @@ func NewReport(mode string, results []TableResult) *Report {
 			EventsChecked:      r.EventsChecked,
 			ChainsChecked:      r.ChainsChecked,
 			ChainsInconclusive: r.ChainsInconclusive,
+			InconclusiveKind:   r.InconclusiveKind,
 		})
 	}
 	rep.Verdict = verdictOf(rep.Summary)
@@ -276,6 +297,14 @@ func (r *Report) ExitError() error {
 	case VerdictError:
 		return fmt.Errorf("%d table(s) could not be verified due to errors", r.Summary.Error)
 	case VerdictUnproven:
+		// The exit stays non-zero even when every inconclusive is benign: the
+		// operator asked this run to prove recover inputs and it proved none,
+		// which a CI gate must not read as success. The message carries the
+		// split so a human reading the failure knows whether anything was
+		// actually wrong.
+		if n := r.Summary.InconclusiveNothingToCheck; n > 0 {
+			return fmt.Errorf("no tables were verified (%d inconclusive, of which %d had nothing to check — quiet or append-only); nothing proven", r.Summary.Inconclusive, n)
+		}
 		return fmt.Errorf("no tables were verified (%d inconclusive); nothing proven", r.Summary.Inconclusive)
 	}
 	return nil

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -59,6 +59,39 @@ type TableResult struct {
 	EventsChecked      int
 	ChainsChecked      int
 	ChainsInconclusive int
+	// InconclusiveKind subdivides an inconclusive verdict — see the constants
+	// beside it. Empty for every other status and for the content modes,
+	// whose inconclusives are not yet classified.
+	InconclusiveKind string
+}
+
+// InconclusiveKind values (#1416). One bucket was carrying three meanings:
+// "nothing happened", "nothing could ever be asserted here", and "there was
+// assertable content and it was not asserted". Only the third deserves an
+// operator's attention, and a summary that adds all three into one number
+// cannot be read.
+const (
+	// InconclusiveNoActivity: zero events in the window. Expected on a quiet
+	// table; not a finding.
+	InconclusiveNoActivity = "no-activity"
+	// InconclusiveNothingToAssert: activity existed but the check does not
+	// apply to its shape (every event its row's only change — append-only).
+	// Permanent for such tables; not a finding.
+	InconclusiveNothingToAssert = "nothing-to-assert"
+	// InconclusiveUnproven: assertable content existed and was not asserted
+	// (truncated window, unresolved comparisons, drift rows). The one kind
+	// worth attention.
+	InconclusiveUnproven = "unproven"
+)
+
+// InconclusiveKindBenign reports whether kind is one of the two
+// expected-and-permanent shapes — the ones a summary counts as "nothing to
+// check" rather than "not proven". An empty kind is NOT benign: it is an
+// unclassified inconclusive (the content modes, or an older producer), and
+// defaulting the unknown to benign is the direction a verify tool must never
+// round.
+func InconclusiveKindBenign(kind string) bool {
+	return kind == InconclusiveNoActivity || kind == InconclusiveNothingToAssert
 }
 
 // Config wires the three data sources verify needs.


### PR DESCRIPTION
verify: split the inconclusive bucket — a clean recover-inputs run read as 20 warnings (#1416)

`--check recover` renders one amber row per inconclusive table, and on a real
WordPress server 20 of 28 tables were inconclusive on a HEALTHY run. The bucket
was carrying three meanings and rendering them identically:

  - no activity in the window (quiet table) — expected, not a finding
  - nothing to assert, ever (append-only shape: every chain a single INSERT) —
    expected and PERMANENT for that table
  - assertable content existed and was not asserted (truncated window,
    unresolved comparisons, drift rows, mid-history chains) — the one kind
    worth an operator's attention

TableResult/TableReport gain InconclusiveKind (no-activity | nothing-to-assert
| unproven); Summary gains InconclusiveNothingToCheck, the benign slice, with
the attention-worthy number as the REMAINDER so an unclassified inconclusive
(content modes, older producers) lands on the attention side — defaulting the
unknown to benign is the direction a verify tool must never round. The console
mirrors both fields; the struct-conversion drift guard fired on the build
exactly as its comment promises, which is how the mirror could not be
forgotten.

Wording is rewritten from the operator's question. "nothing was proven — no
before-image comparison in this window was conclusive" described the
algorithm's state; an append-only table now reads "each a row's only change and
all inserts — consecutive-change cross-checks do not apply here", and the
unproven case carries the actionable hint (widen --lookback to give
mid-history chains their predecessors). The console renders benign
inconclusives neutral — never amber — and a finished run gets a verdict
sentence in words, so the answer no longer has to be derived from 28 rows.

Two classification rules were wrong in the first draft and the EXISTING tests
caught both: a single mid-history UPDATE is not append-only (the row has prior
history the window cannot see — widening the lookback makes it assertable, so
"does not apply" would over-claim benignity), and a drift-rows-only table is
not "no changes in the window" (Events counts what was WALKED, so it is zero
there too).

Deliberately unchanged: the exit contract. An all-inconclusive run still exits
non-zero however benign the reasons — the operator asked this run to prove
recover inputs and it proved none, which a CI gate must not read as success.
The exit message now carries the split so the human reading the failure knows
nothing was wrong. And no benign table renders as a match: a table with
nothing to assert must never read as "its before-images were checked", because
nobody looked.

Mutation-tested 6/6 caught, one of them only after adding an integration test
for the seam between the walk and the report — the walk and the report each
had their own tests and both stayed green with the copy between them deleted.

Closes #1416
