### PR TITLE
console: Connect AI as literal steps for non-technical users

### DIFF
--- a/docs/connect-ai.md
+++ b/docs/connect-ai.md
@@ -23,7 +23,11 @@ server, exactly like the console's Time-travel tab; without one the tool says so
 
 ---
 
-## Step 0 — you need the console with a token
+## Step 1 — you need the console with a token
+
+> The numbers here match the cards on the console's **Connect AI** page
+> (Step 1 · Access token, Step 2 · Console address, Step 3 · Add it to
+> Claude), so you can follow either surface.
 
 The AI connects to your **web console**, which serves an MCP endpoint at
 `/mcp`. If you already run `bintrail-console` (standalone `serve`, `watch`, or
@@ -54,7 +58,7 @@ token is their credential.
 
 ---
 
-## Step 1 — copy your MCP URL
+## Step 2 — copy your MCP URL
 
 Open the console in your browser → **Settings → Connect AI**. Copy the URL it
 shows, e.g.:
@@ -72,26 +76,28 @@ Two things worth knowing (the page handles both for you):
   runs** — LAN, VPN, or an SSH/SSM port-forward are all fine. Nothing needs to
   be on the public internet.
 
-## Step 2 — install the bundle in Claude Desktop
+## Step 3 — install the bundle in Claude Desktop
 
 1. Grab the `.mcpb` file from the **Connect AI** page's download button (or the
    [releases page](https://github.com/dbtrail/dbtrail/releases)) — pick the one
    matching the machine where Claude Desktop runs.
 2. **Double-click it.** Claude Desktop opens an install dialog.
 3. Fill in the two fields:
-   - **Console / MCP endpoint URL** — the URL from step 1
+   - **Console / MCP endpoint URL** — the URL from step 2
    - **Access token** — your console token (Claude Desktop stores it as a
      sensitive value)
 
 That's it. No config files were harmed.
 
-> **Platform note:** published bundles cover macOS (both chips: darwin-arm64
-> and darwin-amd64) and Linux (amd64 and arm64). There is no Windows bundle
-> yet — on Windows, add the console as a claude.ai custom connector (public
-> HTTPS deployments), or use the raw-config fallback on the Connect AI page
-> with a bridge you build yourself.
+> **Platform note:** the Linux bundles (amd64/arm64) are built by CI on every
+> release. The macOS bundles (darwin-arm64 and darwin-amd64) are attached by
+> hand and MOST releases carry them, but a few skipped the step - if your
+> release lacks them, take the newest release's darwin file or build your own
+> with `make mcpb` (output in `dist/mcpb/`). There is no Windows bundle yet -
+> on Windows, add the console as a claude.ai custom connector (public HTTPS
+> deployments); it needs no download at all.
 
-## Step 3 — ask something
+## Step 4 — ask something
 
 Open a new Claude Desktop conversation. The `query`, `recover`, `recover_cascade`,
 `status`, `list_schema_changes`, and `reconstruct` tools are now available. Try:
@@ -138,7 +144,7 @@ directly with a DSN — see [mcp-server.md](mcp-server.md).
 | Symptom | Likely cause, in order of likelihood |
 |---|---|
 | **401 unauthorized** | Wrong token; or you're not talking to the console you think you are — a port-forward pointing at a stale process, another console on the same port. Check with `curl -H "Authorization: Bearer $TOKEN" http://host:8090/api/capabilities` — it should return JSON with `"mcp": true`. |
-| **403 "no token configured"** | No token exists yet. Open **Settings → Connect AI** and click **Generate token** (step 0) — no restart needed. (Or set `--token` / `BINTRAIL_CONSOLE_TOKEN` and restart.) |
+| **403 "no token configured"** | No token exists yet. Open **Settings → Connect AI** and click **Generate token** (step 1) — no restart needed. (Or set `--token` / `BINTRAIL_CONSOLE_TOKEN` and restart.) |
 | **Connection refused / timeout** | The URL isn't reachable from the AI client's machine. `curl http://host:8090/api/healthz` from that machine; if you tunnel, remember tunnels can idle out — re-establish and retry. |
 | **Bundle download 404s** | That release predates the bundles. Take the latest release, or build with `make mcpb`. |
 | **Tools don't appear in Claude Desktop** | Check Desktop's MCP logs (Settings → Extensions): the bridge exits with a one-line reason — bad URL and rejected token are spelled out, it never hangs silently. |

--- a/docs/connect-ai.md
+++ b/docs/connect-ai.md
@@ -33,8 +33,8 @@ token**, and you mint one without leaving the browser:
 Open **Settings → Connect AI** in the sidebar. If no token is configured yet,
 the **Access token** card has a **Generate token** button — click it, copy the
 value it shows (it appears exactly once and is never stored), and you're done.
-No flags, no environment variables, no restart. The same card rotates or
-revokes the token later. The generated token is scoped to the MCP tools only —
+No flags, no environment variables, no restart. The same card replaces the
+token (**New token**) or deletes it (**Delete token**) later. The generated token is scoped to the MCP tools only —
 it cannot administer the console — and it carries the permission grants of the
 session that minted it, so each MCP tool works only if your session could use
 the matching console surface directly (details in
@@ -85,10 +85,11 @@ Two things worth knowing (the page handles both for you):
 
 That's it. No config files were harmed.
 
-> **macOS / Windows note:** published bundles currently cover Linux (the
-> release build matrix). On a Mac, build a native bundle from source with
-> `make mcpb` (output in `dist/mcpb/`), or use the raw-config fallback on the
-> Connect AI page — same two values, five lines of JSON.
+> **Platform note:** published bundles cover macOS (both chips: darwin-arm64
+> and darwin-amd64) and Linux (amd64 and arm64). There is no Windows bundle
+> yet — on Windows, add the console as a claude.ai custom connector (public
+> HTTPS deployments), or use the raw-config fallback on the Connect AI page
+> with a bridge you build yourself.
 
 ## Step 3 — ask something
 

--- a/docs/console.md
+++ b/docs/console.md
@@ -979,8 +979,8 @@ Rules that differ from the standalone `bintrail-mcp` server:
   atomic write, versioned envelope with the registry's read-only-if-newer
   contract), its plaintext is shown exactly once at generation, and it is
   **scoped to `/mcp` alone** — it cannot drive the browser API (registry
-  CRUD, monitor verbs, or its own rotation). Rotate/revoke from the same
-  card take effect on the next request, including for sibling console
+  CRUD, monitor verbs, or its own rotation). New token / Delete token from
+  the same card take effect on the next request, including for sibling console
   processes sharing the file: every `/mcp` request re-validates the
   credential, so a rotated-away or revoked token stops authenticating
   immediately. An MCP *session* is additionally bound to the credential that
@@ -1023,7 +1023,7 @@ The UI's **Settings → Connect AI** page assembles all of this for you: the
 ready-to-copy `/mcp` URL for the selected server (the per-server form when
 more than one server is registered), the `.mcpb` bundle download for the
 running version, and the raw-config fallback above. Its **Access token** card
-generates, rotates, and revokes the managed MCP token; the plaintext is
+generates, replaces (**New token**), and deletes the managed MCP token; the plaintext is
 displayed exactly once, at generation, and never stored. For the
 start-to-finish walkthrough (bundle install included), see
 [Connect an AI assistant](connect-ai.md).

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -5516,7 +5516,7 @@ function mcpTokenCard(tok, minted) {
   if (tok.managed) {
     if (!minted) {
       card.append(el("p", { class: "stg-hint", text:
-        "You already created a token" + (tok.created_at ? " on " + utcLabel(tok.created_at) : "") +
+        "A token already exists" + (tok.created_at ? " (created " + utcLabel(tok.created_at) + ")" : "") +
         ". Its value is not saved anywhere, so it cannot be shown again." +
         // read_only hides the buttons below, so never tell that user to click one
         (tok.read_only ? "" : " Lost it? Click New token: you get a fresh value to copy, and the old one stops working.") }));
@@ -5576,19 +5576,26 @@ function bundleCard() {
   const released = /^\d+\.\d+\.\d+$/.test(ver);
   card.append(el("ol", { class: "cn-steps" },
     el("li", { text: "You need the Claude Desktop app installed (claude.ai/download). Using claude.ai in the browser instead? See the note below." }),
-    el("li", { text: released
+    el("li", { text: released && guessPlatform()
       ? "Download the installer with the button below; it is the best guess for this computer, and the note under the buttons says when to pick a different file."
       : "Download the installer from the releases page below; the note under the button says which file matches this computer." }),
     el("li", { text: "Double-click the downloaded file. Claude Desktop opens and asks to install dbtrail; accept." }),
     el("li", { text: "Claude then asks for two things. In \"Console / MCP endpoint URL\" paste the address from step 2; in \"Access token\" paste the token from step 1." }),
     el("li", { text: "Open a new chat and try: what changed in my database in the last hour?" })));
-  if (released) {
-    const asset = "dbtrail-" + guessPlatform() + ".mcpb";
+  const plat = guessPlatform();
+  if (released && plat) {
+    const asset = "dbtrail-" + plat + ".mcpb";
     card.append(el("div", { class: "cn-links" },
-      el("a", { class: "btn btn-sm", href: "https://github.com/dbtrail/dbtrail/releases/download/v" + ver + "/" + asset, text: "Download " + asset }),
+      el("a", { class: "btn btn-sm", href: "https://github.com/dbtrail/dbtrail/releases/download/v" + ver + "/" + asset, target: "_blank", rel: "noopener", text: "Download " + asset }),
       el("a", { class: "btn btn-sm btn-ghost", href: "https://github.com/dbtrail/dbtrail/releases/tag/v" + ver, target: "_blank", rel: "noopener", text: "All downloads for v" + ver })));
     card.append(el("p", { class: "form-hint", text:
-      "The download matches this console's version (v" + ver + ") and guesses your computer (Macs are assumed Apple chip). Intel Mac? Use All downloads and take dbtrail-darwin-amd64.mcpb. Windows has no installer yet; use the claude.ai note below instead. If the link lands on Not Found, that older release predates the installer; take the newest release's file from All downloads." }));
+      "The download matches this console's version (v" + ver + ") and guesses your computer (Macs are assumed Apple chip). Intel Mac? Use All downloads and take dbtrail-darwin-amd64.mcpb. If the link lands on Not Found, that release shipped without this file; take the newest release's file from All downloads instead." }));
+  } else if (released) {
+    // Windows on a released build: never render a download that can only 404.
+    card.append(el("div", { class: "cn-links" },
+      el("a", { class: "btn btn-sm", href: "https://github.com/dbtrail/dbtrail/releases/tag/v" + ver, target: "_blank", rel: "noopener", text: "All downloads for v" + ver })));
+    card.append(el("p", { class: "form-hint", text:
+      "There is no Windows installer yet. Use the claude.ai note below instead; it needs no download at all." }));
   } else {
     card.append(el("div", { class: "cn-links" },
       el("a", { class: "btn btn-sm", href: "https://github.com/dbtrail/dbtrail/releases", target: "_blank", rel: "noopener", text: "Open the releases page" })));
@@ -5605,7 +5612,12 @@ function bundleCard() {
 // all-downloads link covers every other combination.
 function guessPlatform() {
   const ua = navigator.userAgent || "";
-  if (/Windows/i.test(ua)) return "windows-amd64";
+  // Empty on Windows ON PURPOSE: no Windows .mcpb has ever been published
+  // (the release matrix builds the bridge for linux; darwin is attached by
+  // hand), so synthesizing the name renders a download button whose link
+  // can only ever 404 while the hint below says the installer does not
+  // exist. The caller treats empty as "no direct download".
+  if (/Windows/i.test(ua)) return "";
   if (/Mac/i.test(ua)) return "darwin-arm64";
   return "linux-amd64";
 }

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -5408,13 +5408,13 @@ async function renderConnect() {
   if (gen !== serverGen) {
     // The consumed plaintext cannot be re-shown; say so instead of losing it
     // silently (the user must rotate to get a usable value).
-    if (minted) toastError("Token display interrupted; the plain token is gone. Rotate to get a fresh one");
+    if (minted) toastError("Token display interrupted; the plain token is gone. Click New token to get a fresh one");
     return;
   }
   try {
     buildConnect(servers, tokStatus, minted);
   } catch (err) {
-    if (minted) toastError("Token display interrupted; the plain token is gone. Rotate to get a fresh one");
+    if (minted) toastError("Token display interrupted; the plain token is gone. Click New token to get a fresh one");
     const v = VIEW(); clear(v); v.append(pageHead("Connect AI", null)); renderError(v, err);
   }
 }
@@ -5487,7 +5487,7 @@ async function revokeMCPToken() {
   try {
     await api("/api/mcp-token", { method: "DELETE" });
   } catch (err) {
-    toastError("Revoke failed: " + (err.message || err));
+    toastError("Could not delete the token: " + (err.message || err));
     return;
   }
   toast("Token deleted. AI clients that used it are disconnected");
@@ -5507,7 +5507,7 @@ function mcpTokenCard(tok, minted) {
     card.append(el("p", { class: "stg-hint", text: "Here is your new token. Copy it NOW and keep it somewhere safe (a password manager is ideal). It is not stored anywhere, so this is the only time it will ever be on screen:" }));
     card.append(el("div", { class: "cn-urlrow" },
       el("code", { class: "stg-code cn-url", text: minted }),
-      el("button", { class: "btn btn-sm", type: "button", text: "Copy", onclick: () => copyText(minted, "MCP token") })));
+      el("button", { class: "btn btn-sm", type: "button", text: "Copy", onclick: () => copyText(minted, "Access token") })));
   }
   if (!tok) {
     card.append(el("p", { class: "stg-hint", text: "We could not check whether a token exists. Reload the page to try again." }));
@@ -5517,7 +5517,9 @@ function mcpTokenCard(tok, minted) {
     if (!minted) {
       card.append(el("p", { class: "stg-hint", text:
         "You already created a token" + (tok.created_at ? " on " + utcLabel(tok.created_at) : "") +
-        ". Its value is not saved anywhere, so it cannot be shown again. Lost it? Click New token: you get a fresh value to copy, and the old one stops working." }));
+        ". Its value is not saved anywhere, so it cannot be shown again." +
+        // read_only hides the buttons below, so never tell that user to click one
+        (tok.read_only ? "" : " Lost it? Click New token: you get a fresh value to copy, and the old one stops working.") }));
     }
     if (tok.read_only) {
       card.append(el("p", { class: "form-hint", text:
@@ -5555,7 +5557,7 @@ function mcpEndpointCard(servers) {
   const url = mcpURL(servers);
   card.append(el("div", { class: "cn-urlrow" },
     el("code", { class: "stg-code cn-url", text: url }),
-    el("button", { class: "btn btn-sm", type: "button", text: "Copy", onclick: () => copyText(url, "MCP URL") })));
+    el("button", { class: "btn btn-sm", type: "button", text: "Copy", onclick: () => copyText(url, "Console address") })));
   if ((servers || []).length > 1) {
     card.append(el("p", { class: "form-hint", text:
       "This address points at the server picked in the left sidebar (the Server box at the top). To connect a different server, pick it there first and copy again: each server has its own address." }));
@@ -5575,7 +5577,7 @@ function bundleCard() {
   card.append(el("ol", { class: "cn-steps" },
     el("li", { text: "You need the Claude Desktop app installed (claude.ai/download). Using claude.ai in the browser instead? See the note below." }),
     el("li", { text: released
-      ? "Download the installer with the button below; it picks the right file for this computer."
+      ? "Download the installer with the button below; it is the best guess for this computer, and the note under the buttons says when to pick a different file."
       : "Download the installer from the releases page below; the note under the button says which file matches this computer." }),
     el("li", { text: "Double-click the downloaded file. Claude Desktop opens and asks to install dbtrail; accept." }),
     el("li", { text: "Claude then asks for two things. In \"Console / MCP endpoint URL\" paste the address from step 2; in \"Access token\" paste the token from step 1." }),
@@ -5586,12 +5588,12 @@ function bundleCard() {
       el("a", { class: "btn btn-sm", href: "https://github.com/dbtrail/dbtrail/releases/download/v" + ver + "/" + asset, text: "Download " + asset }),
       el("a", { class: "btn btn-sm btn-ghost", href: "https://github.com/dbtrail/dbtrail/releases/tag/v" + ver, target: "_blank", rel: "noopener", text: "All downloads for v" + ver })));
     card.append(el("p", { class: "form-hint", text:
-      "The download matches this console's version (v" + ver + "). If the link lands on a page saying Not Found, that older release predates the installer; use All downloads and take the newest release's file instead." }));
+      "The download matches this console's version (v" + ver + ") and guesses your computer (Macs are assumed Apple chip). Intel Mac? Use All downloads and take dbtrail-darwin-amd64.mcpb. Windows has no installer yet; use the claude.ai note below instead. If the link lands on Not Found, that older release predates the installer; take the newest release's file from All downloads." }));
   } else {
     card.append(el("div", { class: "cn-links" },
       el("a", { class: "btn btn-sm", href: "https://github.com/dbtrail/dbtrail/releases", target: "_blank", rel: "noopener", text: "Open the releases page" })));
     card.append(el("p", { class: "form-hint", text:
-      "This console is a development build, so there is no matching download link. Open the releases page, take the NEWEST release, and download the file for this computer: Mac is dbtrail-darwin-arm64.mcpb, Windows is dbtrail-windows-amd64.mcpb, Linux is dbtrail-linux-amd64.mcpb." }));
+      "This console is a development build, so there is no matching download link. Open the releases page, take the NEWEST release, and download the file for this computer: Mac with Apple chip is dbtrail-darwin-arm64.mcpb, Intel Mac is dbtrail-darwin-amd64.mcpb, Linux is dbtrail-linux-amd64.mcpb (or -arm64). Windows has no installer yet; use the claude.ai note below instead." }));
   }
   card.append(el("p", { class: "form-hint", text:
     "Using claude.ai in the browser instead of the desktop app? If this console is reachable from the internet, open claude.ai, go to Settings, then Connectors, then Add custom connector, and paste the same address and token there. On a private network (only reachable from inside), use the desktop app instead." }));

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -5449,8 +5449,8 @@ function copyText(text, what) {
 function buildConnect(servers, tokStatus, minted) {
   const v = VIEW(); clear(v);
   const sub = el("p", { class: "page-sub" },
-    "Let an AI assistant query this console: the same read-only tools and result caps as this UI. ",
-    el("b", { text: "A token is only ever shown once, at the moment you generate it." }));
+    "Let Claude (or another AI assistant) read this console and answer questions about your database history. Three steps: create an access token, copy this console's address, and give both to Claude. The AI sees the same read-only view as this page; it can never change your data. ",
+    el("b", { text: "Your token is shown only once, right after you create it, so copy it somewhere safe at that moment." }));
   v.append(pageHead("Connect AI", sub));
 
   const cards = el("div", { class: "cards" });
@@ -5466,7 +5466,7 @@ function buildConnect(servers, tokStatus, minted) {
 // capability gate (the endpoint may have just become usable), and re-renders
 // the view with the plaintext displayed once.
 async function mintMCPToken(rotate) {
-  if (rotate && !window.confirm("Rotate the MCP token? The current value stops working immediately and every connected AI client will need the new one.")) return;
+  if (rotate && !window.confirm("Replace the token? The current one stops working right away, and every AI client that used it will need the new one. The new value appears on the next screen, ready to copy.")) return;
   // Only the mutation itself may report failure — once the POST succeeded the
   // token EXISTS (and on rotate the old one is already dead), so a failing
   // follow-up refresh must never toast "generation failed".
@@ -5483,14 +5483,14 @@ async function mintMCPToken(rotate) {
 }
 
 async function revokeMCPToken() {
-  if (!window.confirm("Revoke the managed MCP token? Connected AI clients stop working immediately.")) return;
+  if (!window.confirm("Delete the token? Every AI client using it stops working right away. You can create a new token here whenever you want.")) return;
   try {
     await api("/api/mcp-token", { method: "DELETE" });
   } catch (err) {
     toastError("Revoke failed: " + (err.message || err));
     return;
   }
-  toast("Managed MCP token revoked");
+  toast("Token deleted. AI clients that used it are disconnected");
   try { await gateCapabilities(); } catch (_) {}
   renderConnect();
 }
@@ -5499,43 +5499,45 @@ async function revokeMCPToken() {
 // without leaving the UI. The token value renders exactly once — right after
 // generation — and is otherwise represented only by its creation date.
 function mcpTokenCard(tok, minted) {
-  const card = el("div", { class: "card" }, el("div", { class: "card-title", text: "Access token" }));
+  const card = el("div", { class: "card" }, el("div", { class: "card-title", text: "Step 1 · Access token" }));
   // The one-time plaintext renders UNCONDITIONALLY — a failed status fetch
   // must never swallow a token that was just minted (after a rotate, it is
   // the only valid credential and cannot be re-displayed).
   if (minted) {
-    card.append(el("p", { class: "stg-hint", text: "Token generated. Copy it now; it is not stored and will never show again:" }));
+    card.append(el("p", { class: "stg-hint", text: "Here is your new token. Copy it NOW and keep it somewhere safe (a password manager is ideal). It is not stored anywhere, so this is the only time it will ever be on screen:" }));
     card.append(el("div", { class: "cn-urlrow" },
       el("code", { class: "stg-code cn-url", text: minted }),
       el("button", { class: "btn btn-sm", type: "button", text: "Copy", onclick: () => copyText(minted, "MCP token") })));
   }
   if (!tok) {
-    card.append(el("p", { class: "stg-hint", text: "Token status unavailable. Reload the page to retry." }));
+    card.append(el("p", { class: "stg-hint", text: "We could not check whether a token exists. Reload the page to try again." }));
     return card;
   }
   if (tok.managed) {
     if (!minted) {
       card.append(el("p", { class: "stg-hint", text:
-        "A managed token is active" + (tok.created_at ? " (created " + utcLabel(tok.created_at) + ")" : "") +
-        ". Its value is not stored and cannot be re-displayed; rotate to get a fresh one." }));
+        "You already created a token" + (tok.created_at ? " on " + utcLabel(tok.created_at) : "") +
+        ". Its value is not saved anywhere, so it cannot be shown again. Lost it? Click New token: you get a fresh value to copy, and the old one stops working." }));
     }
     if (tok.read_only) {
       card.append(el("p", { class: "form-hint", text:
-        "The token file was written by a newer bintrail; the token works, but rotate/revoke are unavailable from this build." }));
+        "This token was created by a newer version of bintrail. It keeps working, but this page cannot replace or delete it; upgrading the console brings those buttons back." }));
     } else {
       card.append(el("div", { class: "cn-links" },
-        el("button", { class: "btn btn-sm", type: "button", text: "Rotate token", onclick: () => mintMCPToken(true) }),
-        el("button", { class: "btn btn-sm btn-ghost", type: "button", text: "Revoke", onclick: revokeMCPToken })));
+        el("button", { class: "btn btn-sm", type: "button", text: "New token", onclick: () => mintMCPToken(true) }),
+        el("button", { class: "btn btn-sm btn-ghost", type: "button", text: "Delete token", onclick: revokeMCPToken })));
     }
   } else if (!minted) {
     card.append(el("p", { class: "stg-hint", text:
-      "AI clients authenticate with a token (password login is a browser credential and cannot be used by them). Generate one here: no flags, no environment variables, no restart. The token only grants the read-only MCP tools; it cannot manage this console." }));
+      "Claude cannot use your console password; it needs its own token, a long random key that works as its password. Click Generate token and copy the value that appears. The token only lets an AI read your history; it cannot change data or console settings." }));
     card.append(el("div", { class: "cn-links" },
       el("button", { class: "btn btn-sm", type: "button", text: "Generate token", onclick: () => mintMCPToken(false) })));
   }
   if (tok.static) {
-    card.append(el("p", { class: "form-hint", text:
-      "A static token from --token / BINTRAIL_CONSOLE_TOKEN is also configured. It keeps working, but it is environment-owned and cannot be managed here." }));
+    card.append(el("p", { class: "form-hint" },
+      "A fixed token set outside this page also works (CLI: ",
+      el("code", { text: "--token" }), " or ", el("code", { text: "BINTRAIL_CONSOLE_TOKEN" }),
+      "). It is managed wherever it was set up, not here."));
   }
   return card;
 }
