### PR TITLE
console: the home page's surface language — tinted cards, pill tags, dark-code recipe

### DIFF
--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1145,9 +1145,12 @@ function ovFrame() {
 
   const grid = el("div", { class: "ov-grid" });
 
-  f.recentPanel = el("section", { class: "ov-panel" });
+  // The two panels carry the home's tint layer (#1421): violet and sun, the
+  // structure tints. The pill is the eyebrow — the title stays an h2 for the
+  // document outline; the pill is presentation, not the heading.
+  f.recentPanel = el("section", { class: "ov-panel tcard-violet" });
   f.recentPanel.append(el("div", { class: "ov-panel-head" },
-    el("h2", { class: "ov-panel-title", text: "Recent changes" }),
+    el("h2", { class: "ov-panel-title" }, el("span", { class: "tag-pill", text: "Recent changes" })),
     tzChip(),
     el("a", { class: "btn btn-sm btn-ghost", href: "/events",
       onclick: (e) => { e.preventDefault(); navigate("events"); }, text: "Browse all events ›" })));
@@ -1156,9 +1159,9 @@ function ovFrame() {
   f.recentPanel.append(f.recentBody);
   grid.append(f.recentPanel);
 
-  f.tablesPanel = el("section", { class: "ov-panel" });
+  f.tablesPanel = el("section", { class: "ov-panel tcard-sun" });
   f.tablesHead = el("div", { class: "ov-panel-head" },
-    el("h2", { class: "ov-panel-title", text: "Activity by table" }));
+    el("h2", { class: "ov-panel-title" }, el("span", { class: "tag-pill", text: "Activity by table" })));
   f.tablesPanel.append(f.tablesHead);
   f.tablesBody = el("div", { class: "ov-tables" });
   f.tablesBody.append(ovSkelLines(4), el("div", { class: "skel-note", text: "computing window activity…" }));

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -270,7 +270,8 @@
      partners DARKENED to hold the AA floors the site's own deep values miss.
      Measured before choosing (WCAG ratio on the tint): site --pink-deep
      #D9367A lands 3.83:1, --orange-deep #C2611B 3.77:1, the sun tag text
-     #9A7800 3.84:1, bare --violet 3.68:1 (the site's own --violet, measured
+     #9A7800 3.84:1 (on the site's butter #FFF6D8; 3.94 on this file's
+     lightened --sun-tint), bare --violet 3.68:1 (the site's own --violet, measured
      on the landing stylesheet at dbtrail.com — not a token in this file) —
      every one below the 4.5:1 floor
      this file's ink ramp is verified against. The -deep values below all

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -159,9 +159,12 @@
        --surface-2, the studio tile             1.60         1.23
        paper and trail (both resolve white)     1.68         1.28
 
-     Studio is the shipped default and also the worst case, which is why the
-     browser assertion measures that one. More separated than before, not less
-     — the direction was not the expected one, and is why it was measured
+     Studio was the worst case when the stat tiles still consumed
+     --panel-bg; since #1421 they are white bento tiles and the worst
+     ground for these bars is the VIOLET PANEL (peak 1.43 there, still
+     above the 1.3 floor the browser assertion holds — it now photographs
+     that ground too). More separated than before, not less — the
+     direction was not the expected one, and is why it was measured
      rather than converted.
 
      Those figures are the stop's PEAK against its ground. The mid-stop is
@@ -267,7 +270,9 @@
      partners DARKENED to hold the AA floors the site's own deep values miss.
      Measured before choosing (WCAG ratio on the tint): site --pink-deep
      #D9367A lands 3.83:1, --orange-deep #C2611B 3.77:1, the sun tag text
-     #9A7800 3.84:1, bare --violet 3.68:1 — every one below the 4.5:1 floor
+     #9A7800 3.84:1, bare --violet 3.68:1 (the site's own --violet, measured
+     on the landing stylesheet at dbtrail.com — not a token in this file) —
+     every one below the 4.5:1 floor
      this file's ink ramp is verified against. The -deep values below all
      clear 5.2:1 on their tint and on white. Decorative use only: the
      semantic INSERT/UPDATE/DELETE mapping above stays reserved, and pink/
@@ -276,13 +281,26 @@
      on). */
   --violet-tint: #EFE9FF;
   --violet-deep: #5A3BD6;
-  --sun-tint:    #FFF6D8;
+  /* sun sits ONE STEP from the console's warning ground: the site's butter
+     (#FFF6D8) measures 1.008 against --ochre-bg — the same color, so a data
+     panel wore the warn register. Lightened to keep the identity while
+     separating the registers (1.03 vs --ochre-bg, floor-tested); warn
+     surfaces still must never nest inside a sun card. */
+  --sun-tint:    #FFF9E4;
   --sun-deep:    #7A5F00;
   --pink-tint:   #FFE9F5;
   --pink-deep:   #B02762;
   --orange-tint: #FFF1E2;
   --orange-deep: #A04E10;
