### PR TITLE
console: /baselines and /verification redesigned — context strip, three regions, mode explanations, live progress, expandable history

### DIFF
--- a/consoleapp/verify.go
+++ b/consoleapp/verify.go
@@ -792,7 +792,9 @@ func toWireResult(res verify.TableResult, explainable bool) console.VerifyTableR
 		Schema: res.Schema, Table: res.Table, Status: string(status),
 		Reason: reason, Detail: reason,
 		InconclusiveKind: res.InconclusiveKind,
-		SourceRows:       res.SourceRows, ReconstructRows: res.ReconstructRows, Anchor: res.Anchor,
+		SourceRows:       res.SourceRows, ReconstructRows: res.ReconstructRows,
+		EventsChecked: res.EventsChecked, ChainsChecked: res.ChainsChecked,
+		Anchor:      res.Anchor,
 		Explainable: explainable,
 	}
 }

--- a/consoleapp/verify_test.go
+++ b/consoleapp/verify_test.go
@@ -53,6 +53,17 @@ func TestToWireResult(t *testing.T) {
 	// set, not by the zero struct: the walk and the report each had their own
 	// tests, and the engine-side copy stayed green with the field deleted —
 	// this is the console's instance of the same seam.
+	// The recover-inputs counters must survive the copy too (#1425 review:
+	// the console rendered a counts column these fields never reached).
+	counted := toWireResult(verify.TableResult{
+		Schema: "wp", Table: "orders", Status: verify.StatusMatch,
+		EventsChecked: 120, ChainsChecked: 7,
+	}, false)
+	if counted.EventsChecked != 120 || counted.ChainsChecked != 7 {
+		t.Errorf("counters = %d/%d, want 120/7 — the walk's counts must reach the wire",
+			counted.EventsChecked, counted.ChainsChecked)
+	}
+
 	quiet := toWireResult(verify.TableResult{
 		Schema: "wp", Table: "quiet", Status: verify.StatusInconclusive,
 		Detail: "no changes in the window", InconclusiveKind: verify.InconclusiveNoActivity,

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -3531,13 +3531,14 @@ async function renderBaselines() {
     v.append(pageHead("Baselines", el("p", { class: "page-sub" },
       "Full-table snapshots Time-travel and full restores are built from. ",
       el("b", { text: "Nothing is ever executed" }), " against your source by viewing this page.")));
-    const cards = el("div", { class: "cards" });
-    cards.append(baselineSummaryCard(baselines, servers.find((s) => s.id === (currentServer || defaultServerId))));
-    v.append(cards);
     if (serversErr) v.append(el("div", { class: "error-box", text: "Could not load servers: " + serversErr }));
-    const grid = el("div", { class: "ov-grid", style: "margin-top:18px" });
-    grid.append(baselinesPanel(baselines, servers, { serversErr: serversErr }));
-    v.append(grid);
+    // #1415: a context strip and a full-width list, not two half-width cards
+    // sharing only a left edge. The strip carries the facts that are ABOUT the
+    // collection (source, count, freshness, tables-per-snapshot when uniform)
+    // so the rows below can carry only what varies between snapshots.
+    const cur = servers.find((s) => s.id === (currentServer || defaultServerId));
+    v.append(baselineContextStrip(baselines, cur, { serversErr: serversErr }));
+    v.append(baselinesPanel(baselines, servers, { serversErr: serversErr }));
     viewEnter();
   } catch (err) {
     const v = VIEW(); clear(v); v.append(pageHead("Baselines", null)); renderError(v, err);
@@ -3556,12 +3557,16 @@ async function renderVerification() {
     // "Select a server to run verification" while a server IS selected.
     const serversErr = serversRes && serversRes.error;
     const v = VIEW(); clear(v);
+    // The old subtitle described one of the three modes and was wrong about a
+    // second (#1418): "prove a snapshot still reconstructs" — the
+    // recovery-inputs check uses no snapshot at all.
     v.append(pageHead("Verification", el("p", { class: "page-sub" },
-      "Prove a snapshot still reconstructs what it claims — the check that answers whether a restore would actually work.")));
+      "Prove your safety net works before you need it — three checks, from the index's own consistency to a full comparison against your live data.")));
     if (serversErr) v.append(el("div", { class: "error-box", text: "Could not load servers: " + serversErr }));
-    const grid = el("div", { class: "ov-grid", style: "margin-top:18px" });
-    grid.append(verifyPanel(servers, { hideTitle: true, serversErr: serversErr }));
-    v.append(grid);
+    // Three regions with visible separation (#1419): what you can run, what is
+    // running or just ran, what ran before. One undifferentiated card made
+    // "No verification run yet" sit directly above five past runs.
+    verifyRegions(servers, { serversErr: serversErr }).forEach((region) => v.append(region));
     viewEnter();
   } catch (err) {
     const v = VIEW(); clear(v); v.append(pageHead("Verification", null)); renderError(v, err);
@@ -3913,13 +3918,67 @@ function baselineRefreshNote(rf) {
   return el("p", { class: "form-hint", text: text });
 }
 
+// snapshotTablesUniform: the per-snapshot table count, when EVERY snapshot
+// has the same one — else null. A value identical in all 22 rows was the
+// list's widest column saying nothing (#1415); uniform, it is a fact about
+// the collection and belongs in the context strip.
+function snapshotTablesUniform(snaps) {
+  if (!snaps || !snaps.length) return null;
+  const n = (snaps[0].tables || []).length;
+  return snaps.every((sn) => (sn.tables || []).length === n) ? n : null;
+}
+
+// baselineContextStrip (#1415): one horizontal band of facts about where the
+// snapshots come from and how fresh they are — a context strip, not a card —
+// plus the page's one primary action. Replaces the half-width summary card
+// whose eyebrow duplicated the H1 and whose 405px forced the source path to
+// wrap mid-word.
+function baselineContextStrip(b, cur, opts) {
+  const strip = el("section", { class: "tcard ctx-strip" });
+  const item = (label, val, cls) => el("div", { class: "ctx-item" + (cls ? " " + cls : "") },
+    el("span", { class: "ctx-label", text: label }),
+    typeof val === "string" ? el("span", { class: "ctx-value", text: val }) : val);
+  if (!b || b.error) {
+    strip.append(item("BASELINES", "could not load: " + ((b && b.error) || "unavailable")));
+    return strip;
+  }
+  if (!b.configured) {
+    strip.append(item("SOURCE", "not configured"));
+    strip.append(item("TIME-TRAVEL", "off"));
+    return strip;
+  }
+  const snaps = b.snapshots || [];
+  // The source path is code, and it gets the width to render as one line —
+  // the dark code-ink treatment the recipe reserves for SQL/DSNs/paths.
+  strip.append(item("SOURCE", el("code", { class: "code-ink ctx-source", text: b.source }), "ctx-grow"));
+  strip.append(item("SNAPSHOTS", String(snaps.length) + (b.truncated ? "+" : "")));
+  if (snaps.length) {
+    // One fact, one place: absolute and relative side by side, instead of the
+    // same freshness spelled two ways 300px apart.
+    strip.append(item("LATEST", snaps[0].time + " UTC · " + formatAge(snaps[0].age_hours) + " ago"));
+  }
+  const uniform = snapshotTablesUniform(snaps);
+  if (uniform !== null) strip.append(item("TABLES", uniform + " per snapshot"));
+  strip.append(item("TIME-TRAVEL", b.reconstruct ? "enabled" : "off (archives disabled)"));
+  // The page's primary action, at page level — not a list-header costume.
+  if (capsCache.baseline_trigger && cur && cur.id && b.configured) {
+    const btn = el("button", { class: "btn ctx-action", type: "button", text: "Create baseline" });
+    btn.onclick = () => createBaseline(cur.id, btn);
+    strip.append(btn);
+  }
+  return strip;
+}
+
 // opts.serversErr: when /api/servers failed, `servers` is empty for the WRONG
 // reason. Without it this panel derives affirmative claims from a failure —
-// the Create baseline button vanishes with no stated cause, and the `owner`
+// the empty state advises adding a server that exists, and the `owner`
 // fallback below attributes the snapshots to the daemon when the selected
 // server may have its own baseline_s3.
 function baselinesPanel(b, servers, opts) {
-  const panel = el("section", { class: "ov-panel" });
+  // Full-width (#1415): this list is the page. The Create-baseline action
+  // moved to the context strip — at page level it is a page action; inside
+  // this header it read as scoped to the list.
+  const panel = el("section", { class: "ov-panel vfy-panel-full" });
   const cur = (servers || []).find((s) => s.id === (currentServer || defaultServerId));
   let owner = cur ? serverLabel(cur) : "";
   if (!owner && b && !b.error && b.configured && !(opts && opts.serversErr)) {
@@ -3928,14 +3987,6 @@ function baselinesPanel(b, servers, opts) {
   const head = el("div", { class: "ov-panel-head" },
     el("h2", { class: "ov-panel-title", text: "Baseline snapshots" + (owner ? " — " + owner : "") }),
     tzChip());
-  // Create-baseline action: only when the daemon opted in (capsCache.baseline_trigger),
-  // a real server is selected, and it has a baseline destination configured (else the
-  // endpoint 400s). The endpoint still re-validates the source DSN server-side.
-  if (capsCache.baseline_trigger && cur && cur.id && b && !b.error && b.configured) {
-    const btn = el("button", { class: "btn btn-sm", type: "button", text: "Create baseline" });
-    btn.onclick = () => createBaseline(cur.id, btn);
-    head.append(btn);
-  }
   panel.append(head);
   // The daemon's periodic refresh (#1171). Shown next to the list because the
   // question it answers — "is this list going to keep moving on its own?" — is
@@ -3972,16 +4023,25 @@ function baselinesPanel(b, servers, opts) {
           ? "⚠ BASELINE STALE — full-table restore broken; take a fresh baseline"
           : "BASELINE " + b.staleness.toUpperCase() })));
     }
+    // Row hierarchy (#1415): the newest snapshot is what Time-travel and a
+    // restore actually use — it gets the treatment; the rest are history and
+    // read denser. Relative age sits NEXT TO the absolute time (two facts
+    // about the same instant, formerly ~650px apart), and the table count
+    // appears per-row only when it VARIES — a value identical in every row
+    // is a fact about the collection and lives in the context strip.
+    const uniformTables = snapshotTablesUniform(b.snapshots);
     b.snapshots.forEach((sn, idx) => {
-      const row = el("div", { class: "stg-row" });
+      const row = el("div", { class: "stg-row" + (idx === 0 ? " stg-row-latest" : "") });
+      if (idx === 0) row.append(el("span", { class: "tag-pill", text: "Newest" }));
       row.append(tsSpan("stg-name mono", sn.time));
+      row.append(el("span", { class: "stg-rel", text: formatAge(sn.age_hours) + " ago" }));
       row.append(el("span", { class: "stg-dest", text:
-        (sn.tables || []).length + " table(s)" + (sn.binlog_file ? " · " + sn.binlog_file + ":" + sn.binlog_pos : "") }));
+        (uniformTables === null ? (sn.tables || []).length + " table(s)" + (sn.binlog_file ? " · " : "") : "") +
+        (sn.binlog_file ? sn.binlog_file + ":" + sn.binlog_pos : "") }));
       if (idx === 0 && sn.staleness && sn.staleness !== "ok") {
         row.append(el("span", { class: "chip chip-mon", text:
           sn.staleness === "broken" ? "⚠ STALE — restore broken" : sn.staleness.toUpperCase() }));
       }