@@ -5544,10 +5546,10 @@ function mcpTokenCard(tok, minted) {
 // how-to-enable explanation when no token is configured (capabilities.mcp) —
 // never a URL presented as ready that would only ever answer 403.
 function mcpEndpointCard(servers) {
-  const card = el("div", { class: "card" }, el("div", { class: "card-title", text: "MCP endpoint" }));
+  const card = el("div", { class: "card" }, el("div", { class: "card-title", text: "Step 2 · Console address" }));
   if (!capsCache.mcp) {
     card.append(el("p", { class: "stg-hint", text:
-      "MCP is not available yet: this console has no access token configured. Generate one in the Access token card above and this card becomes a ready-to-copy URL." }));
+      "This card fills in after step 1: create the access token and this console's address appears here, ready to copy." }));
     return card;
   }
   const url = mcpURL(servers);
@@ -5556,10 +5558,10 @@ function mcpEndpointCard(servers) {
     el("button", { class: "btn btn-sm", type: "button", text: "Copy", onclick: () => copyText(url, "MCP URL") })));
   if ((servers || []).length > 1) {
     card.append(el("p", { class: "form-hint", text:
-      "This URL targets the server selected in the sidebar; the bare /mcp targets the console's default server. Switch servers to get each one's URL." }));
+      "This address points at the server picked in the left sidebar (the Server box at the top). To connect a different server, pick it there first and copy again: each server has its own address." }));
   }
   card.append(el("p", { class: "form-hint", text:
-    "The credential is the console access token from the card above (or --token / BINTRAIL_CONSOLE_TOKEN), sent as an Authorization: Bearer header." }));
+    "When Claude asks for the URL, paste this address. When it asks for the access token, paste the one from step 1." }));
   return card;
 }
 