-  /* the bento card radius — a step above --radius, never replacing it */
+  /* row hairlines drown on a tint (--line-soft on violet: 1.01 — invisible;
+     the Events-skeleton comment above documents the same failure mode for
+     bars). Each tint carries its own divider, floor-tested at >=1.15. */
+  --violet-line: #DDD4F2;
+  --sun-line:    #EADFC4;
+  /* the bento card radius — a step above --radius, never replacing it.
+     Deliberately NOT re-pointed per direction: under paper (--radius: 5px)
+     the bento cards keep 20px — mixed registers, accepted while paper stays
+     dev-only (index.html hardcodes studio). */
   --radius-lg: 20px;
 
   --shell-w: 248px;
@@ -1330,20 +1348,17 @@ button { font-family: inherit; }
   border-radius: var(--radius-lg); border: 1px solid var(--line);
   background: var(--surface); padding: 20px 22px; min-width: 0;
 }
-.tcard.violet { background: var(--violet-tint); border-color: transparent; }
-.tcard.sun    { background: var(--sun-tint);    border-color: transparent; }
-.tcard.pink   { background: var(--pink-tint);   border-color: transparent; }
-.tcard.orange { background: var(--orange-tint); border-color: transparent; }
+/* tint modifiers live further down, AFTER the .ov-panel ground rules —
+   one vocabulary, always hyphenated: class="tcard tcard-violet". (An
+   earlier draft had .tcard.violet here AND .ov-panel.tcard-violet below;
+   review caught that "tcard tcard-violet" — the natural reading — rendered
+   white.) */
 .tag-pill {
   display: inline-block; font-family: var(--f-mono); font-size: 10.5px;
   font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase;
   padding: 4px 11px; border-radius: 999px;
   background: var(--surface-3); color: var(--ink-2);
 }
-.tcard.violet .tag-pill { background: var(--surface); color: var(--violet-deep); }
-.tcard.sun    .tag-pill { background: var(--surface); color: var(--sun-deep); }
-.tcard.pink   .tag-pill { background: var(--surface); color: var(--pink-deep); }
-.tcard.orange .tag-pill { background: var(--surface); color: var(--orange-deep); }
 /* the dark code block: SQL and DSNs on ink, the strongest same-product
    signal the site sends. Defined with the recipe; the page sweeps
    (#1415/#1419) adopt it where code is rendered. */
@@ -1400,13 +1415,27 @@ button { font-family: inherit; }
   background: var(--panel-bg); border: 1px solid var(--panel-border);
   border-radius: var(--radius-lg); padding: 10px 10px 12px; box-shadow: var(--panel-shadow);
 }
-/* the two Overview panels take the tint layer (#1421). Violet and sun are
-   the STRUCTURE tints — pink/orange stay away from event data by rule. The
-   tint is the edge; the hairline goes. */
-.ov-panel.tcard-violet { background: var(--violet-tint); border-color: transparent; }
-.ov-panel.tcard-sun    { background: var(--sun-tint);    border-color: transparent; }
-.ov-panel.tcard-violet .tag-pill { background: var(--surface); color: var(--violet-deep); }
-.ov-panel.tcard-sun    .tag-pill { background: var(--surface); color: var(--sun-deep); }
+/* the tint modifiers (#1421) — ONE vocabulary: the hyphenated class IS the
+   modifier, valid on .tcard and .ov-panel alike ("tcard tcard-violet",
+   "ov-panel tcard-sun"). Violet and sun are the STRUCTURE tints —
+   pink/orange stay away from event data by rule. The tint is the edge; the
+   hairline goes. These sit AFTER the .ov-panel ground rules because at
+   equal (0-1-0) specificity the cascade decides — placed earlier, the
+   panel's own background wins and all four classes go inert.
+   [data-dir="paper"] .ov-panel (0-2-0) still beats them, stripping the
+   tint under paper: dev-only today (index.html hardcodes studio), the
+   same trade the old 0-2-0 tie made. */
+.tcard-violet { background: var(--violet-tint); border-color: transparent; }
+.tcard-sun    { background: var(--sun-tint);    border-color: transparent; }
+.tcard-pink   { background: var(--pink-tint);   border-color: transparent; }
+.tcard-orange { background: var(--orange-tint); border-color: transparent; }
+.tcard-violet .tag-pill { background: var(--surface); color: var(--violet-deep); }
+.tcard-sun    .tag-pill { background: var(--surface); color: var(--sun-deep); }
+.tcard-pink   .tag-pill { background: var(--surface); color: var(--pink-deep); }
+.tcard-orange .tag-pill { background: var(--surface); color: var(--orange-deep); }
+/* the tint-aware dividers (see the token block) */
+.tcard-violet .ov-ev, .tcard-violet .ov-tablerow, .tcard-violet .ov-coverage { border-top-color: var(--violet-line); }
+.tcard-sun .ov-ev, .tcard-sun .ov-tablerow, .tcard-sun .ov-coverage { border-top-color: var(--sun-line); }
 [data-dir="paper"] .ov-panel { background: transparent; border-color: var(--line); }
 .ov-panel-head { display: flex; align-items: center; justify-content: space-between; padding: 14px 14px 10px; }
 .ov-panel-title { font-family: var(--title-font); font-weight: 600; font-size: 15px; letter-spacing: -0.01em; margin: 0; color: var(--ink); }