-      row.append(el("span", { class: "stg-age", text: formatAge(sn.age_hours) + " ago" }));
       list.append(row);
     });
     if (b.truncated) list.append(el("div", { class: "ev-empty", text: "…older snapshots not shown." }));
@@ -4041,88 +4101,106 @@ async function pollBaseline(id) {
   return null;
 }
 
-// verifyPanel (#677): trigger/poll/explain the recovery-chain verification
-// engine (`bintrail verify`) for the selected server. Mirrors baselinesPanel's
-// structure — its own capability gate (verify_trigger, process-global, like
+// verifyRegions (#677, restructured #1419): trigger/poll/explain the
+// recovery-chain verification engine (`bintrail verify`) for the selected
+// server. Its own capability gate (verify_trigger, process-global, like
 // baseline_trigger) plus a per-server precondition (verify: a baseline is
 // configured; verify_live_source: a source DSN is also configured), both
 // re-enforced server-side so this gating is UX only.
-// opts.hideTitle: /verification renders pageHead("Verification") already, and
-// an h1 immediately above an identical h2 is a duplicated landmark for anyone
-// navigating by heading. The parameter exists rather than deleting the head
-// outright because the head is also the panel's own append target in three
-// early-return branches.
-function verifyPanel(servers, opts) {
-  // Full-width. This override was originally a workaround: verification was a
-  // third panel in a 2-column grid built for archiving | baselines, and with
-  // align-items:start it landed under the SHORT sibling with a dead gap beside
-  // the tall one. #1384 moved it to its own route, where it is the only panel,
-  // so the span is no longer compensating for anything — it is simply what a
-  // sole panel should do. Kept because the grid is still 2-column.
-  const panel = el("section", { class: "ov-panel vfy-panel-full" });
+//
+// The three regions of /verification — control,
+// current run, history — as separate surfaces. The gating branches (feature
+// off, no server) collapse to a single explanatory card, since with nothing
+// runnable the other two regions have nothing to hold.
+function verifyRegions(servers, opts) {
   const cur = (servers || []).find((s) => s.id === (currentServer || defaultServerId));
-  const head = el("div", { class: "ov-panel-head" });
-  if (!(opts && opts.hideTitle)) head.append(el("h2", { class: "ov-panel-title", text: "Verification" }));
-  const list = el("div", { class: "stg-list vfy-list" });
 
   if (!capsCache.verify_trigger) {
-    list.append(el("div", { class: "stg-empty" },
-      el("p", { class: "stg-empty-lead", text: "Verification from the console is turned off." }),
-      el("p", { class: "stg-empty-sub", text:
-        "Ask whoever manages this server to turn it on (set BINTRAIL_CONSOLE_VERIFY_TRIGGER=1 and restart). Already on the default setup? Re-download docker-compose.yml — running \"docker compose pull\" alone doesn't add new settings to a file you already have." })));
-    panel.append(head, list);
-    return panel;
+    const card = el("section", { class: "tcard vfy-region" },
+      el("div", { class: "stg-empty" },
+        el("p", { class: "stg-empty-lead", text: "Verification from the console is turned off." }),
+        el("p", { class: "stg-empty-sub", text:
+          "Ask whoever manages this server to turn it on (set BINTRAIL_CONSOLE_VERIFY_TRIGGER=1 and restart). Already on the default setup? Re-download docker-compose.yml — running \"docker compose pull\" alone doesn't add new settings to a file you already have." })));
+    return [card];
   }
   if (!cur || !cur.id) {
     // A failed /api/servers arrives here as an empty list, and "Select a
     // server" is then an instruction to do something the operator already did.
-    // archivingPanel takes serversErr for exactly this reason; prepending an
-    // error box above the panel does not stop the panel from contradicting it.
-    list.append(el("div", { class: "ev-empty", text: (opts && opts.serversErr)
-      ? "Could not load the server list, so verification cannot target one: " + opts.serversErr
-      : "Select a server to run verification." }));
-    panel.append(head, list);
-    return panel;
+    const card = el("section", { class: "tcard vfy-region" },
+      el("div", { class: "ev-empty", text: (opts && opts.serversErr)
+        ? "Could not load the server list, so verification cannot target one: " + opts.serversErr
+        : "Select a server to run verification." }));
+    return [card];
   }
 
+  // ── Region 1: what you can run ──
+  const control = el("section", { class: "tcard tcard-violet vfy-region vfy-control" });
+  control.append(el("div", { class: "vfy-region-head" },
+    el("h2", { class: "ov-panel-title" }, el("span", { class: "tag-pill", text: "Run a check" }))));
   const modeSel = el("select", { class: "select vfy-mode" },
     el("option", { value: "baseline-anchored", text: "Compare two saved snapshots (recommended)" }));
   if (capsCache.verify_live_source) {
     modeSel.append(el("option", { value: "live-source", text: "Compare against your live database (slower)" }));
   }
   modeSel.append(el("option", { value: "recover-inputs", text: "Check recovery inputs (no snapshot needed)" }));
-  const warn = el("p", { class: "form-hint vfy-livewarn", hidden: true, text:
-    "This reads your entire live table — it can take a while and adds load on your database. Best run outside busy hours." });
 
   const results = el("div", { class: "vfy-results" });
-  const btn = el("button", { class: "btn btn-sm", type: "button", text: "Run verification" });
+  const btn = el("button", { class: "btn vfy-run", type: "button", text: "Run verification" });
   const configured = !!capsCache.verify;
   // The snapshot-comparison modes need a baseline location; the
   // recover-inputs check reads only the index, so it stays runnable on a
   // server with no baseline configured.
-  const updateBtn = () => { btn.disabled = !configured && modeSel.value !== "recover-inputs"; };
-  modeSel.onchange = () => { warn.hidden = modeSel.value !== "live-source"; updateBtn(); };
-  updateBtn();
+  const help = el("p", { class: "form-hint vfy-modehelp" });
+  const updateMode = () => {
+    btn.disabled = !configured && modeSel.value !== "recover-inputs";
+    help.textContent = VFY_MODE_HELP[modeSel.value] || "";
+  };
+  modeSel.onchange = updateMode;
+  updateMode();
   btn.onclick = () => createVerify(cur.id, modeSel.value, btn, results);
-  head.append(el("div", { class: "vfy-actions" }, modeSel, btn));
-  panel.append(head);
-
+  control.append(el("div", { class: "vfy-actions" }, modeSel, btn));
+  control.append(help);
   if (!configured) {
-    list.append(el("div", { class: "stg-empty" },
-      el("p", { class: "stg-empty-lead", text: "No baseline set up for this server yet." }),
-      el("p", { class: "stg-empty-sub", text:
-        "Snapshot comparison checks your two most recent snapshots against each other — set a baseline location (Manage servers → Edit → Advanced) and create at least two to use it. \"Check recovery inputs\" works without one: it only reads the index." })));
-  } else {
-    list.append(warn);
+    control.append(el("p", { class: "form-hint", text:
+      "No baseline set up for this server yet — the two snapshot-comparison modes need one (Manage servers → Edit → Advanced, then create at least two snapshots). \"Check recovery inputs\" works without one: it only reads the index." }));
   }
+
+  // ── Region 2: what is running or just ran ──
+  const current = el("section", { class: "tcard vfy-region vfy-current" });
+  current.append(el("div", { class: "vfy-region-head" },
+    el("h2", { class: "ov-panel-title" }, el("span", { class: "tag-pill", text: "Current run" }))));
   renderVerifyResults(results, null, cur.id);
-  list.append(results);
+  current.append(results);
+  // The per-row nouns are precise AND internal (#1419 §5) — the glossary is
+  // the affordance that keeps them from requiring a source dive.
+  current.append(el("details", { class: "form-advanced vfy-glossary" },
+    el("summary", { class: "form-adv-summary", text: "What these words mean" }),
+    el("p", { class: "form-hint", text: "Chain — every indexed event for one row, oldest to newest. The walk follows each row's history in order." }),
+    el("p", { class: "form-hint", text: "Before-image assertion — each UPDATE/DELETE stores what the row looked like just before it; the check asserts that matches what the previous event left behind. This is exactly the data an undo script would be built from." }),
+    el("p", { class: "form-hint", text: "Began mid-history — the window caught a row mid-life, so its first event has no stored predecessor to check against. Widening the lookback usually resolves it." }),
+    el("p", { class: "form-hint", text: "Nothing to check / no activity — quiet or append-only tables, where zero assertions is the expected outcome; counted separately so they don't read as findings." })));
+
+  // ── Region 3: what ran before ──
+  const historyCard = el("section", { class: "tcard vfy-region vfy-histcard" });
+  historyCard.append(el("div", { class: "vfy-region-head" },
+    el("h2", { class: "ov-panel-title" }, el("span", { class: "tag-pill", text: "History" })),
+    tzChip()));
   const history = el("div", { class: "vfy-history" });
-  list.append(history);
+  historyCard.append(history);
   loadVerifyHistory(cur.id, history);
-  panel.append(list);
-  return panel;
+
+  return [control, current, historyCard];
 }
+
+// VFY_MODE_HELP (#1418): what each mode proves, what it needs, what it costs
+// — one compressed sentence set per mode, swapped under the select as the
+// operator browses. Source of truth for the long form is the issue; keep
+// these three claims per entry: proof, prerequisite, cost.
+const VFY_MODE_HELP = {
+  "baseline-anchored": "Replays your indexed changes from the previous snapshot forward and fingerprints the result against the newest one. Proves your backup chain is sound — the default. Needs two snapshots; never touches your database.",
+  "live-source": "Rebuilds each table from a snapshot plus the indexed changes and compares it against the real table. The strongest proof, and the only mode that reads your database — it can take a while and adds load, so best run outside busy hours. It can also report honest drift from writes that bypassed the binlog.",
+  "recover-inputs": "Walks the index's own before/after images and checks every row's chain is self-consistent — exactly the data an undo script would be built from. Needs no snapshot and never touches your database.",
+};
 
 // createVerify triggers an in-process verify run on the daemon for the
 // selected server, then polls until it finishes, updating resultsEl live
@@ -4144,7 +4222,10 @@ async function createVerify(id, mode, btn, resultsEl) {
   toast("Verification started…");
   const done = await pollVerify(id, (st) => renderVerifyResults(resultsEl, st, id));
   restore();
-  if (done) renderVerifyResults(resultsEl, done, id);
+  // justFinished: the running→done transition gets a one-shot highlight so
+  // completion is perceptible off-chip (#1420); the toast below is the other
+  // half for an operator who looked away.
+  if (done) renderVerifyResults(resultsEl, done, id, { justFinished: true });
   // The finished run is now in the persisted history too — refresh the list.
   const histBox = document.querySelector(".vfy-history");
   if (histBox) loadVerifyHistory(id, histBox);
@@ -4247,13 +4328,19 @@ async function loadVerifyHistory(id, box) {
     return;
   }
   clear(box);
-  if (!recs.length) return;
+  if (!recs.length) {
+    box.append(el("div", { class: "ev-empty", text: "No past runs yet." }));
+    return;
+  }
   const latest = recs.find((r) => r.state === "succeeded" || r.state === "failed");
   if (latest && latest.finished_at) {
     const sec = (Date.now() - Date.parse(latest.finished_at)) / 1000;
     const s = latest.summary || {};
+    // chip-age, NOT chip-mon and NOT the live treatment: this is a staleness
+    // age, and it used to wear the same amber as RUNNING (#1420) — a live
+    // state and an old fact were indistinguishable at a glance.
     box.append(el("div", { class: "vfy-summary" },
-      el("span", { class: "chip chip-mon", text: "LAST VERIFIED " + agoText(sec) }),
+      el("span", { class: "chip chip-age", text: "LAST VERIFIED " + agoText(sec) }),
       el("span", { class: "stg-age", text: latest.state === "failed"
         ? "failed — " + (latest.last_error || "unknown error")
         : ((s.mismatch || s.error)
@@ -4267,33 +4354,112 @@ async function loadVerifyHistory(id, box) {
     else if (r.state === "failed") outcome = "failed — " + (r.last_error || "unknown error");
     else outcome = vfySummaryText(s);
     const when = utcLabel(r.finished_at || r.since || "");
-    const row = el("div", { class: "stg-row" });
+    // Expandable (#1417): the per-table detail is ALREADY in this record —
+    // VerifyRunRecord embeds VerifyStatus, results included — the old
+    // renderer just dropped it on the floor. Disclosure, not navigation:
+    // the history is short and comparing runs side by side is the point.
+    const row = el("button", { class: "stg-row vfy-histrow", type: "button", "aria-expanded": "false" });
     row.append(
-      el("span", { class: "stg-age", text: when }),
+      icon("caret", "ev-caret"),
+      el("span", { class: "stg-name mono", text: when }),
       el("span", { text: (VFY_MODE_LABEL[r.mode] || r.mode || "") + (r.trigger === "scheduled" ? " (scheduled)" : "") }),
       el("span", { class: "stg-age", text: outcome }));
-    box.append(row);
+    const detail = el("div", { class: "vfy-histdetail", hidden: "" });
+    let rendered = false;
+    row.onclick = () => {
+      const open = row.classList.toggle("open");
+      row.setAttribute("aria-expanded", open ? "true" : "false");
+      detail.hidden = !open;
+      if (open && !rendered) {
+        rendered = true;
+        if ((r.results || []).length) {
+          renderVerifyResults(detail, r, id, { history: true });
+        } else {
+          detail.append(el("div", { class: "ev-empty", text: "This run recorded no per-table detail" +
+            (r.state === "skipped" ? " — it was skipped before any table was checked." : ".") }));
+        }
+      }
+    };
+    box.append(row, detail);
   });
 }
 
-// renderVerifyResults draws the current run's summary + per-table cards into
-// container, reusing the doctor preflight card styling (pass/fail/warn) since
-// both are "a list of named checks, each with a status and free-text detail".
-function renderVerifyResults(container, status, id) {
+// vfySortResults:// vfySortResults: worst verdict first (#1419 §3) — a mismatch must not sit
+// at alphabetical position 31 below the fold, visually identical to the 46
+// clean rows around it. Within a band the alphabetical order is kept (stable
+// sort), so scanning stays predictable. Display-only: the wire order is the
+// engine's completion order and the summary counts are order-free.
+const VFY_SORT_BAND = { fail: 0, warn: 2, note: 3, pass: 4 };
+function vfySortResults(results) {
+  return results.map((r, i) => [r, i]).sort((a, b) => {
+    const ba = vfyCardClass(a[0]), bb = vfyCardClass(b[0]);
+    // error shares the "fail" class with mismatch; keep mismatch first.
+    const rank = (r, band) => band === "fail" ? (r.status === "mismatch" ? 0 : 1) : VFY_SORT_BAND[band];
+    const d = rank(a[0], ba) - rank(b[0], bb);
+    return d !== 0 ? d : a[1] - b[1];
+  }).map((p) => p[0]);
+}
+
+// vfyCountsText: the per-table counters as a compact fixed column (#1419 §2)
+// — only the recover-inputs rows carry them (content modes omit all three).
+function vfyCountsText(r) {
+  if (r.events_checked === undefined && r.chains_checked === undefined) return "";
+  return (r.events_checked || 0) + " ev · " + (r.chains_checked || 0) + " chains";
+}
+
+// renderVerifyResults draws one run's summary + per-table rows into
+// container. Used by the live poll loop (results appear as they land) AND by
+// an expanded history record (#1417) — a VerifyRunRecord embeds VerifyStatus,
+// so the shapes are compatible by construction.
+//
+// opts.history: rendering a PAST run — no Explain buttons (a new verify run
+// discards the previous run's drill-down artifacts, so the button would 404
+// or answer about a different run), and no "no run yet" placeholder. Also
+// DERIVED from the record itself: every persisted VerifyRunRecord carries
+// `trigger` ("manual"/"scheduled", no omitempty) and the live VerifyStatus
+// never does, so a call site that forgets the option cannot resurrect the
+// dead buttons — deriving beats threading, and the fixture cannot red-check
+// the threaded half (recover-inputs rows are never explainable).
+// opts.justFinished: the completion transition (#1420) — a one-shot highlight
+// on the summary row so the running→done change is perceptible to someone
+// not staring at the chip.
+function renderVerifyResults(container, status, id, opts) {
   clear(container);
+  const history = (opts && opts.history) || (status && status.trigger !== undefined);
   if (!status || status.state === "idle") {
-    container.append(el("div", { class: "ev-empty", text: "No verification run yet." }));
+    if (!history) {
+      container.append(el("div", { class: "ev-empty", text: "No run in this session yet — results appear here, table by table, as a run progresses. Past runs are under History." }));
+    }
     return;
   }
+  const running = status.state === "running";
+  // RUNNING is a live state and gets a live treatment — animated, distinct
+  // from every age/staleness chip on the page (#1420): the old amber
+  // chip-mon was also the LAST VERIFIED treatment, so a glance could not
+  // tell "in flight" from "13h old".
+  const chipCls = { running: "chip chip-live", succeeded: "chip chip-done", failed: "chip chip-fail" }[status.state] || "chip chip-mon";
   const stateLabel = { running: "RUNNING", succeeded: "DONE", failed: "FAILED" }[status.state] || status.state.toUpperCase();
-  const summaryRow = el("div", { class: "vfy-summary" },
-    el("span", { class: "chip chip-mon", text: stateLabel }));
+  const summaryRow = el("div", { class: "vfy-summary" + ((opts && opts.justFinished) ? " vfy-flash" : "") },
+    el("span", { class: chipCls, text: stateLabel }));
   if (status.mode) summaryRow.append(el("span", { class: "stg-age", text: VFY_MODE_LABEL[status.mode] || status.mode }));
   const s = status.summary || {};
-  if (status.results && status.results.length) {
+  const done = (status.results || []).length;
+  if (running) {
+    // Progress, not a tally (#1420): the engine has no planned-total, so the
+    // honest number is tables completed so far — framed as progress, because
+    // a partial count read as final says "20 inconclusive" about a run that
+    // has not finished (sharpest for inconclusive, #1416).
+    summaryRow.append(el("span", { class: "stg-age", text: done + " table(s) checked so far" }));
+    if (done) summaryRow.append(el("span", { class: "stg-age vfy-sofar", text: vfySummaryText(s) + " — so far" }));
+  } else if (done) {
     summaryRow.append(el("span", { class: "stg-age", text: vfySummaryText(s) }));
   }
   container.append(summaryRow);
+  if (running) {
+    // Motion (#1420): the page must look like a page doing work. The strip is
+    // CSS-animated behind prefers-reduced-motion, like every other motion here.
+    container.append(el("div", { class: "vfy-progress" }, el("span", { class: "vfy-progress-bar" })));
+  }
   // The verdict sentence (#1416): the answer to the operator's question in
   // words, so it does not have to be derived from 28 rows. Only on a FINISHED
   // run — a partial tally must not be read as a verdict (#1420).
@@ -4303,24 +4469,32 @@ function renderVerifyResults(container, status, id) {
   if (status.note) container.append(el("p", { class: "form-hint", text: status.note }));
   if (status.last_error) container.append(el("p", { class: "form-msg err", text: status.last_error }));
 
-  const cards = el("div", { class: "doctor-cards" });
-  (status.results || []).forEach((r) => {
+  // Structured rows (#1419 §2), worst first (§3): table, verdict and counts
+  // are columns the eye can scan; the detail sentence is the LAST, flexible
+  // column, ellipsized with the full text a click (or hover title) away.
+  const rows = el("div", { class: "vfy-rows" });
+  vfySortResults(status.results || []).forEach((r) => {
     // Statuses are normalized server-side (verify.NormalizeStatus), so only
     // the four keys above can arrive; if that ever breaks, fail — never reassure.
     const cls = vfyCardClass(r);
-    const card = el("div", { class: "doctor-card " + cls });
-    card.append(el("span", { class: "dc-mark", text: VFY_STATUS_MARK[cls] || "?" }));
-    const body = el("div", { class: "dc-body" },
-      el("div", { class: "dc-name", text: r.schema + "." + r.table + " — " + r.status + (r.reason ? " — " + r.reason : "") }));
-    if (r.explainable) {
+    const row = el("div", { class: "vfy-row " + cls });
+    row.append(el("span", { class: "vfy-mark", text: VFY_STATUS_MARK[cls] || "?" }));
+    row.append(el("span", { class: "vfy-tbl", text: r.schema + "." + r.table }));
+    const verdict = r.status === "inconclusive" && VFY_BENIGN_KINDS[r.inconclusive_kind]
+      ? "nothing to check" : r.status;
+    row.append(el("span", { class: "vfy-verdict", text: verdict }));
+    row.append(el("span", { class: "vfy-counts", text: vfyCountsText(r) }));
+    const reason = el("span", { class: "vfy-reason", text: r.reason || "", title: r.reason || "" });
+    reason.onclick = () => reason.classList.toggle("wrap");
+    row.append(reason);
+    if (r.explainable && !history) {
       const explainBtn = el("button", { class: "btn btn-sm btn-ghost", type: "button", text: "Explain" });
       explainBtn.onclick = () => openVerifyExplain(id, r.schema, r.table, explainBtn);
-      body.append(explainBtn);
+      row.append(explainBtn);
     }
-    card.append(body);
-    cards.append(card);
+    rows.append(row);
   });
-  container.append(cards);
+  container.append(rows);
 }
 
 // openVerifyExplain shows the row-level drill-down for one mismatched table,

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -4078,12 +4078,10 @@ async function createBaseline(id, btn) {
   } else {
     toast("Baseline still running — check back shortly.");
   }
-  // Create baseline now lives on /baselines (#1384) while the summary card
-  // still appears on /storage, so refresh whichever is on screen. Hardcoding
-  // /storage would leave the page that OWNS the button showing a stale list
-  // right after the run it started.
-  // Only /baselines: the Create baseline button lives in baselinesPanel, which
-  // no longer renders on Storage, so a /storage arm here would be unreachable.
+  // Only /baselines needs the refresh: the button lives in
+  // baselineContextStrip (#1415 moved it out of baselinesPanel), and both the
+  // strip and the snapshot list render only on this page — a /storage arm
+  // here would be unreachable.
   if (location.pathname === "/baselines") renderBaselines();
 }
 
@@ -4181,7 +4179,7 @@ function verifyRegions(servers, opts) {
     el("summary", { class: "form-adv-summary", text: "What these words mean" }),
     el("p", { class: "form-hint", text: "Chain — every indexed event for one row, oldest to newest. The walk follows each row's history in order." }),
     el("p", { class: "form-hint", text: "Before-image assertion — each UPDATE/DELETE stores what the row looked like just before it; the check asserts that matches what the previous event left behind. This is exactly the data an undo script would be built from." }),
-    el("p", { class: "form-hint", text: "Began mid-history — the window caught a row mid-life, so its first event has no stored predecessor to check against. Widening the lookback usually resolves it." }),
+    el("p", { class: "form-hint", text: "Began mid-history — the window caught a row mid-life, so its first event has no stored predecessor to check against. Widening the lookback (CLI: verify --check recover --lookback …) can give these chains their predecessors — when the earlier history is still in the index." }),
     el("p", { class: "form-hint", text: "Nothing to check / no activity — quiet or append-only tables, where zero assertions is the expected outcome; counted separately so they don't read as findings." })));
 
   // ── Region 3: what ran before ──
@@ -4202,7 +4200,7 @@ function verifyRegions(servers, opts) {
 // these three claims per entry: proof, prerequisite, cost.
 const VFY_MODE_HELP = {
   "baseline-anchored": "Replays your indexed changes from the previous snapshot forward and fingerprints the result against the newest one. Strong evidence your backup chain is sound — the default. Needs two snapshots; never touches your database.",
-  "live-source": "Rebuilds each table from a snapshot plus the indexed changes and compares it against the real table. The strongest check, and the only mode that reads your database — it can take a while, adds load, and needs a QUIET table: writes landing during the scan read as mismatches. Best run outside busy hours.",
+  "live-source": "Rebuilds each table from a snapshot plus the indexed changes and compares it against the real table. The strongest content check, and the only mode that reads your database — it can take a while, adds load, and needs a QUIET table: writes landing during the scan read as mismatches. Best run outside busy hours.",
   "recover-inputs": "Walks the index's own before/after images and checks every row's chain is self-consistent — exactly the data an undo script would be built from. Needs no snapshot and never touches your database.",
 };
 
@@ -4391,8 +4389,9 @@ async function loadVerifyHistory(id, box) {
 
 // vfySortResults: worst verdict first (#1419 §3) — a mismatch must not sit
 // at alphabetical position 31 below the fold, visually identical to the 46
-// clean rows around it. Within a band the alphabetical order is kept (stable
-// sort), so scanning stays predictable. Display-only: the wire order is the
+// clean rows around it. Within a band the incoming order is kept
+// (stable sort) — alphabetical in practice, because both result enumerators
+// sort; the ORDER BY is theirs, not this function's. Display-only: the wire order is the
 // engine's completion order and the summary counts are order-free.
 const VFY_SORT_BAND = { warn: 2, note: 3, pass: 4 }; // fail band ranks 0/1 inline (mismatch first)
 function vfySortResults(results) {
@@ -4436,7 +4435,7 @@ function renderVerifyResults(container, status, id, opts) {
   const history = (opts && opts.history) || (status && status.trigger !== undefined);
   if (!status || status.state === "idle") {
     if (!history) {
-      container.append(el("div", { class: "ev-empty", text: "No run in this session yet — results appear here, table by table, as a run progresses. Past runs are under History." }));
+      container.append(el("div", { class: "ev-empty", text: "No run yet — results appear here, table by table, once you start one. Past runs are under History." }));
     }
     return;
   }

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -3491,10 +3491,10 @@ function buildStorage(serversRes, rotation, storage, baselines, telemetry) {
 
   // Storage keeps storage POLICY. Baselines and verification moved to their
   // own routes (#1384): the snapshot list is unbounded, so it used to push
-  // verification off the fold, and verifyPanel needed a both-columns override
-  // to escape a grid built for two panels. baselineSummaryCard stays as the
-  // pointer — the count and age belong on a storage overview, the full list
-  // does not.
+  // verification off the fold inside a grid built for two panels (the
+  // verification builder is verifyRegions since #1419). baselineSummaryCard
+  // stays as the pointer — the count and age belong on a storage overview,
+  // the full list does not.
   const grid = el("div", { class: "ov-grid", style: "margin-top:18px" });
   grid.append(archivingPanel(servers, serversErr));
   v.append(grid);
@@ -3537,7 +3537,7 @@ async function renderBaselines() {
     // collection (source, count, freshness, tables-per-snapshot when uniform)
     // so the rows below can carry only what varies between snapshots.
     const cur = servers.find((s) => s.id === (currentServer || defaultServerId));
-    v.append(baselineContextStrip(baselines, cur, { serversErr: serversErr }));
+    v.append(baselineContextStrip(baselines, cur));
     v.append(baselinesPanel(baselines, servers, { serversErr: serversErr }));
     viewEnter();
   } catch (err) {
@@ -3922,8 +3922,12 @@ function baselineRefreshNote(rf) {
 // has the same one — else null. A value identical in all 22 rows was the
 // list's widest column saying nothing (#1415); uniform, it is a fact about
 // the collection and belongs in the context strip.
-function snapshotTablesUniform(snaps) {
-  if (!snaps || !snaps.length) return null;
+function snapshotTablesUniform(snaps, truncated) {
+  // A TRUNCATED listing cannot decide either way: promoting the visible
+  // rows' count to "N per snapshot" claims snapshots the API never showed,
+  // and suppressing the per-row column does the same in the other
+  // direction — under truncation the rows keep their column.
+  if (truncated || !snaps || !snaps.length) return null;
   const n = (snaps[0].tables || []).length;
   return snaps.every((sn) => (sn.tables || []).length === n) ? n : null;
 }
@@ -3933,7 +3937,7 @@ function snapshotTablesUniform(snaps) {
 // plus the page's one primary action. Replaces the half-width summary card
 // whose eyebrow duplicated the H1 and whose 405px forced the source path to
 // wrap mid-word.
-function baselineContextStrip(b, cur, opts) {
+function baselineContextStrip(b, cur) {
   const strip = el("section", { class: "tcard ctx-strip" });
   const item = (label, val, cls) => el("div", { class: "ctx-item" + (cls ? " " + cls : "") },
     el("span", { class: "ctx-label", text: label }),
@@ -3957,7 +3961,7 @@ function baselineContextStrip(b, cur, opts) {
     // same freshness spelled two ways 300px apart.
     strip.append(item("LATEST", snaps[0].time + " UTC · " + formatAge(snaps[0].age_hours) + " ago"));
   }
-  const uniform = snapshotTablesUniform(snaps);
+  const uniform = snapshotTablesUniform(snaps, b.truncated);
   if (uniform !== null) strip.append(item("TABLES", uniform + " per snapshot"));
   strip.append(item("TIME-TRAVEL", b.reconstruct ? "enabled" : "off (archives disabled)"));
   // The page's primary action, at page level — not a list-header costume.
@@ -3978,7 +3982,7 @@ function baselinesPanel(b, servers, opts) {
   // Full-width (#1415): this list is the page. The Create-baseline action
   // moved to the context strip — at page level it is a page action; inside
   // this header it read as scoped to the list.
-  const panel = el("section", { class: "ov-panel vfy-panel-full" });
+  const panel = el("section", { class: "ov-panel" });
   const cur = (servers || []).find((s) => s.id === (currentServer || defaultServerId));
   let owner = cur ? serverLabel(cur) : "";
   if (!owner && b && !b.error && b.configured && !(opts && opts.serversErr)) {
@@ -4029,7 +4033,7 @@ function baselinesPanel(b, servers, opts) {
     // about the same instant, formerly ~650px apart), and the table count
     // appears per-row only when it VARIES — a value identical in every row
     // is a fact about the collection and lives in the context strip.
-    const uniformTables = snapshotTablesUniform(b.snapshots);
+    const uniformTables = snapshotTablesUniform(b.snapshots, b.truncated);
     b.snapshots.forEach((sn, idx) => {
       const row = el("div", { class: "stg-row" + (idx === 0 ? " stg-row-latest" : "") });
       if (idx === 0) row.append(el("span", { class: "tag-pill", text: "Newest" }));
@@ -4197,8 +4201,8 @@ function verifyRegions(servers, opts) {
 // operator browses. Source of truth for the long form is the issue; keep
 // these three claims per entry: proof, prerequisite, cost.
 const VFY_MODE_HELP = {
-  "baseline-anchored": "Replays your indexed changes from the previous snapshot forward and fingerprints the result against the newest one. Proves your backup chain is sound — the default. Needs two snapshots; never touches your database.",
-  "live-source": "Rebuilds each table from a snapshot plus the indexed changes and compares it against the real table. The strongest proof, and the only mode that reads your database — it can take a while and adds load, so best run outside busy hours. It can also report honest drift from writes that bypassed the binlog.",
+  "baseline-anchored": "Replays your indexed changes from the previous snapshot forward and fingerprints the result against the newest one. Strong evidence your backup chain is sound — the default. Needs two snapshots; never touches your database.",
+  "live-source": "Rebuilds each table from a snapshot plus the indexed changes and compares it against the real table. The strongest check, and the only mode that reads your database — it can take a while, adds load, and needs a QUIET table: writes landing during the scan read as mismatches. Best run outside busy hours.",
   "recover-inputs": "Walks the index's own before/after images and checks every row's chain is self-consistent — exactly the data an undo script would be built from. Needs no snapshot and never touches your database.",
 };
 
@@ -4225,7 +4229,7 @@ async function createVerify(id, mode, btn, resultsEl) {
   // justFinished: the running→done transition gets a one-shot highlight so
   // completion is perceptible off-chip (#1420); the toast below is the other
   // half for an operator who looked away.
-  if (done) renderVerifyResults(resultsEl, done, id, { justFinished: true });
+  if (done) renderVerifyResults(resultsEl, done, id, { justFinished: done.state === "succeeded" });
   // The finished run is now in the persisted history too — refresh the list.
   const histBox = document.querySelector(".vfy-history");
   if (histBox) loadVerifyHistory(id, histBox);
@@ -4347,7 +4351,7 @@ async function loadVerifyHistory(id, box) {
           ? s.match + " match · " + s.mismatch + " mismatch · " + s.error + " error"
           : s.match + "/" + s.total + " match") })));
   }
-  recs.slice(0, 8).forEach((r) => {
+  recs.slice(0, 8).forEach((r, i) => {
     const s = r.summary || {};
     let outcome;
     if (r.state === "skipped") outcome = "skipped — " + (r.skip_reason || "");
@@ -4358,13 +4362,14 @@ async function loadVerifyHistory(id, box) {
     // VerifyRunRecord embeds VerifyStatus, results included — the old
     // renderer just dropped it on the floor. Disclosure, not navigation:
     // the history is short and comparing runs side by side is the point.
-    const row = el("button", { class: "stg-row vfy-histrow", type: "button", "aria-expanded": "false" });
+    const detailID = "vfy-hist-" + i;
+    const row = el("button", { class: "stg-row vfy-histrow", type: "button", "aria-expanded": "false", "aria-controls": detailID });
     row.append(
       icon("caret", "ev-caret"),
       el("span", { class: "stg-name mono", text: when }),
       el("span", { text: (VFY_MODE_LABEL[r.mode] || r.mode || "") + (r.trigger === "scheduled" ? " (scheduled)" : "") }),
       el("span", { class: "stg-age", text: outcome }));
-    const detail = el("div", { class: "vfy-histdetail", hidden: "" });
+    const detail = el("div", { class: "vfy-histdetail", id: detailID, hidden: "" });
     let rendered = false;
     row.onclick = () => {
       const open = row.classList.toggle("open");
@@ -4384,12 +4389,12 @@ async function loadVerifyHistory(id, box) {
   });
 }
 
-// vfySortResults:// vfySortResults: worst verdict first (#1419 §3) — a mismatch must not sit
+// vfySortResults: worst verdict first (#1419 §3) — a mismatch must not sit
 // at alphabetical position 31 below the fold, visually identical to the 46
 // clean rows around it. Within a band the alphabetical order is kept (stable
 // sort), so scanning stays predictable. Display-only: the wire order is the
 // engine's completion order and the summary counts are order-free.
-const VFY_SORT_BAND = { fail: 0, warn: 2, note: 3, pass: 4 };
+const VFY_SORT_BAND = { warn: 2, note: 3, pass: 4 }; // fail band ranks 0/1 inline (mismatch first)
 function vfySortResults(results) {
   return results.map((r, i) => [r, i]).sort((a, b) => {
     const ba = vfyCardClass(a[0]), bb = vfyCardClass(b[0]);
@@ -4400,8 +4405,11 @@ function vfySortResults(results) {
   }).map((p) => p[0]);
 }
 
-// vfyCountsText: the per-table counters as a compact fixed column (#1419 §2)
-// — only the recover-inputs rows carry them (content modes omit all three).
+// vfyCountsText: the per-table counters as a compact fixed column (#1419 §2).
+// The wire carries them only for recover-inputs rows (toWireResult copies the
+// walk's counters; the content modes never set them) — review caught the
+// first cut reading keys the DTO did not carry at all, rendering the column
+// permanently blank.
 function vfyCountsText(r) {
   if (r.events_checked === undefined && r.chains_checked === undefined) return "";
   return (r.events_checked || 0) + " ev · " + (r.chains_checked || 0) + " chains";

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1951,7 +1951,6 @@ button { font-family: inherit; }
 .stg-empty-sub { margin: 0; font-size: 12.5px; color: var(--ink-3); max-width: 52ch; }
 
 /* Verification panel (#677) */
-.vfy-panel-full { grid-column: 1 / -1; }
 .vfy-actions { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
 /* wide enough for its own longest option — the select used to cut
    "Check recovery inputs (no sn" mid-word (#1419 §6) */
@@ -2017,13 +2016,16 @@ button { font-family: inherit; }
 }
 
 /* expandable history rows (#1417): full-width button rows with a caret */
-.vfy-histrow { width: 100%; text-align: left; background: none; border: none; cursor: pointer; font: inherit; color: inherit; }
+/* border:none kills the UA button chrome, so the .stg-row divider it also
+   resets is re-added explicitly — review caught the collapsed list running
+   together with no hairlines */
+.vfy-histrow { width: 100%; text-align: left; background: none; border: none; border-bottom: 1px solid var(--line-soft); cursor: pointer; font: inherit; color: inherit; }
 .vfy-histrow .ev-caret { transition: transform .14s; }
 .vfy-histrow.open .ev-caret { transform: rotate(90deg); }
 .vfy-histdetail { padding: 4px 10px 10px 30px; border-top: 1px dashed var(--line-soft); }
 
 /* baselines context strip (#1415) */
-.ctx-strip { display: flex; align-items: center; gap: 22px; flex-wrap: wrap; margin-top: 4px; padding: 14px 18px; }
+.ctx-strip { display: flex; align-items: center; gap: 22px; flex-wrap: wrap; margin-top: 4px; margin-bottom: 16px; padding: 14px 18px; }
 .ctx-item { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
 .ctx-grow { flex: 1 1 320px; }
 .ctx-label { font-family: var(--f-mono); font-size: 9.5px; font-weight: 700; letter-spacing: 0.08em; color: var(--ink-4); text-transform: uppercase; }

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1952,10 +1952,88 @@ button { font-family: inherit; }
 
 /* Verification panel (#677) */
 .vfy-panel-full { grid-column: 1 / -1; }
-.vfy-actions { display: flex; align-items: center; gap: 8px; }
-.vfy-mode { max-width: 260px; }
-.vfy-livewarn { margin: 0 0 8px; color: var(--orange-2); }
+.vfy-actions { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+/* wide enough for its own longest option — the select used to cut
+   "Check recovery inputs (no sn" mid-word (#1419 §6) */
+.vfy-mode { max-width: none; width: auto; min-width: 340px; }
 .vfy-results { display: flex; flex-direction: column; gap: 8px; }
+
+/* ── /verification region surfaces (#1419): control / current / history ── */
+.vfy-region { margin-top: 16px; padding: 16px 18px 18px; }
+.vfy-region-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 10px; }
+.vfy-region-head .ov-panel-title { margin: 0; }
+.vfy-modehelp { margin: 8px 2px 0; max-width: 860px; }
+.vfy-glossary { margin-top: 12px; }
+
+/* structured result rows (#1419 §2/§3): mark | table | verdict | counts | reason.
+   The verdict column is fixed and colored — the word, not a mid-sentence
+   glyph, carries the answer. Verdict colors reuse the doctor-card bands. */
+.vfy-rows { display: flex; flex-direction: column; }
+.vfy-row {
+  display: grid; grid-template-columns: 18px minmax(180px, 240px) 110px 130px 1fr auto;
+  align-items: center; gap: 10px; padding: 7px 10px;
+  border-top: 1px solid var(--line-soft); border-left: 3px solid transparent;
+}
+.vfy-row:first-child { border-top: none; }
+.vfy-row.pass { border-left-color: var(--insert); }
+.vfy-row.fail { border-left-color: var(--delete); background: color-mix(in srgb, var(--delete) 4%, transparent); }
+.vfy-row.warn { border-left-color: var(--ochre); }
+.vfy-row.note { border-left-color: var(--line); }
+.vfy-mark { font-weight: 700; text-align: center; }
+.vfy-row.pass .vfy-mark { color: var(--insert); }
+.vfy-row.fail .vfy-mark { color: var(--delete); }
+.vfy-row.warn .vfy-mark { color: var(--orange-2); }
+.vfy-row.note .vfy-mark { color: var(--ink-4); }
+.vfy-tbl { font-family: var(--f-mono); font-size: 12.5px; color: var(--ink); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.vfy-verdict { font-family: var(--f-mono); font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; }
+.vfy-row.pass .vfy-verdict { color: var(--insert); }
+.vfy-row.fail .vfy-verdict { color: var(--delete); }
+.vfy-row.warn .vfy-verdict { color: var(--orange-2); }
+.vfy-row.note .vfy-verdict { color: var(--ink-3); }
+.vfy-counts { font-family: var(--f-mono); font-size: 11px; color: var(--ink-3); white-space: nowrap; }
+.vfy-reason { font-size: 12px; color: var(--ink-3); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; cursor: pointer; }
+.vfy-reason.wrap { white-space: normal; }
+
+/* live-state chip (#1420): animated, and DISTINCT from every age chip. The
+   pulse rides prefers-reduced-motion like all console motion. */
+.chip-live { color: var(--orange-2); border-color: var(--ochre); background: var(--ochre-bg); }
+.chip-live::before { content: ""; width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
+.chip-done { color: var(--insert); border-color: var(--insert); background: color-mix(in srgb, var(--insert) 8%, transparent); }
+.chip-fail { color: var(--delete); border-color: var(--delete); background: color-mix(in srgb, var(--delete) 8%, transparent); }
+.chip-age { color: var(--ink-3); border-color: var(--line); background: var(--surface-2); }
+
+/* indeterminate progress strip (#1420): the engine has no planned-total, so
+   this is honest motion, not a fake percentage. */
+.vfy-progress { height: 4px; border-radius: 2px; background: var(--surface-3); overflow: hidden; position: relative; }
+.vfy-progress-bar { display: block; height: 100%; width: 30%; border-radius: 2px; background: var(--ochre); }
+.vfy-sofar { font-style: italic; }
+@media (prefers-reduced-motion: no-preference) {
+  .chip-live::before { animation: vfy-pulse 1.2s ease-in-out infinite; }
+  .vfy-progress-bar { animation: vfy-sweep 1.4s ease-in-out infinite; }
+  .vfy-flash { animation: vfy-done-flash 1.2s ease-out 1; }
+  @keyframes vfy-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.25; } }
+  @keyframes vfy-sweep { 0% { margin-left: -30%; } 100% { margin-left: 100%; } }
+  @keyframes vfy-done-flash { 0% { background: color-mix(in srgb, var(--insert) 14%, transparent); } 100% { background: transparent; } }
+}
+
+/* expandable history rows (#1417): full-width button rows with a caret */
+.vfy-histrow { width: 100%; text-align: left; background: none; border: none; cursor: pointer; font: inherit; color: inherit; }
+.vfy-histrow .ev-caret { transition: transform .14s; }
+.vfy-histrow.open .ev-caret { transform: rotate(90deg); }
+.vfy-histdetail { padding: 4px 10px 10px 30px; border-top: 1px dashed var(--line-soft); }
+
+/* baselines context strip (#1415) */
+.ctx-strip { display: flex; align-items: center; gap: 22px; flex-wrap: wrap; margin-top: 4px; padding: 14px 18px; }
+.ctx-item { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+.ctx-grow { flex: 1 1 320px; }
+.ctx-label { font-family: var(--f-mono); font-size: 9.5px; font-weight: 700; letter-spacing: 0.08em; color: var(--ink-4); text-transform: uppercase; }
+.ctx-value { font-size: 13px; color: var(--ink); }
+.ctx-source { display: block; font-size: 12px; padding: 6px 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ctx-action { align-self: center; margin-left: auto; }
+/* the newest snapshot is what a restore actually uses — it gets the
+   treatment; relative age rides beside the absolute time */
+.stg-row-latest { background: var(--violet-tint); border-radius: var(--radius-sm); }
+.stg-rel { font-family: var(--f-mono); font-size: 11px; color: var(--ink-3); white-space: nowrap; }
 .vfy-summary { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
 
 /* Verify explain modal: a wider modal + doctor-cards for each diverging row,

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1964,7 +1964,8 @@ button { font-family: inherit; }
 .vfy-modehelp { margin: 8px 2px 0; max-width: 860px; }
 .vfy-glossary { margin-top: 12px; }
 
-/* structured result rows (#1419 §2/§3): mark | table | verdict | counts | reason.
+/* structured result rows (#1419 §2/§3): mark | table | verdict | counts |
+   reason | explain (the trailing auto track holds the Explain button).
    The verdict column is fixed and colored — the word, not a mid-sentence
    glyph, carries the answer. Verdict colors reuse the doctor-card bands. */
 .vfy-rows { display: flex; flex-direction: column; }

--- a/internal/console/verify_trigger.go
+++ b/internal/console/verify_trigger.go
@@ -125,7 +125,14 @@ type VerifyTableResult struct {
 	InconclusiveKind string `json:"inconclusive_kind,omitempty"`
 	SourceRows       int64  `json:"source_rows,omitempty"`
 	ReconstructRows  int64  `json:"reconstruct_rows,omitempty"`
-	Anchor           string `json:"anchor,omitempty"`
+	// EventsChecked/ChainsChecked: the recover-inputs walk's per-table
+	// counters, same tag names as the CLI's verify --format json (#1425
+	// review: the console rendered a counts column these fields never
+	// reached — toWireResult dropped them on the floor). Zero-omitted; the
+	// content modes carry neither.
+	EventsChecked int `json:"events_checked,omitempty"`
+	ChainsChecked int `json:"chains_checked,omitempty"`
+	Anchor        string `json:"anchor,omitempty"`
 	// Explainable is true only for a baseline-anchored mismatch whose pair is
 	// still cached from the run that produced this result — the precondition
 	// for calling Explain on it.

--- a/internal/console/verify_trigger_wire_test.go
+++ b/internal/console/verify_trigger_wire_test.go
@@ -14,6 +14,10 @@ import (
 // shadowed under VerifyRunRecord, and silently kill Explain on every LIVE
 // run. This test is the boundary's Go half; the e2e's three legs all sit on
 // the JS side.
+//
+// Scope honesty: this leg sees only a NO-omitempty addition — an omitempty
+// Trigger populated mid-run would slip a zero-value marshal. If you add one,
+// extend this test with a POPULATED status.
 func TestVerifyStatusCarriesNoTriggerKey(t *testing.T) {
 	b, err := json.Marshal(VerifyStatus{State: "running"})
 	if err != nil {

--- a/internal/console/verify_trigger_wire_test.go
+++ b/internal/console/verify_trigger_wire_test.go
@@ -1,0 +1,44 @@
+package console
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestVerifyStatusCarriesNoTriggerKey pins the premise the console frontend
+// DERIVES history-ness from (#1417/#1425 review): renderVerifyResults treats
+// any status carrying a `trigger` key as a persisted VerifyRunRecord and
+// suppresses the Explain buttons — records always carry it (no omitempty),
+// live statuses never do. Adding Trigger to VerifyStatus (a plausible #1191
+// follow-up: "a scheduled run is in flight") would compile clean, marshal
+// shadowed under VerifyRunRecord, and silently kill Explain on every LIVE
+// run. This test is the boundary's Go half; the e2e's three legs all sit on
+// the JS side.
+func TestVerifyStatusCarriesNoTriggerKey(t *testing.T) {
+	b, err := json.Marshal(VerifyStatus{State: "running"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := m["trigger"]; ok {
+		t.Fatalf("VerifyStatus marshals a trigger key: %s — the console derives \"this is a "+
+			"history record\" from that key's presence, so a live status carrying it silently "+
+			"removes Explain from every live run; carry run provenance on VerifyRunRecord only, "+
+			"or re-teach app.js renderVerifyResults first", b)
+	}
+	rec, err := json.Marshal(VerifyRunRecord{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var rm map[string]any
+	if err := json.Unmarshal(rec, &rm); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := rm["trigger"]; !ok {
+		t.Fatalf("VerifyRunRecord no longer always carries trigger: %s — the same derivation "+
+			"then misses real history records and resurrects the dead Explain buttons", rec)
+	}
+}

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -1993,7 +1993,25 @@ try {
       controlTinted: regions[0] ? regions[0].classList.contains("tcard-violet") : false,
       subDescribesAll: !/prove a snapshot still reconstructs/i.test(document.querySelector(".page-sub").textContent),
       helpBefore, helpAfter: help ? help.textContent : "",
-      selWideEnough: sel ? sel.scrollWidth <= sel.clientWidth + 2 : false,
+      // Measured, not scrollWidth: Chrome reports scrollWidth == clientWidth
+      // for a <select> at ANY width (the dropdown clips, the control never
+      // scrolls) — the first cut of this assertion stayed green with the old
+      // 260px cap restored. Render the longest option's text in the select's
+      // own font and compare real pixels, leaving room for the chrome.
+      selWideEnough: (() => {
+        if (!sel) return false;
+        const cs = getComputedStyle(sel);
+        const probe = document.createElement("span");
+        probe.style.cssText = "position:absolute;visibility:hidden;white-space:nowrap;font:" + cs.font;
+        document.body.appendChild(probe);
+        let widest = 0;
+        Array.from(sel.options).forEach((o) => {
+          probe.textContent = o.textContent;
+          widest = Math.max(widest, probe.getBoundingClientRect().width);
+        });
+        probe.remove();
+        return sel.clientWidth >= widest + 30;
+      })(),
     };
   });
   (vfyStruct.regionCount >= 3 && vfyStruct.controlTinted)
@@ -2053,7 +2071,13 @@ try {
     : bad("verification: rows sort worst-first and the benign verdict is written in words", JSON.stringify(vfyOrder));
 
   // (d) a REAL run end to end: recover-inputs over the fixture index.
-  await page.evaluate(() => { document.querySelector(".vfy-run").click(); });
+  await page.evaluate(() => {
+    // Self-contained: leg (a) set the mode, but this leg's premise (a run
+    // that reads only the index) must not depend on assertion ordering.
+    const sel = document.querySelector(".vfy-mode");
+    if (sel.value !== "recover-inputs") { sel.value = "recover-inputs"; sel.dispatchEvent(new Event("change")); }
+    document.querySelector(".vfy-run").click();
+  });
   await page.waitForFunction(() => document.querySelector(".vfy-results .chip-done") !== null, { timeout: 60000 });
   const vfyDone = await page.evaluate(() => ({
     verdictSentence: (document.querySelector(".vfy-results .form-hint") || {}).textContent || "",

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -1885,15 +1885,30 @@ try {
   await page.evaluate(() => navigate("baselines"));
   await page.waitForFunction(() => Array.from(document.querySelectorAll(".stg-row")).some((r) => r.textContent.includes("binlog.000001:50")), { timeout: 10000 });
   const stg = await page.evaluate(() => {
-    const heads = Array.from(document.querySelectorAll(".ov-panel-head"));
-    const bHead = heads.find((h) => /Baseline snapshots/.test(h.textContent));
-    const btn = bHead ? Array.from(bHead.querySelectorAll("button")).find((b) => b.textContent === "Create baseline") : null;
+    // #1415: the Create action moved to the context strip (page level); the
+    // uniform table count moved there too, so the row carries only what
+    // varies (the binlog anchor) plus the newest treatment.
+    const strip = document.querySelector(".ctx-strip");
+    const btn = strip ? Array.from(strip.querySelectorAll("button")).find((b) => b.textContent === "Create baseline") : null;
     const row = Array.from(document.querySelectorAll(".stg-row")).find((r) => r.textContent.includes("binlog.000001:50"));
-    return { capOn: !!capsCache.baseline_trigger, btnPresent: !!btn, btnEnabled: btn ? !btn.disabled : false, rowText: row ? row.textContent : "" };
+    return { capOn: !!capsCache.baseline_trigger, stripPresent: !!strip,
+      stripText: strip ? strip.textContent : "",
+      btnPresent: !!btn, btnEnabled: btn ? !btn.disabled : false,
+      rowText: row ? row.textContent : "",
+      rowIsLatest: row ? row.classList.contains("stg-row-latest") : false,
+      sourceOneLine: strip && strip.querySelector(".ctx-source") ?
+        getComputedStyle(strip.querySelector(".ctx-source")).whiteSpace === "nowrap" : false };
   });
   stg.capOn ? ok("baselines: baseline_trigger capability reaches the frontend") : bad("baselines: baseline_trigger capability reaches the frontend", "capsCache.baseline_trigger falsy");
-  (stg.btnPresent && stg.btnEnabled) ? ok("baselines: Create-baseline button renders enabled when both gates pass") : bad("baselines: Create-baseline button renders enabled when both gates pass", `present=${stg.btnPresent} enabled=${stg.btnEnabled}`);
-  stg.rowText.includes("1 table(s)") ? ok("baselines: the fixture snapshot is listed with its table count") : bad("baselines: the fixture snapshot is listed with its table count", stg.rowText);
+  (stg.stripPresent && stg.btnPresent && stg.btnEnabled) ? ok("baselines: Create baseline is a page action on the context strip, enabled when both gates pass") : bad("baselines: Create baseline is a page action on the context strip, enabled when both gates pass", `strip=${stg.stripPresent} present=${stg.btnPresent} enabled=${stg.btnEnabled}`);
+  // The facts moved, they did not vanish: table count and source live on the
+  // strip; the row keeps the anchor and gains the newest treatment.
+  (/1 per snapshot/.test(stg.stripText) && stg.sourceOneLine)
+    ? ok("baselines: the uniform table count and the one-line source render on the strip")
+    : bad("baselines: the uniform table count and the one-line source render on the strip", stg.stripText);
+  (stg.rowIsLatest && /ago/.test(stg.rowText) && !/table\(s\)/.test(stg.rowText))
+    ? ok("baselines: the newest row wears the treatment, carries relative age, and drops the constant column")
+    : bad("baselines: the newest row wears the treatment, carries relative age, and drops the constant column", stg.rowText);
 
   // Scenario 15c — the button's other gate arms, fixture-driven through the
   // REAL baselinesPanel (destination-missing can't exist live once the daemon
@@ -1901,19 +1916,25 @@ try {
   // empty state; capability off → no button even with a destination.
   const gates = await page.evaluate(() => {
     const servers = [{ id: "srv-fix", name: "fixture" }];
+    const cur = servers[0];
     const keepCur = currentServer;
     currentServer = "srv-fix";
+    // The button lives on the STRIP since #1415 — drive both builders so the
+    // gate holds where the button actually is AND the panel keeps its empty
+    // states.
     const cfgOff = baselinesPanel({ configured: false }, servers);
+    const cfgOffStrip = baselineContextStrip({ configured: false }, cur);
     const keepCap = capsCache.baseline_trigger;
     capsCache.baseline_trigger = false;
     const capOff = baselinesPanel({ configured: true, source: "/tmp/baselines", snapshots: [] }, servers);
+    const capOffStrip = baselineContextStrip({ configured: true, source: "/tmp/baselines", snapshots: [] }, cur);
     capsCache.baseline_trigger = keepCap;
     currentServer = keepCur;
     const hasBtn = (n) => Array.from(n.querySelectorAll("button")).some((b) => b.textContent === "Create baseline");
     return {
-      cfgOffBtn: hasBtn(cfgOff),
+      cfgOffBtn: hasBtn(cfgOff) || hasBtn(cfgOffStrip),
       cfgOffEmpty: /No baselines configured/.test(cfgOff.textContent),
-      capOffBtn: hasBtn(capOff),
+      capOffBtn: hasBtn(capOff) || hasBtn(capOffStrip),
       capOffEmpty: /no snapshots found/.test(capOff.textContent),
     };
   });
@@ -1948,15 +1969,154 @@ try {
   ok("protect: /baselines renders the snapshot panel");
 
   await page.evaluate(() => navigate("verification"));
-  // NOT .ov-panel-title: the page suppresses the panel's own h2 (hideTitle) so
-  // it does not sit under an identical h1, which makes that selector
-  // unsatisfiable here. Anchor on the page heading and the mode control — the
-  // things whose absence would mean the route did not render.
   await page.waitForFunction(() => location.pathname === "/verification"
     && Array.from(document.querySelectorAll("h1.page-title")).some((h) => /Verification/.test(h.textContent))
-    && document.querySelector(".vfy-panel-full") !== null,
+    && document.querySelectorAll(".vfy-region").length >= 3,
     { timeout: 10000 });
-  ok("protect: /verification renders the verification panel");
+  ok("protect: /verification renders its three regions");
+
+  // Scenario 15v — the verification page rework (#1417/#1418/#1419/#1420),
+  // driven END TO END against the real daemon: a real recover-inputs run over
+  // the fixture index, then the history it persists.
+  //
+  // (a) structure + mode help (#1418/#1419): three separated regions; the
+  // help swaps with the select and describes the selected mode.
+  const vfyStruct = await page.evaluate(() => {
+    const regions = document.querySelectorAll(".vfy-region");
+    const sel = document.querySelector(".vfy-mode");
+    const help = document.querySelector(".vfy-modehelp");
+    const helpBefore = help ? help.textContent : "";
+    sel.value = "recover-inputs";
+    sel.dispatchEvent(new Event("change"));
+    return {
+      regionCount: regions.length,
+      controlTinted: regions[0] ? regions[0].classList.contains("tcard-violet") : false,
+      subDescribesAll: !/prove a snapshot still reconstructs/i.test(document.querySelector(".page-sub").textContent),
+      helpBefore, helpAfter: help ? help.textContent : "",
+      selWideEnough: sel ? sel.scrollWidth <= sel.clientWidth + 2 : false,
+    };
+  });
+  (vfyStruct.regionCount >= 3 && vfyStruct.controlTinted)
+    ? ok("verification: control / current / history are separate surfaces, control wears the structure tint")
+    : bad("verification: control / current / history are separate surfaces, control wears the structure tint", JSON.stringify(vfyStruct));
+  (vfyStruct.helpBefore && vfyStruct.helpAfter && vfyStruct.helpBefore !== vfyStruct.helpAfter
+    && /never touches your database/.test(vfyStruct.helpAfter))
+    ? ok("verification: the mode help swaps with the select and states proof, prerequisite, cost")
+    : bad("verification: the mode help swaps with the select and states proof, prerequisite, cost", JSON.stringify({ b: vfyStruct.helpBefore, a: vfyStruct.helpAfter }));
+  vfyStruct.selWideEnough
+    ? ok("verification: the mode select no longer truncates its own options")
+    : bad("verification: the mode select no longer truncates its own options", "scrollWidth > clientWidth");
+
+  // (b) the running treatment (#1420), pinned through the REAL renderer with
+  // a synthetic in-flight status — the fixture run below is too fast to
+  // photograph mid-flight deterministically.
+  const vfyRunning = await page.evaluate(() => {
+    const tmp = document.createElement("div");
+    document.body.appendChild(tmp);
+    renderVerifyResults(tmp, { state: "running", mode: "recover-inputs",
+      results: [{ schema: "a", table: "b", status: "match" }],
+      summary: { match: 1, mismatch: 0, inconclusive: 0, error: 0, total: 1 } }, "x");
+    const out = {
+      liveChip: !!tmp.querySelector(".chip-live"),
+      progress: !!tmp.querySelector(".vfy-progress"),
+      soFar: /so far/.test(tmp.textContent),
+      noVerdict: !/verified clean/.test(tmp.textContent),
+      ageChipDistinct: !tmp.querySelector(".chip-age"),
+    };
+    tmp.remove();
+    return out;
+  });
+  (vfyRunning.liveChip && vfyRunning.progress && vfyRunning.soFar && vfyRunning.noVerdict)
+    ? ok("verification: a running status renders motion, progress-so-far framing, and no early verdict")
+    : bad("verification: a running status renders motion, progress-so-far framing, and no early verdict", JSON.stringify(vfyRunning));
+
+  // (c) worst-first ordering (#1419 §3), pinned through the real renderer.
+  const vfyOrder = await page.evaluate(() => {
+    const tmp = document.createElement("div");
+    document.body.appendChild(tmp);
+    renderVerifyResults(tmp, { state: "succeeded", mode: "recover-inputs",
+      results: [
+        { schema: "s", table: "aaa_clean", status: "match" },
+        { schema: "s", table: "bbb_quiet", status: "inconclusive", inconclusive_kind: "no-activity" },
+        { schema: "s", table: "mmm_broken", status: "mismatch", reason: "chain break" },
+        { schema: "s", table: "ccc_hard", status: "inconclusive" },
+      ],
+      summary: { match: 1, mismatch: 1, inconclusive: 2, inconclusive_nothing_to_check: 1, error: 0, total: 4 } }, "x");
+    const order = Array.from(tmp.querySelectorAll(".vfy-row .vfy-tbl")).map((n) => n.textContent);
+    const verdicts = Array.from(tmp.querySelectorAll(".vfy-row .vfy-verdict")).map((n) => n.textContent);
+    tmp.remove();
+    return { order, verdicts };
+  });
+  (vfyOrder.order[0] === "s.mmm_broken" && vfyOrder.order[3] === "s.aaa_clean"
+    && vfyOrder.verdicts.includes("nothing to check"))
+    ? ok("verification: rows sort worst-first and the benign verdict is written in words")
+    : bad("verification: rows sort worst-first and the benign verdict is written in words", JSON.stringify(vfyOrder));
+
+  // (d) a REAL run end to end: recover-inputs over the fixture index.
+  await page.evaluate(() => { document.querySelector(".vfy-run").click(); });
+  await page.waitForFunction(() => document.querySelector(".vfy-results .chip-done") !== null, { timeout: 60000 });
+  const vfyDone = await page.evaluate(() => ({
+    verdictSentence: (document.querySelector(".vfy-results .form-hint") || {}).textContent || "",
+    rows: document.querySelectorAll(".vfy-results .vfy-row").length,
+    failChip: !!document.querySelector(".vfy-results .chip-fail"),
+  }));
+  (vfyDone.rows > 0 && vfyDone.verdictSentence.length > 0 && !vfyDone.failChip)
+    ? ok("verification: a real recover-inputs run completes with structured rows and a verdict sentence")
+    : bad("verification: a real recover-inputs run completes with structured rows and a verdict sentence", JSON.stringify(vfyDone));
+
+  // (e) history (#1417): the finished run is a disclosure row that expands to
+  // its per-table detail — data the old renderer dropped on the floor — and
+  // LAST VERIFIED wears the age treatment, not the live one (#1420).
+  await page.waitForFunction(() => document.querySelectorAll(".vfy-histrow").length > 0, { timeout: 10000 });
+  const vfyHist = await page.evaluate(() => {
+    const row = document.querySelector(".vfy-histrow");
+    row.click();
+    const detail = row.nextElementSibling;
+    return {
+      expanded: row.getAttribute("aria-expanded") === "true",
+      detailRows: detail ? detail.querySelectorAll(".vfy-row").length : 0,
+      detailExplainBtns: detail ? Array.from(detail.querySelectorAll("button")).filter((b) => b.textContent === "Explain").length : -1,
+      lastChipAge: !!document.querySelector(".vfy-history .chip-age"),
+      lastChipNotLive: !document.querySelector(".vfy-history .chip-live"),
+    };
+  });
+  (vfyHist.expanded && vfyHist.detailRows > 0 && vfyHist.detailExplainBtns === 0)
+    ? ok("verification: a history row expands to per-table detail, with no dead Explain buttons")
+    : bad("verification: a history row expands to per-table detail, with no dead Explain buttons", JSON.stringify(vfyHist));
+  // The dead-button rule pinned where the fixture cannot: recover-inputs
+  // results are never explainable, so the real history above holds this
+  // assertion vacuously. A synthetic explainable mismatch through the REAL
+  // renderer is the only shape that can see the {history:true} suppression —
+  // the mutation dropping it stayed green against the fixture alone.
+  const vfyDeadBtn = await page.evaluate(() => {
+    const mk = (opts) => {
+      const tmp = document.createElement("div");
+      document.body.appendChild(tmp);
+      renderVerifyResults(tmp, { state: "succeeded", mode: "baseline-anchored",
+        results: [{ schema: "s", table: "t", status: "mismatch", reason: "digest differs", explainable: true }],
+        summary: { match: 0, mismatch: 1, inconclusive: 0, error: 0, total: 1 } }, "x", opts);
+      const n = Array.from(tmp.querySelectorAll("button")).filter((b) => b.textContent === "Explain").length;
+      tmp.remove();
+      return n;
+    };
+    // The third leg is the derivation: a RECORD (trigger present) with the
+    // option forgotten must still suppress the button — this is what makes
+    // the call-site mutation structurally impossible.
+    const tmp = document.createElement("div");
+    document.body.appendChild(tmp);
+    renderVerifyResults(tmp, { state: "succeeded", mode: "baseline-anchored", trigger: "manual",
+      results: [{ schema: "s", table: "t", status: "mismatch", reason: "digest differs", explainable: true }],
+      summary: { match: 0, mismatch: 1, inconclusive: 0, error: 0, total: 1 } }, "x");
+    const derived = Array.from(tmp.querySelectorAll("button")).filter((b) => b.textContent === "Explain").length;
+    tmp.remove();
+    return { live: mk(undefined), history: mk({ history: true }), derived };
+  });
+  (vfyDeadBtn.live === 1 && vfyDeadBtn.history === 0 && vfyDeadBtn.derived === 0)
+    ? ok("verification: Explain renders on a live run and never on a history record — even when the option is forgotten")
+    : bad("verification: Explain renders on a live run and never on a history record — even when the option is forgotten", JSON.stringify(vfyDeadBtn));
+  (vfyHist.lastChipAge && vfyHist.lastChipNotLive)
+    ? ok("verification: LAST VERIFIED wears the age treatment, distinct from RUNNING")
+    : bad("verification: LAST VERIFIED wears the age treatment, distinct from RUNNING", JSON.stringify(vfyHist));
 
   await page.evaluate(() => navigate("storage"));
   await page.waitForFunction(() => location.pathname === "/storage"

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -1994,12 +1994,13 @@ try {
       subDescribesAll: !/prove a snapshot still reconstructs/i.test(document.querySelector(".page-sub").textContent),
       helpBefore, helpAfter: help ? help.textContent : "",
       // Measured, not scrollWidth: Chrome reports scrollWidth == clientWidth
-      // for a <select> at ANY width (the dropdown clips, the control never
-      // scrolls) — the first cut of this assertion stayed green with the old
-      // 260px cap restored. Render the longest option's text in the select's
-      // own font and compare real pixels, leaving room for the chrome.
-      selWideEnough: (() => {
-        if (!sel) return false;
+      // for a <select> at ANY width (the closed control clips its text and
+      // never scrolls; the popup sizes itself) — the first cut of this
+      // assertion stayed green with the old 260px cap restored. Render the
+      // longest option's text in the select's own font and compare real
+      // pixels, leaving room for the chrome.
+      selWide: (() => {
+        if (!sel) return { ok: false, why: "no select" };
         const cs = getComputedStyle(sel);
         const probe = document.createElement("span");
         probe.style.cssText = "position:absolute;visibility:hidden;white-space:nowrap;font:" + cs.font;
@@ -2010,7 +2011,8 @@ try {
           widest = Math.max(widest, probe.getBoundingClientRect().width);
         });
         probe.remove();
-        return sel.clientWidth >= widest + 30;
+        return { ok: sel.clientWidth >= widest + 30,
+          why: "clientWidth=" + sel.clientWidth + " vs widest+30=" + Math.round(widest + 30) };
       })(),
     };
   });
@@ -2021,9 +2023,10 @@ try {
     && /never touches your database/.test(vfyStruct.helpAfter))
     ? ok("verification: the mode help swaps with the select and states proof, prerequisite, cost")
     : bad("verification: the mode help swaps with the select and states proof, prerequisite, cost", JSON.stringify({ b: vfyStruct.helpBefore, a: vfyStruct.helpAfter }));
-  vfyStruct.selWideEnough
+  (vfyStruct.selWide && vfyStruct.selWide.ok)
     ? ok("verification: the mode select no longer truncates its own options")
-    : bad("verification: the mode select no longer truncates its own options", "scrollWidth > clientWidth");
+    : bad("verification: the mode select no longer truncates its own options",
+        vfyStruct.selWide ? vfyStruct.selWide.why : "probe missing");
 
   // (b) the running treatment (#1420), pinned through the REAL renderer with
   // a synthetic in-flight status — the fixture run below is too fast to

--- a/test/console-e2e/run.sh
+++ b/test/console-e2e/run.sh
@@ -199,7 +199,7 @@ if [ "${ARC_LIVE:-0}" -lt 6 ] || [ "${ARC_ARCH:-0}" -lt 1 ]; then
 fi
 
 echo "==> launch source-less watch daemon on :$PORT"
-BINTRAIL_CONSOLE_TOKEN="$TOKEN" BINTRAIL_CONSOLE_BASELINE_TRIGGER=1 "$CONSOLE_BIN" watch \
+BINTRAIL_CONSOLE_TOKEN="$TOKEN" BINTRAIL_CONSOLE_BASELINE_TRIGGER=1 BINTRAIL_CONSOLE_VERIFY_TRIGGER=1 "$CONSOLE_BIN" watch \
   --index-dsn "${BASE_DSN}/${IDX_DB}" \
   --console-listen "127.0.0.1:$PORT" \
   --console-token "$TOKEN" \


### PR DESCRIPTION
Closes #1415. Closes #1417. Closes #1418. Closes #1419. Closes #1420.

One PR because the five issues share a surface language (the #1421 recipe) and two files; each lands whole:

**/baselines (#1415)** — the half-width summary card becomes a full-width **context strip**: source path as one-line dark code (`.code-ink`), snapshot count, latest time with its relative age *beside* it, tables-per-snapshot only when uniform, time-travel state, and **Create baseline** as the page action it is. The list goes full width; the newest snapshot wears the violet treatment and a `Newest` pill; rows drop the constant column.

**/verification (#1418/#1419/#1420)** — three regions with visible separation: *Run a check* (violet, per-mode help stating **proof, prerequisite, cost** — the old subtitle described one mode and was wrong about a second), *Current run*, *History*. Result rows are **columns** (mark | table | verdict word | counts | reason), **sorted worst-first**; a glossary names `chain` / `before-image assertion` / `began mid-history`. A running verification gets an animated live chip, an indeterminate progress strip, counts framed **"so far"** (a partial tally must not read as a verdict — #1416's sharpest case), and a one-shot completion flash. `LAST VERIFIED` drops the amber it shared with `RUNNING`. The mode select no longer truncates its own options.

**History (#1417)** — rows are disclosure rows; the per-table detail was already persisted and on the wire (`VerifyRunRecord` embeds `VerifyStatus`) — the old renderer dropped it on the floor. **Explain never renders on a record**, and the rule is *derived from the record itself* (`trigger` is always present there, never on a live status), so a call site that forgets the option cannot resurrect the dead buttons — the fixture structurally cannot red-check the threaded half (recover-inputs rows are never explainable), which is why derivation replaced threading.

Guards: e2e scenario 15v drives a **real recover-inputs run end to end** (`BINTRAIL_CONSOLE_VERIFY_TRIGGER=1` in the harness): regions, help swap, select width, running treatment (via the real renderer on a synthetic in-flight status — the fixture run completes too fast to photograph), worst-first order, verdict sentence, history expansion, chip split, dead-button rule in three legs. 283/283; five-mutation red-check killed every guard, and the one mutation no fixture could kill became the derived rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