@@ -5567,24 +5569,32 @@ function mcpEndpointCard(servers) {
 // RUNNING version. Best-effort: a release that predates the bundle artifact
 // 404s the direct link, so a releases-page path is always offered too.
 function bundleCard() {
-  const card = el("div", { class: "card" }, el("div", { class: "card-title", text: "Claude Desktop bundle" }));
+  const card = el("div", { class: "card" }, el("div", { class: "card-title", text: "Step 3 · Add it to Claude" }));
   const ver = String(capsCache.version || "").replace(/^v/, "");
   const released = /^\d+\.\d+\.\d+$/.test(ver);
-  card.append(el("p", { class: "stg-hint", text:
-    "Install the bundle in Claude Desktop (double-click), then paste the URL above and your console token: no config files to edit." }));
+  card.append(el("ol", { class: "cn-steps" },
+    el("li", { text: "You need the Claude Desktop app installed (claude.ai/download). Using claude.ai in the browser instead? See the note below." }),
+    el("li", { text: released
+      ? "Download the installer with the button below; it picks the right file for this computer."
+      : "Download the installer from the releases page below; the note under the button says which file matches this computer." }),
+    el("li", { text: "Double-click the downloaded file. Claude Desktop opens and asks to install dbtrail; accept." }),
+    el("li", { text: "Claude then asks for two things. In \"Console / MCP endpoint URL\" paste the address from step 2; in \"Access token\" paste the token from step 1." }),
+    el("li", { text: "Open a new chat and try: what changed in my database in the last hour?" })));
   if (released) {
     const asset = "dbtrail-" + guessPlatform() + ".mcpb";
     card.append(el("div", { class: "cn-links" },
       el("a", { class: "btn btn-sm", href: "https://github.com/dbtrail/dbtrail/releases/download/v" + ver + "/" + asset, text: "Download " + asset }),
       el("a", { class: "btn btn-sm btn-ghost", href: "https://github.com/dbtrail/dbtrail/releases/tag/v" + ver, target: "_blank", rel: "noopener", text: "All downloads for v" + ver })));
     card.append(el("p", { class: "form-hint", text:
-      "The link matches this console's version (v" + ver + "). Older releases don't carry the bundle; if the download 404s, pick a newer release from the releases page." }));
+      "The download matches this console's version (v" + ver + "). If the link lands on a page saying Not Found, that older release predates the installer; use All downloads and take the newest release's file instead." }));
   } else {
     card.append(el("div", { class: "cn-links" },
       el("a", { class: "btn btn-sm", href: "https://github.com/dbtrail/dbtrail/releases", target: "_blank", rel: "noopener", text: "Open the releases page" })));
     card.append(el("p", { class: "form-hint", text:
-      "This console is an unversioned build, so no exact bundle link can be derived; pick the bundle matching your platform from the latest release." }));
+      "This console is a development build, so there is no matching download link. Open the releases page, take the NEWEST release, and download the file for this computer: Mac is dbtrail-darwin-arm64.mcpb, Windows is dbtrail-windows-amd64.mcpb, Linux is dbtrail-linux-amd64.mcpb." }));
   }