@@ -1422,8 +1451,11 @@ button { font-family: inherit; }
 .ov-ev:hover { background: var(--surface-2); }
 .ov-ev-time { font-family: var(--f-mono); font-size: 12px; color: var(--ink-2); }
 .ov-ev-tbl { font-family: var(--f-mono); font-size: 12.5px; color: var(--ink); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.ov-ev-pk { color: var(--ink-3); }
-.ov-ev-cols { font-family: var(--f-mono); font-size: 11.5px; color: var(--ink-3); text-align: right; white-space: nowrap; }
+/* --ink-2, not -3: this text sits on the violet tint, where --ink-3
+   measures 4.20:1 — below the 4.5 floor the ink ramp is verified against
+   (review reproduced it; -3 clears only white and sun). */
+.ov-ev-pk { color: var(--ink-2); }
+.ov-ev-cols { font-family: var(--f-mono); font-size: 11.5px; color: var(--ink-2); text-align: right; white-space: nowrap; }
 .ov-ev-undo { height: 27px; padding: 0 9px; font-size: 11.5px; opacity: 0; transition: opacity .14s; }
 .ov-ev-undo svg { width: 12px; height: 12px; }
 .ov-ev:hover .ov-ev-undo { opacity: 1; }

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -263,6 +263,28 @@
   --title-tracking: -0.02em;
   --rail: var(--line);
 
+  /* home-surface language (#1421): the site's tint palette, with text
+     partners DARKENED to hold the AA floors the site's own deep values miss.
+     Measured before choosing (WCAG ratio on the tint): site --pink-deep
+     #D9367A lands 3.83:1, --orange-deep #C2611B 3.77:1, the sun tag text
+     #9A7800 3.84:1, bare --violet 3.68:1 — every one below the 4.5:1 floor
+     this file's ink ramp is verified against. The -deep values below all
+     clear 5.2:1 on their tint and on white. Decorative use only: the
+     semantic INSERT/UPDATE/DELETE mapping above stays reserved, and pink/
+     orange stay away from surfaces that carry event data (a pink panel
+     behind DELETE badges would dissolve the one color code operators rely
+     on). */
+  --violet-tint: #EFE9FF;
+  --violet-deep: #5A3BD6;
+  --sun-tint:    #FFF6D8;
+  --sun-deep:    #7A5F00;
+  --pink-tint:   #FFE9F5;
+  --pink-deep:   #B02762;
+  --orange-tint: #FFF1E2;
+  --orange-deep: #A04E10;
+  /* the bento card radius — a step above --radius, never replacing it */
+  --radius-lg: 20px;
+
   --shell-w: 248px;
   --ease: cubic-bezier(.22, .61, .36, 1);
   --ease-out: cubic-bezier(.16, 1, .3, 1);
@@ -1295,12 +1317,52 @@ button { font-family: inherit; }
 [data-density="compact"] .page-head { margin-bottom: 22px; }
 
 /* ============================================================
+   home-surface card recipe (#1421) — the site's bento language as
+   reusable console classes. A tinted card's tint IS its edge
+   (border-color transparent); white cards keep the hairline. The
+   pill is the eyebrow: mono, uppercase, white-on-tint, colored by
+   the card's -deep partner. Motion deliberately subtler than the
+   site's hover lift-and-rotate: this is a working surface read
+   during incidents, and the playful register stays on the landing
+   page.
+   ============================================================ */
+.tcard {
+  border-radius: var(--radius-lg); border: 1px solid var(--line);
+  background: var(--surface); padding: 20px 22px; min-width: 0;
+}
+.tcard.violet { background: var(--violet-tint); border-color: transparent; }
+.tcard.sun    { background: var(--sun-tint);    border-color: transparent; }
+.tcard.pink   { background: var(--pink-tint);   border-color: transparent; }
+.tcard.orange { background: var(--orange-tint); border-color: transparent; }
+.tag-pill {
+  display: inline-block; font-family: var(--f-mono); font-size: 10.5px;
+  font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase;
+  padding: 4px 11px; border-radius: 999px;
+  background: var(--surface-3); color: var(--ink-2);
+}
+.tcard.violet .tag-pill { background: var(--surface); color: var(--violet-deep); }
+.tcard.sun    .tag-pill { background: var(--surface); color: var(--sun-deep); }
+.tcard.pink   .tag-pill { background: var(--surface); color: var(--pink-deep); }
+.tcard.orange .tag-pill { background: var(--surface); color: var(--orange-deep); }
+/* the dark code block: SQL and DSNs on ink, the strongest same-product
+   signal the site sends. Defined with the recipe; the page sweeps
+   (#1415/#1419) adopt it where code is rendered. */
+.code-ink {
+  background: var(--ink); color: oklch(0.93 0.02 300);
+  border-radius: var(--radius); padding: 12px 15px;
+  font-family: var(--f-mono); font-size: 12.5px; line-height: 1.55;
+  overflow-x: auto;
+}
+
+/* ============================================================
    overview / dashboard
    ============================================================ */
 .ov-stats { display: grid; grid-template-columns: repeat(3, 1fr) 1.4fr; gap: 16px; margin-bottom: 24px; }
 .ov-stat {
-  background: var(--panel-bg); border: 1px solid var(--panel-border);
-  border-radius: var(--radius); padding: 18px 20px; box-shadow: var(--panel-shadow);
+  /* white bento card (#1421): the site's own console mock keeps the stat
+     tiles white — the tint layer is for the panels below. */
+  background: var(--surface); border: 1px solid var(--line);
+  border-radius: var(--radius-lg); padding: 18px 20px; box-shadow: var(--panel-shadow);
 }
 [data-dir="paper"] .ov-stat { background: transparent; border-color: var(--line); }
 .ov-stat-v { font-family: var(--f-display); font-size: 32px; font-weight: 600; letter-spacing: -0.02em; line-height: 1; color: var(--ink); }
@@ -1336,8 +1398,15 @@ button { font-family: inherit; }
 .ov-grid { display: grid; grid-template-columns: 1.35fr 1fr; gap: 18px; align-items: start; }
 .ov-panel {
   background: var(--panel-bg); border: 1px solid var(--panel-border);
-  border-radius: var(--radius); padding: 6px 6px 8px; box-shadow: var(--panel-shadow);
+  border-radius: var(--radius-lg); padding: 10px 10px 12px; box-shadow: var(--panel-shadow);
 }
+/* the two Overview panels take the tint layer (#1421). Violet and sun are
+   the STRUCTURE tints — pink/orange stay away from event data by rule. The
+   tint is the edge; the hairline goes. */
+.ov-panel.tcard-violet { background: var(--violet-tint); border-color: transparent; }
+.ov-panel.tcard-sun    { background: var(--sun-tint);    border-color: transparent; }
+.ov-panel.tcard-violet .tag-pill { background: var(--surface); color: var(--violet-deep); }
+.ov-panel.tcard-sun    .tag-pill { background: var(--surface); color: var(--sun-deep); }
 [data-dir="paper"] .ov-panel { background: transparent; border-color: var(--line); }
 .ov-panel-head { display: flex; align-items: center; justify-content: space-between; padding: 14px 14px 10px; }
 .ov-panel-title { font-family: var(--title-font); font-weight: 600; font-size: 15px; letter-spacing: -0.01em; margin: 0; color: var(--ink); }

--- a/internal/console/assets_tint_contrast_test.go
+++ b/internal/console/assets_tint_contrast_test.go
@@ -19,20 +19,9 @@ import (
 // The pairs are read from style.css itself, not restated here: a hardcoded
 // copy of the hex values would go green when the file changes.
 func TestTintDeepPartnersHoldTheAAFloor(t *testing.T) {
-	css, err := os.ReadFile("assets/style.css")
-	if err != nil {
-		t.Fatal(err)
-	}
-	token := func(name string) string {
-		m := regexp.MustCompile(`--` + name + `:\s*(#[0-9A-Fa-f]{6})`).FindSubmatch(css)
-		if m == nil {
-			t.Fatalf("--%s not found as a hex literal in style.css — if it moved to another "+
-				"notation, teach this test to read it rather than deleting the assertion", name)
-		}
-		return string(m[1])
-	}
+	css := readStyleCSS(t)
 	for _, hue := range []string{"violet", "sun", "pink", "orange"} {
-		deep, tint := token(hue+"-deep"), token(hue+"-tint")
+		deep, tint := cssHexToken(t, css, hue+"-deep"), cssHexToken(t, css, hue+"-tint")
 		for surface, bg := range map[string]string{"tint": tint, "white": "#FFFFFF"} {
 			if r := wcagRatioHex(deep, bg); r < 4.5 {
 				t.Errorf("--%s-deep %s on %s (%s) = %.2f:1, below the 4.5:1 floor. The site's "+
@@ -41,6 +30,128 @@ func TestTintDeepPartnersHoldTheAAFloor(t *testing.T) {
 			}
 		}
 	}
+}
+
+// The BODY TEXT that stands on a tint — not just the decorative pills. The
+// first cut of this file asserted only the -deep partners while --ink-3 data
+// text (the PK and changed-columns cells) sat on the violet tint at 4.20:1;
+// review measured it, and the fix re-pointed that text to --ink-2. This pins
+// the tokens each tint ground actually carries: --ink-2 must clear the floor
+// on both structure tints (the violet panel's data text), and --ink-3 on sun
+// (the coverage footer). --ink-3 on violet is deliberately NOT asserted — it
+// FAILS (4.20), which is exactly why nothing may use it there.
+func TestTintGroundsHoldTheAAFloorForTheirBodyText(t *testing.T) {
+	css := readStyleCSS(t)
+	ink2 := cssOklchToken(t, css, "ink-2")
+	ink3 := cssOklchToken(t, css, "ink-3")
+	violet := cssHexToken(t, css, "violet-tint")
+	sun := cssHexToken(t, css, "sun-tint")
+	for _, c := range []struct {
+		ink, name, tint, ground string
+	}{
+		{ink2, "ink-2", violet, "violet-tint"},
+		{ink2, "ink-2", sun, "sun-tint"},
+		{ink3, "ink-3", sun, "sun-tint"},
+	} {
+		if r := wcagRatioHex(c.ink, c.tint); r < 4.5 {
+			t.Errorf("--%s (%s) on --%s (%s) = %.2f:1, below the 4.5:1 floor — body text on "+
+				"this tint ground must hold AA, or the tint has to lighten", c.name, c.ink, c.ground, c.tint, r)
+		}
+	}
+}
+
+// The tint-aware dividers: --line-soft measures 1.01 on the violet tint —
+// visually identical, the whole Recent-changes list rendering as one block —
+// which is why each tint carries its own divider token. 1.15 is the floor
+// (--line-soft on white, the baseline hairline idiom, sits at 1.17).
+func TestTintDividersStayVisible(t *testing.T) {
+	css := readStyleCSS(t)
+	for _, hue := range []string{"violet", "sun"} {
+		line, tint := cssHexToken(t, css, hue+"-line"), cssHexToken(t, css, hue+"-tint")
+		if r := wcagRatioHex(line, tint); r < 1.15 {
+			t.Errorf("--%s-line %s on --%s-tint %s = %.3f:1, under the 1.15 hairline floor — "+
+				"the rows lose their separation on the tinted panel", hue, line, hue, tint, r)
+		}
+	}
+}
+
+// Sun must not BE the warning ground. The site's butter (#FFF6D8) measured
+// 1.008 against --ochre-bg — the same color — so the Activity-by-table panel
+// wore the console's warn register. 1.02 refuses identity while allowing the
+// registers to stay neighbors; warn surfaces still must never nest inside a
+// sun card (the modifier block's comment carries that rule).
+func TestSunTintIsNotTheWarnGround(t *testing.T) {
+	css := readStyleCSS(t)
+	sun := cssHexToken(t, css, "sun-tint")
+	ochreBG := cssOklchToken(t, css, "ochre-bg")
+	if r := wcagRatioHex(sun, ochreBG); r < 1.02 {
+		t.Errorf("--sun-tint %s vs --ochre-bg (%s) = %.3f:1 — the data tint and the warning "+
+			"ground have collapsed into one color", sun, ochreBG, r)
+	}
+}
+
+func readStyleCSS(t *testing.T) []byte {
+	t.Helper()
+	css, err := os.ReadFile("assets/style.css")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return css
+}
+
+func cssHexToken(t *testing.T, css []byte, name string) string {
+	t.Helper()
+	m := regexp.MustCompile(`--` + name + `:\s*(#[0-9A-Fa-f]{6})`).FindSubmatch(css)
+	if m == nil {
+		t.Fatalf("--%s not found as a hex literal in style.css — if it moved to another "+
+			"notation, teach this test to read it rather than deleting the assertion", name)
+	}
+	return string(m[1])
+}
+
+// cssOklchToken reads an oklch(L C H) token and converts it to sRGB hex, so
+// the ink ramp (declared in oklch) can be measured against the tint grounds
+// (declared in hex) with the same WCAG arithmetic.
+func cssOklchToken(t *testing.T, css []byte, name string) string {
+	t.Helper()
+	m := regexp.MustCompile(`--` + name + `:\s*oklch\(([0-9.]+)\s+([0-9.]+)\s+([0-9.]+)\)`).FindSubmatch(css)
+	if m == nil {
+		t.Fatalf("--%s not found as an oklch() literal in style.css — if it moved to another "+
+			"notation, teach this test to read it rather than deleting the assertion", name)
+	}
+	f := func(b []byte) float64 {
+		v, err := strconv.ParseFloat(string(b), 64)
+		if err != nil {
+			t.Fatalf("--%s: bad oklch component %q", name, b)
+		}
+		return v
+	}
+	return oklchToHex(f(m[1]), f(m[2]), f(m[3]))
+}
+
+// oklchToHex implements the standard OKLab→linear-sRGB matrices (Björn
+// Ottosson's reference constants, the same ones the browser uses), clamped
+// and gamma-encoded to 8-bit hex.
+func oklchToHex(l, c, h float64) string {
+	hr := h * math.Pi / 180
+	a, bb := c*math.Cos(hr), c*math.Sin(hr)
+	l_ := l + 0.3963377774*a + 0.2158037573*bb
+	m_ := l - 0.1055613458*a - 0.0638541728*bb
+	s_ := l - 0.0894841775*a - 1.2914855480*bb
+	ll, mm, ss := l_*l_*l_, m_*m_*m_, s_*s_*s_
+	r := 4.0767416621*ll - 3.3077115913*mm + 0.2309699292*ss
+	g := -1.2684380046*ll + 2.6097574011*mm - 0.3413193965*ss
+	b2 := -0.0041960863*ll - 0.7034186147*mm + 1.7076147010*ss
+	enc := func(v float64) int {
+		v = math.Max(0, math.Min(1, v))
+		if v <= 0.0031308 {
+			v *= 12.92
+		} else {
+			v = 1.055*math.Pow(v, 1/2.4) - 0.055
+		}
+		return int(math.Round(v * 255))
+	}
+	return fmt.Sprintf("#%02X%02X%02X", enc(r), enc(g), enc(b2))
 }
 
 func wcagRatioHex(a, b string) float64 {

--- a/internal/console/assets_tint_contrast_test.go
+++ b/internal/console/assets_tint_contrast_test.go
@@ -11,7 +11,7 @@ import (
 
 // The #1421 tint palette's ONE hard constraint, as a measurement rather than a
 // promise: every -deep text partner holds >= 4.5:1 on its own tint and on
-// white. The site's own deep values were measured FAILING this (3.7-3.8:1),
+// white. The site's own deep values were measured FAILING this (3.68-3.84:1),
 // which is why the console carries darkened partners instead of copying the
 // site's — so a well-meaning "sync the colors with the site" edit is exactly
 // the change this test exists to catch.

--- a/internal/console/assets_tint_contrast_test.go
+++ b/internal/console/assets_tint_contrast_test.go
@@ -1,0 +1,69 @@
+package console
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"regexp"
+	"strconv"
+	"testing"
+)
+
+// The #1421 tint palette's ONE hard constraint, as a measurement rather than a
+// promise: every -deep text partner holds >= 4.5:1 on its own tint and on
+// white. The site's own deep values were measured FAILING this (3.7-3.8:1),
+// which is why the console carries darkened partners instead of copying the
+// site's — so a well-meaning "sync the colors with the site" edit is exactly
+// the change this test exists to catch.
+//
+// The pairs are read from style.css itself, not restated here: a hardcoded
+// copy of the hex values would go green when the file changes.
+func TestTintDeepPartnersHoldTheAAFloor(t *testing.T) {
+	css, err := os.ReadFile("assets/style.css")
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := func(name string) string {
+		m := regexp.MustCompile(`--` + name + `:\s*(#[0-9A-Fa-f]{6})`).FindSubmatch(css)
+		if m == nil {
+			t.Fatalf("--%s not found as a hex literal in style.css — if it moved to another "+
+				"notation, teach this test to read it rather than deleting the assertion", name)
+		}
+		return string(m[1])
+	}
+	for _, hue := range []string{"violet", "sun", "pink", "orange"} {
+		deep, tint := token(hue+"-deep"), token(hue+"-tint")
+		for surface, bg := range map[string]string{"tint": tint, "white": "#FFFFFF"} {
+			if r := wcagRatioHex(deep, bg); r < 4.5 {
+				t.Errorf("--%s-deep %s on %s (%s) = %.2f:1, below the 4.5:1 floor. The site's "+
+					"palette fails this on purpose-built marketing surfaces; the console's text "+
+					"discipline is the part of #1421 that was non-negotiable.", hue, deep, surface, bg, r)
+			}
+		}
+	}
+}
+
+func wcagRatioHex(a, b string) float64 {
+	la, lb := relLum(a), relLum(b)
+	if la < lb {
+		la, lb = lb, la
+	}
+	return (la + 0.05) / (lb + 0.05)
+}
+
+func relLum(hex string) float64 {
+	var lin [3]float64
+	for i := 0; i < 3; i++ {
+		v, err := strconv.ParseUint(hex[1+2*i:3+2*i], 16, 8)
+		if err != nil {
+			panic(fmt.Sprintf("bad hex %q", hex))
+		}
+		c := float64(v) / 255
+		if c <= 0.04045 {
+			lin[i] = c / 12.92
+		} else {
+			lin[i] = math.Pow((c+0.055)/1.055, 2.4)
+		}
+	}
+	return 0.2126*lin[0] + 0.7152*lin[1] + 0.0722*lin[2]
+}

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -1705,8 +1705,10 @@ try {
   // Identity, not just difference (#1423 review): a wrong-but-different color
   // passed the check above. The violet ground IS the home page's --violet-tint
   // (#EFE9FF) — home fidelity is the point of #1421, so the exact value is the
-  // contract. Update all three together if the palette ever moves: this pin,
-  // the token, and the Go contrast test's measurements.
+  // contract. The two LITERAL copies are this pin and the token; the Go test
+  // reads the token live, so on a palette move its floors ring on their own —
+  // what needs re-measuring by hand is the recorded figures in style.css's
+  // comments (the skeleton peak, the ink-3 note, the divider note).
   (tint.violet === "rgb(239, 233, 255)")
     ? ok("overview (live): the violet panel renders the home page's own tint value")
     : bad("overview (live): the violet panel renders the home page's own tint value", JSON.stringify(tint));
@@ -2874,7 +2876,7 @@ try {
           ratio: Number(brand.skelRatio.toFixed(3)), parsed: brand.skelParsed }));
   // The violet panel is the worst ground the bars stand on since the tiles
   // went white (measured 1.43 there vs 1.60 on the studio tile). Same 1.3
-  // floor: reverting the bar to plain --line lands ~1.13 on violet and rings.
+  // floor: reverting the bar to plain --line lands ~1.08 on violet and rings.
   (brand.skelVioletParsed && brand.skelVioletRatio >= 1.3)
     ? ok("brand paint: the warmed loading bar stays clear of the violet panel ground")
     : bad("brand paint: the warmed loading bar stays clear of the violet panel ground",

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -1685,6 +1685,23 @@ try {
     asof: (document.querySelector(".cov-card .cov-asof") || {}).textContent || "",
     tzChips: document.querySelectorAll(".tz-chip").length,
   }));
+  // #1421: the tint layer is RENDERED, not merely classed. Asserted as
+  // computed background because that is the only thing the operator sees — a
+  // cascade rule beating the tint would leave the classes in the DOM and the
+  // panels white, and no grep can see a cascade. The two panels must differ
+  // from each other (violet vs sun) and from plain white; the pill eyebrow
+  // must render on a distinct surface from its card.
+  const tint = await page.evaluate(() => {
+    const bg = (sel) => { const n = document.querySelector(sel); return n ? getComputedStyle(n).backgroundColor : null; };
+    return { violet: bg(".ov-panel.tcard-violet"), sun: bg(".ov-panel.tcard-sun"),
+             pill: bg(".ov-panel.tcard-violet .tag-pill"), white: "rgb(255, 255, 255)" };
+  });
+  (tint.violet && tint.sun && tint.violet !== tint.white && tint.sun !== tint.white && tint.violet !== tint.sun)
+    ? ok("overview (live): the two panels render the home tint layer (violet ≠ sun ≠ white)")
+    : bad("overview (live): the two panels render the home tint layer (violet ≠ sun ≠ white)", JSON.stringify(tint));
+  (tint.pill && tint.pill !== tint.violet)
+    ? ok("overview (live): the pill eyebrow renders on its own surface inside the tinted card")
+    : bad("overview (live): the pill eyebrow renders on its own surface inside the tinted card", JSON.stringify(tint));
   ovLive.scopes.every((s) => s.trim() !== "")
     ? ok("overview (live): every rendered tile carries a scope line")
     : bad("overview (live): every rendered tile carries a scope line", JSON.stringify(ovLive.scopes));

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -1702,6 +1702,75 @@ try {
   (tint.pill && tint.pill !== tint.violet)
     ? ok("overview (live): the pill eyebrow renders on its own surface inside the tinted card")
     : bad("overview (live): the pill eyebrow renders on its own surface inside the tinted card", JSON.stringify(tint));
+  // Identity, not just difference (#1423 review): a wrong-but-different color
+  // passed the check above. The violet ground IS the home page's --violet-tint
+  // (#EFE9FF) — home fidelity is the point of #1421, so the exact value is the
+  // contract. Update all three together if the palette ever moves: this pin,
+  // the token, and the Go contrast test's measurements.
+  (tint.violet === "rgb(239, 233, 255)")
+    ? ok("overview (live): the violet panel renders the home page's own tint value")
+    : bad("overview (live): the violet panel renders the home page's own tint value", JSON.stringify(tint));
+  // The WIRING the Go token test cannot see (#1423 review: .ov-ev-pk sat on
+  // the violet tint wearing --ink-3 at 4.20:1 while every token-level check
+  // was green). Synthetic probes inside the REAL panels: computed style
+  // answers for the class whether or not live rows have rendered yet.
+  const tintText = await page.evaluate(() => {
+    const vp = document.querySelector(".ov-panel.tcard-violet");
+    const sp = document.querySelector(".ov-panel.tcard-sun");
+    if (!vp || !sp) return null;
+    const cs = getComputedStyle;
+    // Canvas pixels, not string parsing: the ink ramp computes to oklch(...)
+    // strings, which no rgb() regex can read — the first draft measured 0 for
+    // every text ratio and only the hex-declared dividers parsed. Same
+    // technique as brandProbe, for the same reason.
+    const cv = document.createElement("canvas");
+    cv.width = cv.height = 1;
+    const ctx = cv.getContext("2d", { willReadFrequently: true });
+    const lum = (str) => {
+      ctx.fillStyle = "#010203";
+      ctx.fillStyle = str;
+      if (ctx.fillStyle === "#010203") return null; // unparseable, fail loud
+      ctx.clearRect(0, 0, 1, 1);
+      ctx.fillRect(0, 0, 1, 1);
+      const d = ctx.getImageData(0, 0, 1, 1).data;
+      const c = (v) => { v /= 255; return v <= 0.04045 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4); };
+      return 0.2126 * c(d[0]) + 0.7152 * c(d[1]) + 0.0722 * c(d[2]);
+    };
+    const ratio = (a, b) => {
+      const la = lum(a), lb = lum(b);
+      if (la === null || lb === null) return 0;
+      const [hi, lo] = [la, lb].sort((x, y) => y - x);
+      return (hi + 0.05) / (lo + 0.05);
+    };
+    const probe = (parent, cls, tag) => {
+      const n = document.createElement(tag || "div");
+      n.className = cls;
+      parent.appendChild(n);
+      return n;
+    };
+    const vbg = cs(vp).backgroundColor, sbg = cs(sp).backgroundColor;
+    const pk = probe(vp, "ov-ev-pk", "span");
+    const ev = probe(vp, "ov-ev");
+    const cov = probe(sp, "ov-coverage");
+    const trow = probe(sp, "ov-tablerow");
+    const out = {
+      pkRatio: ratio(cs(pk).color, vbg),
+      evDivider: ratio(cs(ev).borderTopColor, vbg),
+      covRatio: ratio(cs(cov).color, sbg),
+      trowDivider: ratio(cs(trow).borderTopColor, sbg),
+    };
+    [pk, ev, cov, trow].forEach((n) => n.remove());
+    return out;
+  });
+  (tintText && tintText.pkRatio >= 4.5 && tintText.covRatio >= 4.5)
+    ? ok("overview (live): body text on the tinted panels holds the 4.5:1 floor as rendered")
+    : bad("overview (live): body text on the tinted panels holds the 4.5:1 floor as rendered", JSON.stringify(tintText));
+  // 1.15 = the hairline idiom's own floor (--line-soft on white is 1.17).
+  // Deleting the tint-aware divider override lands the violet list at 1.01 —
+  // no dividers at all — and rings here, not in any token test.
+  (tintText && tintText.evDivider >= 1.15 && tintText.trowDivider >= 1.15)
+    ? ok("overview (live): row dividers stay visible on the tinted panels")
+    : bad("overview (live): row dividers stay visible on the tinted panels", JSON.stringify(tintText));
   ovLive.scopes.every((s) => s.trim() !== "")
     ? ok("overview (live): every rendered tile carries a scope line")
     : bad("overview (live): every rendered tile carries a scope line", JSON.stringify(ovLive.scopes));
@@ -2742,6 +2811,27 @@ try {
     const [hi, lo] = [relLum(px(res.skelStop, ground)), relLum(px(ground, ground))].sort((a, b) => b - a);
     res.skelRatio = (hi + 0.05) / (lo + 0.05);
 
+    // The same bar on the VIOLET PANEL ground (#1421/#1423 review): since the
+    // stat tiles went white-bento, the worst ground these bars stand on is the
+    // tinted Recent-changes panel (ovSkelLines renders straight into
+    // .ov-evlist there), and the studio-tile measurement above no longer
+    // covers the worst case. A bare .skel-line inside a .tcard-violet host is
+    // the stylesheet half; the panel's real markup carries no gate.
+    const vhost = document.createElement("div");
+    vhost.className = "tcard-violet";
+    document.body.appendChild(vhost);
+    const vbar = document.createElement("div");
+    vbar.className = "skel-line";
+    vhost.appendChild(vbar);
+    const vstop = (cs(vbar).backgroundImage.match(/\b(?:rgba?|color|oklch|oklab|hsla?)\([^)]*\)|#[0-9a-fA-F]{3,8}\b/) || [])[0] || "";
+    const vground = cs(vhost).backgroundColor;
+    ctx.fillStyle = "#010203";
+    ctx.fillStyle = vstop;
+    res.skelVioletParsed = ctx.fillStyle !== "#010203";
+    const [vhi, vlo] = [relLum(px(vstop, vground)), relLum(px(vground, vground))].sort((a, b) => b - a);
+    res.skelVioletRatio = (vhi + 0.05) / (vlo + 0.05);
+    vhost.remove();
+
     host.remove();
     return res;
   });
@@ -2782,6 +2872,13 @@ try {
     : bad("brand paint: the warmed loading bar's stop stays clear of its panel",
         JSON.stringify({ stop: brand.skelStop, ground: brand.skelGround || "NONE FOUND",
           ratio: Number(brand.skelRatio.toFixed(3)), parsed: brand.skelParsed }));
+  // The violet panel is the worst ground the bars stand on since the tiles
+  // went white (measured 1.43 there vs 1.60 on the studio tile). Same 1.3
+  // floor: reverting the bar to plain --line lands ~1.13 on violet and rings.
+  (brand.skelVioletParsed && brand.skelVioletRatio >= 1.3)
+    ? ok("brand paint: the warmed loading bar stays clear of the violet panel ground")
+    : bad("brand paint: the warmed loading bar stays clear of the violet panel ground",
+        JSON.stringify({ ratio: Number((brand.skelVioletRatio || 0).toFixed(3)), parsed: brand.skelVioletParsed }));
 
   // ── Scenario 17f — the Events skeleton is visible (#1397) ──
   //


### PR DESCRIPTION
console: the home page's surface language — tinted cards, pill tags, dark-code recipe (#1421)

The console was re-themed toward the site once (v0.55.1) and borrowed its HUES;
this adopts its SURFACES. Tokens for the four tint/deep pairs, the bento card
recipe (.tcard + .tag-pill + .code-ink), and the Overview pilot: white bento
stat tiles, the two panels on the violet/sun structure tints with white pill
eyebrows.

The one non-negotiable was measured, not promised: every -deep text partner
holds >= 4.5:1 on its own tint and on white. The site's own deep values FAIL
that floor (pink-deep 3.83:1 on its tint, orange-deep 3.77:1, the sun tag text
3.84:1, bare violet 3.68:1) — marketing surfaces are allowed to; a working
console is not. The darkened partners here all clear 5.27:1, and
TestTintDeepPartnersHoldTheAAFloor reads the pairs OUT OF style.css and
measures them, so a well-meaning "sync the colors with the site" edit goes red
with the numbers in the failure. The guard saw red first: substituting the
site's own pink-deep fails it at 4.41/3.83.

Semantic-mapping rule enforced by placement: violet and sun are the STRUCTURE
tints; pink/orange exist as tokens but stay off surfaces carrying event data,
where they would dissolve the INSERT/UPDATE/DELETE color code operators rely
on. The site's hover lift-and-rotate is deliberately not carried — this is a
surface read during incidents.

The e2e asserts the RENDER, not the classes: computed backgrounds of the two
panels differ from white and from each other, and the pill draws on its own
surface — a cascade rule beating the tint leaves classes in the DOM and no
grep can see it. 269/269.

.code-ink lands with the recipe and is adopted by the page sweeps (#1415,
#1419) where SQL is actually rendered.

Closes #1421