+  card.append(el("p", { class: "form-hint", text:
+    "Using claude.ai in the browser instead of the desktop app? If this console is reachable from the internet, open claude.ai, go to Settings, then Connectors, then Add custom connector, and paste the same address and token there. On a private network (only reachable from inside), use the desktop app instead." }));
   return card;
 }
 
@@ -5610,9 +5620,9 @@ function otherClientsPanel(servers) {
   }, null, 2);
   const panel = el("section", { class: "ov-panel cn-other", style: "margin-top:18px" });
   const adv = el("details", { class: "form-advanced", style: "margin-top:0" },
-    el("summary", { class: "form-adv-summary", text: "Other clients (raw config)" }));
+    el("summary", { class: "form-adv-summary", text: "Other AI tools (technical)" }));
   adv.append(el("p", { class: "form-hint", text:
-    "For claude_desktop_config.json, or any client that launches stdio MCP servers: bintrail-mcp bridges stdio to this console. Replace the placeholder with your console token:" }));
+    "For claude_desktop_config.json, or any client that launches stdio MCP servers: bintrail-mcp bridges stdio to this console. The token travels as an Authorization: Bearer header. Replace the placeholder with your console token:" }));
   adv.append(el("pre", { class: "stg-code cn-snippet", text: snippet }));
   adv.append(el("button", { class: "btn btn-sm", type: "button", text: "Copy snippet", onclick: () => copyText(snippet, "Config snippet") }));
   adv.append(el("p", { class: "form-hint", text:

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -2557,6 +2557,15 @@ button { font-family: inherit; }
 .cards .card .hstat-muted, .cards .card .hstale { color: var(--ink-2); }
 .cards .card .hstale { border-top-color: oklch(0.5 0.05 320 / 0.22); }
 
+/* the Connect AI step list: a real <ol> so the order is structural, not
+   prose — the audience is Claude users following it literally. */
+.cn-steps { margin: 0 0 14px; padding-left: 19px; display: flex; flex-direction: column; gap: 8px; font-size: 13px; color: var(--ink-2); }
+.cn-steps li::marker { color: var(--ink-3); font-weight: 600; }
+/* inline flag/env names in hints never wrap mid-token: a --flag broken
+   across lines reads as "- -flag" to the non-technical audience this page
+   addresses. */
+.card .form-hint code { white-space: nowrap; font-family: var(--f-mono); font-size: 11.5px; }
+
 /* neutral buttons warm on touch — product blue stays the pressed accent.
    Excluded: primary (white-on-gradient, own guard), ghost (borderless is
    its idiom), accent (white label on a warm fill — orange text there would

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -3583,11 +3583,28 @@ try {
     ? ok("tropical: the haze is anchored to scroll content, not the viewport")
     : bad("tropical: the haze is anchored to scroll content, not the viewport", tropSide.attachment);
 
-  // ── Scenario 17c — Connect AI reads as steps, not as jargon. The page's
+
+  // The card tint rotation, on the page from the user's own screenshot. Two
+  // distinct tinted grounds prove rotation; "not white" alone would pass a
+  // single flat tint.
+  await page.evaluate(() => navigate("storage"));
+  await page.waitForFunction(() => location.pathname === "/storage" && document.querySelectorAll(".cards .card").length >= 2, { timeout: 10000 });
+  const tints = await page.evaluate(() => {
+    const cards = Array.from(document.querySelectorAll(".cards .card")).slice(0, 2);
+    return cards.map((c) => getComputedStyle(c).backgroundColor);
+  });
+  (tints.length === 2 && tints[0] !== tints[1] && !tints.includes("rgb(255, 255, 255)") && !tints.includes("rgba(0, 0, 0, 0)"))
+    ? ok("tropical: config cards rotate through the home's tint palette")
+    : bad("tropical: config cards rotate through the home's tint palette", JSON.stringify(tints));
+
+  // ── Scenario 17g — Connect AI reads as steps, not as jargon. The page's
   // audience is Claude users, mostly non-technical; the rewrite turned the
   // three cards into an explicit Step 1/2/3 with a literal ordered list.
   // Structure is the guard (titles, the <ol>, the one-time warning), so a
   // future copy edit can rewrite words but not silently dissolve the steps.
+  // Limit worth naming: run.sh builds without -ldflags, so this only ever
+  // exercises the UNVERSIONED bundle arm; the released arm's copy is not
+  // photographed here.
   await page.evaluate(() => navigate("connect"));
   await page.waitForFunction(() => location.pathname === "/connect"
     && document.querySelectorAll(".view .card").length >= 3, { timeout: 10000 });
@@ -3611,19 +3628,6 @@ try {
   (cn.subOnce && cn.addrCopy)
     ? ok("connect: the one-time-token warning leads the page and the address is one click to copy")
     : bad("connect: the one-time-token warning leads the page and the address is one click to copy", JSON.stringify(cn));
-
-  // The card tint rotation, on the page from the user's own screenshot. Two
-  // distinct tinted grounds prove rotation; "not white" alone would pass a
-  // single flat tint.
-  await page.evaluate(() => navigate("storage"));
-  await page.waitForFunction(() => location.pathname === "/storage" && document.querySelectorAll(".cards .card").length >= 2, { timeout: 10000 });
-  const tints = await page.evaluate(() => {
-    const cards = Array.from(document.querySelectorAll(".cards .card")).slice(0, 2);
-    return cards.map((c) => getComputedStyle(c).backgroundColor);
-  });
-  (tints.length === 2 && tints[0] !== tints[1] && !tints.includes("rgb(255, 255, 255)") && !tints.includes("rgba(0, 0, 0, 0)"))
-    ? ok("tropical: config cards rotate through the home's tint palette")
-    : bad("tropical: config cards rotate through the home's tint palette", JSON.stringify(tints));
 
   // ── Scenario 17f — the Events skeleton is visible (#1397) ──
   //

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -3583,6 +3583,35 @@ try {
     ? ok("tropical: the haze is anchored to scroll content, not the viewport")
     : bad("tropical: the haze is anchored to scroll content, not the viewport", tropSide.attachment);
 
+  // ── Scenario 17c — Connect AI reads as steps, not as jargon. The page's
+  // audience is Claude users, mostly non-technical; the rewrite turned the
+  // three cards into an explicit Step 1/2/3 with a literal ordered list.
+  // Structure is the guard (titles, the <ol>, the one-time warning), so a
+  // future copy edit can rewrite words but not silently dissolve the steps.
+  await page.evaluate(() => navigate("connect"));
+  await page.waitForFunction(() => location.pathname === "/connect"
+    && document.querySelectorAll(".view .card").length >= 3, { timeout: 10000 });
+  const cn = await page.evaluate(() => {
+    const titles = Array.from(document.querySelectorAll(".view .card .card-title")).map((n) => n.textContent);
+    const addrCard = Array.from(document.querySelectorAll(".view .card")).find((c) =>
+      /Step 2/.test((c.querySelector(".card-title") || {}).textContent || ""));
+    return {
+      steps: titles.filter((t) => /^Step [123] · /.test(t)).length,
+      olItems: document.querySelectorAll(".cn-steps li").length,
+      subOnce: /shown only once/.test((document.querySelector(".page-sub") || {}).textContent || ""),
+      addrCopy: addrCard ? Array.from(addrCard.querySelectorAll("button")).some((b) => b.textContent === "Copy") : false,
+    };
+  });
+  (cn.steps === 3)
+    ? ok("connect: the three cards are literal steps 1, 2 and 3")
+    : bad("connect: the three cards are literal steps 1, 2 and 3", JSON.stringify(cn));
+  (cn.olItems >= 5)
+    ? ok("connect: step 3 is an ordered list a non-technical user can follow")
+    : bad("connect: step 3 is an ordered list a non-technical user can follow", "items " + cn.olItems);
+  (cn.subOnce && cn.addrCopy)
+    ? ok("connect: the one-time-token warning leads the page and the address is one click to copy")
+    : bad("connect: the one-time-token warning leads the page and the address is one click to copy", JSON.stringify(cn));
+
   // The card tint rotation, on the page from the user's own screenshot. Two
   // distinct tinted grounds prove rotation; "not white" alone would pass a
   // single flat tint.


### PR DESCRIPTION
## What

The Connect AI page rewritten for its real audience: Claude users, mostly non-technical. The three cards become literal steps (Step 1 · Access token, Step 2 · Console address, Step 3 · Add it to Claude), step 3 is an actual ordered list that says where every value goes (quoting Claude Desktop's own field names verbatim from the bundle manifest), and nothing is left implicit: what the token is, why it shows only once, what New token does to the old one, where claude.ai browser users go instead, and which file matches which computer.

Jargon left the main path: rotate/revoke became New token / Delete token (confirms and toasts included), the Bearer-header detail moved into the technical accordion (now "Other AI tools (technical)"), and every "(CLI: ...)" mention stays marked.

## Honesty fixes the review forced

- **No phantom Windows download**: no Windows .mcpb has ever been published (verified against the release history and the build matrix), yet the button synthesized `dbtrail-windows-amd64.mcpb` on Windows browsers. `guessPlatform` now returns empty there and the card offers the claude.ai connector path instead; the 404 hint stopped blaming release age for files that never existed.
- Intel Macs are told about `dbtrail-darwin-amd64.mcpb` instead of being handed the arm64 file that installs and then cannot run.
- The read-only-token branch no longer instructs the user to click a button that branch hides.
- docs/connect-ai.md renumbered to match the UI's steps (they disagreed on every number), platform note corrected (Linux = CI-built always; macOS = hand-attached, best-effort, with the `make mcpb` escape hatch restored), button names updated here and in docs/console.md.

## Verification

e2e 319/319 including new scenario 17g (three literal step cards, the ordered list, the one-time warning, the copy button), seen red against the old page (0 steps found) before green. Scenario comment names its limit honestly: run.sh builds unversioned, so only the development-build arm of the bundle card is photographed. Two full review passes; pass 2 caught pass 1's own incomplete fix (the Windows button), which is why there were two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
