### PR TITLE
console: Connect AI as three short steps with a drawn install dialog

### DIFF
--- a/docs/connect-ai.md
+++ b/docs/connect-ai.md
@@ -25,9 +25,9 @@ server, exactly like the console's Time-travel tab; without one the tool says so
 
 ## Step 1 — you need the console with a token
 
-> The numbers here match the cards on the console's **Connect AI** page
-> (Step 1 · Access token, Step 2 · Console address, Step 3 · Add it to
-> Claude), so you can follow either surface.
+> The numbers here match the numbered cards on the console's **Connect AI**
+> page (1 Create a token, 2 Copy the address, 3 Add it to Claude), so you can
+> follow either surface.
 
 The AI connects to your **web console**, which serves an MCP endpoint at
 `/mcp`. If you already run `bintrail-console` (standalone `serve`, `watch`, or
@@ -35,7 +35,7 @@ the Docker stack), you're nearly done — the AI client just needs an **access
 token**, and you mint one without leaving the browser:
 
 Open **Settings → Connect AI** in the sidebar. If no token is configured yet,
-the **Access token** card has a **Generate token** button — click it, copy the
+the **Create a token** card has a **Generate token** button — click it, copy the
 value it shows (it appears exactly once and is never stored), and you're done.
 No flags, no environment variables, no restart. The same card replaces the
 token (**New token**) or deletes it (**Delete token**) later. The generated token is scoped to the MCP tools only —

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -5449,8 +5449,7 @@ function copyText(text, what) {
 function buildConnect(servers, tokStatus, minted) {
   const v = VIEW(); clear(v);
   const sub = el("p", { class: "page-sub" },
-    "Let Claude (or another AI assistant) read this console and answer questions about your database history. Three steps: create an access token, copy this console's address, and give both to Claude. The AI sees the same read-only view as this page; it can never change your data. ",
-    el("b", { text: "Your token is shown only once, right after you create it, so copy it somewhere safe at that moment." }));
+    "Three steps and Claude can answer questions about your database history. It can only read; it can never change anything.");
   v.append(pageHead("Connect AI", sub));
 
   const cards = el("div", { class: "cards" });
@@ -5495,16 +5494,36 @@ async function revokeMCPToken() {
   renderConnect();
 }
 
+// cnCard: a step card whose number is a BADGE, not prose. The three cards are
+// the whole how-to, so each stays at one action plus one short line; every
+// conditional or rare fact folds into cnFine below.
+function cnCard(num, title) {
+  return el("div", { class: "card cn-card" },
+    el("div", { class: "card-title cn-title" },
+      el("span", { class: "cn-num", text: String(num) }),
+      title));
+}
+
+// cnFine: collapsed fine print. The audience is non-technical, and the #1430
+// step rewrite proved that spelling every contingency out in the open reads
+// as a wall of text; the facts stay on the page, but folded.
+function cnFine(label, ...kids) {
+  const d = el("details", { class: "form-advanced cn-fine" },
+    el("summary", { class: "form-adv-summary", text: label }));
+  for (const k of kids) d.append(k);
+  return d;
+}
+
 // mcpTokenCard (#1052): generate, rotate, and revoke the managed MCP token
 // without leaving the UI. The token value renders exactly once — right after
 // generation — and is otherwise represented only by its creation date.
 function mcpTokenCard(tok, minted) {
-  const card = el("div", { class: "card" }, el("div", { class: "card-title", text: "Step 1 · Access token" }));
-  // The one-time plaintext renders UNCONDITIONALLY — a failed status fetch
+  const card = cnCard(1, "Create a token");
+  // The one-time plaintext renders UNCONDITIONALLY: a failed status fetch
   // must never swallow a token that was just minted (after a rotate, it is
   // the only valid credential and cannot be re-displayed).
   if (minted) {
-    card.append(el("p", { class: "stg-hint", text: "Here is your new token. Copy it NOW and keep it somewhere safe (a password manager is ideal). It is not stored anywhere, so this is the only time it will ever be on screen:" }));
+    card.append(el("p", { class: "stg-hint", text: "Copy it now and keep it somewhere safe. It will never be shown again:" }));
     card.append(el("div", { class: "cn-urlrow" },
       el("code", { class: "stg-code cn-url", text: minted }),
       el("button", { class: "btn btn-sm", type: "button", text: "Copy", onclick: () => copyText(minted, "Access token") })));
@@ -5516,30 +5535,30 @@ function mcpTokenCard(tok, minted) {
   if (tok.managed) {
     if (!minted) {
       card.append(el("p", { class: "stg-hint", text:
-        "A token already exists" + (tok.created_at ? " (created " + utcLabel(tok.created_at) + ")" : "") +
-        ". Its value is not saved anywhere, so it cannot be shown again." +
+        "You already have a token" + (tok.created_at ? ", created " + utcLabel(tok.created_at) : "") +
+        ". It cannot be shown again." +
         // read_only hides the buttons below, so never tell that user to click one
-        (tok.read_only ? "" : " Lost it? Click New token: you get a fresh value to copy, and the old one stops working.") }));
+        (tok.read_only ? "" : " Lost it? New token gives you a fresh one; the old one stops working.") }));
     }
     if (tok.read_only) {
-      card.append(el("p", { class: "form-hint", text:
-        "This token was created by a newer version of bintrail. It keeps working, but this page cannot replace or delete it; upgrading the console brings those buttons back." }));
+      card.append(cnFine("Why is there no button here?",
+        el("p", { class: "form-hint", text: "This token was created by a newer version of bintrail. It keeps working, but this page cannot replace or delete it; upgrading the console brings those buttons back." })));
     } else {
       card.append(el("div", { class: "cn-links" },
         el("button", { class: "btn btn-sm", type: "button", text: "New token", onclick: () => mintMCPToken(true) }),
         el("button", { class: "btn btn-sm btn-ghost", type: "button", text: "Delete token", onclick: revokeMCPToken })));
     }
   } else if (!minted) {
-    card.append(el("p", { class: "stg-hint", text:
-      "Claude cannot use your console password; it needs its own token, a long random key that works as its password. Click Generate token and copy the value that appears. The token only lets an AI read your history; it cannot change data or console settings." }));
+    card.append(el("p", { class: "stg-hint", text: "The token is Claude's password for this console. It is shown only once, so copy it right away." }));
     card.append(el("div", { class: "cn-links" },
       el("button", { class: "btn btn-sm", type: "button", text: "Generate token", onclick: () => mintMCPToken(false) })));
   }
   if (tok.static) {
-    card.append(el("p", { class: "form-hint" },
-      "A fixed token set outside this page also works (CLI: ",
-      el("code", { text: "--token" }), " or ", el("code", { text: "BINTRAIL_CONSOLE_TOKEN" }),
-      "). It is managed wherever it was set up, not here."));
+    card.append(cnFine("A token was set at startup",
+      el("p", { class: "form-hint" },
+        "That fixed token also works (CLI: ",
+        el("code", { text: "--token" }), " or ", el("code", { text: "BINTRAIL_CONSOLE_TOKEN" }),
+        "). It is managed wherever it was set up, not here.")));
   }
   return card;
 }
@@ -5548,62 +5567,90 @@ function mcpTokenCard(tok, minted) {
 // how-to-enable explanation when no token is configured (capabilities.mcp) —
 // never a URL presented as ready that would only ever answer 403.
 function mcpEndpointCard(servers) {
-  const card = el("div", { class: "card" }, el("div", { class: "card-title", text: "Step 2 · Console address" }));
+  const card = cnCard(2, "Copy the address");
   if (!capsCache.mcp) {
-    card.append(el("p", { class: "stg-hint", text:
-      "This card fills in after step 1: create the access token and this console's address appears here, ready to copy." }));
+    card.append(el("p", { class: "stg-hint", text: "Finish step 1 first; this console's address then appears here, ready to copy." }));
     return card;
   }
   const url = mcpURL(servers);
   card.append(el("div", { class: "cn-urlrow" },
     el("code", { class: "stg-code cn-url", text: url }),
     el("button", { class: "btn btn-sm", type: "button", text: "Copy", onclick: () => copyText(url, "Console address") })));
+  card.append(el("p", { class: "stg-hint", text: "Claude will ask for a URL; this is the one to paste." }));
   if ((servers || []).length > 1) {
-    card.append(el("p", { class: "form-hint", text:
-      "This address points at the server picked in the left sidebar (the Server box at the top). To connect a different server, pick it there first and copy again: each server has its own address." }));
+    card.append(cnFine("Connecting a different server?",
+      el("p", { class: "form-hint", text: "This address points at the server picked in the left sidebar (the Server box at the top). Pick a different server there and copy again; each server has its own address." })));
   }
-  card.append(el("p", { class: "form-hint", text:
-    "When Claude asks for the URL, paste this address. When it asks for the access token, paste the one from step 1." }));
   return card;
 }
 
+// claudeAskMock: a drawn miniature of Claude Desktop's install dialog, so the
+// user recognizes the two fields instead of reading a paragraph about them.
+// The field labels are quoted VERBATIM from
+// build/packaging/mcpb/manifest.template.json; if the bundle renames them the
+// picture lies, so they change together.
+function claudeAskMock() {
+  const field = (n, label, hint) => el("div", { class: "cn-mock-row" },
+    el("div", { class: "cn-mock-label", text: label }),
+    el("div", { class: "cn-mock-field" },
+      el("span", { class: "cn-chip", text: String(n) }),
+      el("span", { class: "cn-mock-paste", text: hint })));
+  return el("div", { class: "cn-mock" },
+    el("div", { class: "cn-mock-bar" }, el("span", { class: "cn-mock-dots" }), "Claude Desktop"),
+    field(2, "Console / MCP endpoint URL", "paste the address from step 2"),
+    field(1, "Access token", "paste the token from step 1"));
+}
+
+// askExample: the payoff line, drawn as the chat message it becomes.
+function askExample() {
+  return el("div", { class: "cn-ask" },
+    "Then ask Claude: ",
+    el("b", { text: "\u201Cwhat changed in my database in the last hour?\u201D" }));
+}
+
 // bundleCard links the .mcpb bundle (one-click Claude Desktop install) for the
-// RUNNING version. Best-effort: a release that predates the bundle artifact
-// 404s the direct link, so a releases-page path is always offered too.
+// RUNNING version. Honesty rules carried from #1430: never render a download
+// that can only 404 (no Windows bundle has ever been published, and an
+// unversioned build has no matching asset), and the dialog mock's field
+// labels come verbatim from the manifest.
 function bundleCard() {
-  const card = el("div", { class: "card" }, el("div", { class: "card-title", text: "Step 3 · Add it to Claude" }));
+  const card = cnCard(3, "Add it to Claude");
   const ver = String(capsCache.version || "").replace(/^v/, "");
   const released = /^\d+\.\d+\.\d+$/.test(ver);
-  card.append(el("ol", { class: "cn-steps" },
-    el("li", { text: "You need the Claude Desktop app installed (claude.ai/download). Using claude.ai in the browser instead? See the note below." }),
-    el("li", { text: released && guessPlatform()
-      ? "Download the installer with the button below; it is the best guess for this computer, and the note under the buttons says when to pick a different file."
-      : "Download the installer from the releases page below; the note under the button says which file matches this computer." }),
-    el("li", { text: "Double-click the downloaded file. Claude Desktop opens and asks to install dbtrail; accept." }),
-    el("li", { text: "Claude then asks for two things. In \"Console / MCP endpoint URL\" paste the address from step 2; in \"Access token\" paste the token from step 1." }),
-    el("li", { text: "Open a new chat and try: what changed in my database in the last hour?" })));
   const plat = guessPlatform();
+  const relTag = "https://github.com/dbtrail/dbtrail/releases/tag/v" + ver;
   if (released && plat) {
     const asset = "dbtrail-" + plat + ".mcpb";
+    card.append(el("p", { class: "stg-hint", text: "Get the Claude Desktop app (claude.ai/download), then download this installer and double-click it:" }));
     card.append(el("div", { class: "cn-links" },
-      el("a", { class: "btn btn-sm", href: "https://github.com/dbtrail/dbtrail/releases/download/v" + ver + "/" + asset, target: "_blank", rel: "noopener", text: "Download " + asset }),
-      el("a", { class: "btn btn-sm btn-ghost", href: "https://github.com/dbtrail/dbtrail/releases/tag/v" + ver, target: "_blank", rel: "noopener", text: "All downloads for v" + ver })));
-    card.append(el("p", { class: "form-hint", text:
-      "The download matches this console's version (v" + ver + ") and guesses your computer (Macs are assumed Apple chip). Intel Mac? Use All downloads and take dbtrail-darwin-amd64.mcpb. If the link lands on Not Found, that release shipped without this file; take the newest release's file from All downloads instead." }));
+      el("a", { class: "btn btn-sm", href: "https://github.com/dbtrail/dbtrail/releases/download/v" + ver + "/" + asset, target: "_blank", rel: "noopener", text: "Download the installer" }),
+      el("a", { class: "btn btn-sm btn-ghost", href: relTag, target: "_blank", rel: "noopener", text: "All downloads" })));
+    card.append(el("p", { class: "stg-hint", text: "Claude opens and asks for two things:" }));
+    card.append(claudeAskMock());
+    card.append(askExample());
+    card.append(cnFine("Intel Mac, Windows, or claude.ai in the browser?",
+      el("p", { class: "form-hint", text: "The download button guesses this computer from the browser, and Macs are assumed to have an Apple chip. On an Intel Mac, use All downloads and take dbtrail-darwin-amd64.mcpb (v" + ver + " matches this console)." }),
+      el("p", { class: "form-hint", text: "If the download lands on Not Found, that release shipped without the installer; take the newest release's file from All downloads instead." }),
+      el("p", { class: "form-hint", text: "Windows has no installer yet. Use claude.ai in the browser: if this console is reachable from the internet, open Settings, then Connectors, then Add custom connector, and paste the same address and token. On a private network (only reachable from inside), the browser path cannot reach it; use the desktop app on a Mac or Linux machine instead." })));
   } else if (released) {
-    // Windows on a released build: never render a download that can only 404.
-    card.append(el("div", { class: "cn-links" },
-      el("a", { class: "btn btn-sm", href: "https://github.com/dbtrail/dbtrail/releases/tag/v" + ver, target: "_blank", rel: "noopener", text: "All downloads for v" + ver })));
-    card.append(el("p", { class: "form-hint", text:
-      "There is no Windows installer yet. Use the claude.ai note below instead; it needs no download at all." }));
+    // Windows on a released build: the desktop bundle does not exist, so the
+    // browser connector IS the path, not a footnote.
+    card.append(el("p", { class: "stg-hint", text: "There is no Windows installer yet. Connect from claude.ai in the browser instead: open Settings, then Connectors, then Add custom connector, and paste the address and token from steps 1 and 2." }));
+    card.append(askExample());
+    card.append(cnFine("Console on a private network?",
+      el("p", { class: "form-hint", text: "The browser path needs this console to be reachable from the internet. On a private network (only reachable from inside), install the desktop bundle on a Mac or Linux machine instead; All downloads below has the files." }),
+      el("p", { class: "form-hint" }, el("a", { href: relTag, target: "_blank", rel: "noopener", text: "All downloads for v" + ver }))));
   } else {
+    card.append(el("p", { class: "stg-hint", text: "Get the Claude Desktop app (claude.ai/download), then download the newest installer for this computer and double-click it:" }));
     card.append(el("div", { class: "cn-links" },
       el("a", { class: "btn btn-sm", href: "https://github.com/dbtrail/dbtrail/releases", target: "_blank", rel: "noopener", text: "Open the releases page" })));
-    card.append(el("p", { class: "form-hint", text:
-      "This console is a development build, so there is no matching download link. Open the releases page, take the NEWEST release, and download the file for this computer: Mac with Apple chip is dbtrail-darwin-arm64.mcpb, Intel Mac is dbtrail-darwin-amd64.mcpb, Linux is dbtrail-linux-amd64.mcpb (or -arm64). Windows has no installer yet; use the claude.ai note below instead." }));
+    card.append(el("p", { class: "stg-hint", text: "Claude opens and asks for two things:" }));
+    card.append(claudeAskMock());
+    card.append(askExample());
+    card.append(cnFine("Which file is for this computer?",
+      el("p", { class: "form-hint", text: "This console is a development build, so there is no matching download link. In the newest release: Mac with Apple chip is dbtrail-darwin-arm64.mcpb, Intel Mac is dbtrail-darwin-amd64.mcpb, Linux is dbtrail-linux-amd64.mcpb (or -arm64). Windows has no installer yet." }),
+      el("p", { class: "form-hint", text: "Using claude.ai in the browser instead of the desktop app? If this console is reachable from the internet, open Settings, then Connectors, then Add custom connector, and paste the same address and token. On a private network (only reachable from inside), use the desktop app." })));
   }
-  card.append(el("p", { class: "form-hint", text:
-    "Using claude.ai in the browser instead of the desktop app? If this console is reachable from the internet, open claude.ai, go to Settings, then Connectors, then Add custom connector, and paste the same address and token there. On a private network (only reachable from inside), use the desktop app instead." }));
   return card;
 }
 

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -5495,8 +5495,8 @@ async function revokeMCPToken() {
 }
 
 // cnCard: a step card whose number is a BADGE, not prose. The three cards are
-// the whole how-to, so each stays at one action plus one short line; every
-// conditional or rare fact folds into cnFine below.
+// the whole how-to, so each stays at one action plus one short line per state;
+// parenthetical and rare facts fold into cnFine below.
 function cnCard(num, title) {
   return el("div", { class: "card cn-card" },
     el("div", { class: "card-title cn-title" },
@@ -5538,7 +5538,7 @@ function mcpTokenCard(tok, minted) {
         "You already have a token" + (tok.created_at ? ", created " + utcLabel(tok.created_at) : "") +
         ". It cannot be shown again." +
         // read_only hides the buttons below, so never tell that user to click one
-        (tok.read_only ? "" : " Lost it? New token gives you a fresh one; the old one stops working.") }));
+        (tok.read_only ? "" : " Lost it? New token gives you a fresh value, shown only once; the old one stops working.") }));
     }
     if (tok.read_only) {
       card.append(cnFine("Why is there no button here?",
@@ -5588,7 +5588,8 @@ function mcpEndpointCard(servers) {
 // user recognizes the two fields instead of reading a paragraph about them.
 // The field labels are quoted VERBATIM from
 // build/packaging/mcpb/manifest.template.json; if the bundle renames them the
-// picture lies, so they change together.
+// picture lies. e2e 17g reads the manifest's user_config titles and compares
+// the drawn labels against them, so renaming either side alone rings.
 function claudeAskMock() {
   const field = (n, label, hint) => el("div", { class: "cn-mock-row" },
     el("div", { class: "cn-mock-label", text: label }),
@@ -5604,7 +5605,7 @@ function claudeAskMock() {
 // askExample: the payoff line, drawn as the chat message it becomes.
 function askExample() {
   return el("div", { class: "cn-ask" },
-    "Then ask Claude: ",
+    "Then open a new chat and ask: ",
     el("b", { text: "\u201Cwhat changed in my database in the last hour?\u201D" }));
 }
 
@@ -5625,7 +5626,7 @@ function bundleCard() {
     card.append(el("div", { class: "cn-links" },
       el("a", { class: "btn btn-sm", href: "https://github.com/dbtrail/dbtrail/releases/download/v" + ver + "/" + asset, target: "_blank", rel: "noopener", text: "Download the installer" }),
       el("a", { class: "btn btn-sm btn-ghost", href: relTag, target: "_blank", rel: "noopener", text: "All downloads" })));
-    card.append(el("p", { class: "stg-hint", text: "Claude opens and asks for two things:" }));
+    card.append(el("p", { class: "stg-hint", text: "Claude opens and asks to install dbtrail; accept, then fill in two things:" }));
     card.append(claudeAskMock());
     card.append(askExample());
     card.append(cnFine("Intel Mac, Windows, or claude.ai in the browser?",
@@ -5635,21 +5636,29 @@ function bundleCard() {
   } else if (released) {
     // Windows on a released build: the desktop bundle does not exist, so the
     // browser connector IS the path, not a footnote.
-    card.append(el("p", { class: "stg-hint", text: "There is no Windows installer yet. Connect from claude.ai in the browser instead: open Settings, then Connectors, then Add custom connector, and paste the address and token from steps 1 and 2." }));
+    card.append(el("p", { class: "stg-hint", text: "There is no Windows installer yet. If this console is reachable from the internet, connect from claude.ai in the browser: open Settings, then Connectors, then Add custom connector, and paste the address and token from steps 1 and 2." }));
     card.append(askExample());
     card.append(cnFine("Console on a private network?",
-      el("p", { class: "form-hint", text: "The browser path needs this console to be reachable from the internet. On a private network (only reachable from inside), install the desktop bundle on a Mac or Linux machine instead; All downloads below has the files." }),
+      el("p", { class: "form-hint", text: "On a private network (only reachable from inside), claude.ai cannot reach this console; install the desktop bundle on a Mac or Linux machine instead. All downloads below has the files." }),
       el("p", { class: "form-hint" }, el("a", { href: relTag, target: "_blank", rel: "noopener", text: "All downloads for v" + ver }))));
-  } else {
+  } else if (plat) {
     card.append(el("p", { class: "stg-hint", text: "Get the Claude Desktop app (claude.ai/download), then download the newest installer for this computer and double-click it:" }));
     card.append(el("div", { class: "cn-links" },
       el("a", { class: "btn btn-sm", href: "https://github.com/dbtrail/dbtrail/releases", target: "_blank", rel: "noopener", text: "Open the releases page" })));
-    card.append(el("p", { class: "stg-hint", text: "Claude opens and asks for two things:" }));
+    card.append(el("p", { class: "stg-hint", text: "Claude opens and asks to install dbtrail; accept, then fill in two things:" }));
     card.append(claudeAskMock());
     card.append(askExample());
     card.append(cnFine("Which file is for this computer?",
       el("p", { class: "form-hint", text: "This console is a development build, so there is no matching download link. In the newest release: Mac with Apple chip is dbtrail-darwin-arm64.mcpb, Intel Mac is dbtrail-darwin-amd64.mcpb, Linux is dbtrail-linux-amd64.mcpb (or -arm64). Windows has no installer yet." }),
       el("p", { class: "form-hint", text: "Using claude.ai in the browser instead of the desktop app? If this console is reachable from the internet, open Settings, then Connectors, then Add custom connector, and paste the same address and token. On a private network (only reachable from inside), use the desktop app." })));
+  } else {
+    // Development build ON WINDOWS: no installer exists at any version, so
+    // the browser connector is the only path here too.
+    card.append(el("p", { class: "stg-hint", text: "There is no Windows installer. If this console is reachable from the internet, connect from claude.ai in the browser: open Settings, then Connectors, then Add custom connector, and paste the address and token from steps 1 and 2." }));
+    card.append(askExample());
+    card.append(cnFine("Console on a private network?",
+      el("p", { class: "form-hint", text: "On a private network (only reachable from inside), claude.ai cannot reach this console; install the desktop bundle on a Mac or Linux machine instead." }),
+      el("p", { class: "form-hint" }, el("a", { href: "https://github.com/dbtrail/dbtrail/releases", target: "_blank", rel: "noopener", text: "Open the releases page" }))));
   }
   return card;
 }

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -5554,7 +5554,7 @@ function mcpTokenCard(tok, minted) {
       el("button", { class: "btn btn-sm", type: "button", text: "Generate token", onclick: () => mintMCPToken(false) })));
   }
   if (tok.static) {
-    card.append(cnFine("A token was set at startup",
+    card.append(cnFine("A token was set at startup, and it already works",
       el("p", { class: "form-hint" },
         "That fixed token also works (CLI: ",
         el("code", { text: "--token" }), " or ", el("code", { text: "BINTRAIL_CONSOLE_TOKEN" }),

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -2559,8 +2559,28 @@ button { font-family: inherit; }
 
 /* the Connect AI step list: a real <ol> so the order is structural, not
    prose — the audience is Claude users following it literally. */
-.cn-steps { margin: 0 0 14px; padding-left: 19px; display: flex; flex-direction: column; gap: 8px; font-size: 13px; color: var(--ink-2); }
-.cn-steps li::marker { color: var(--ink-3); font-weight: 600; }
+/* Connect AI, simple pass: the step number is a badge, the two Claude fields
+   are a drawn dialog, and everything conditional folds into <details>. */
+.cn-title { display: flex; align-items: center; gap: 10px; }
+/* Step cards hug their content: card 3 carries the drawn dialog and is much
+   taller, and stretching 1 and 2 to match reads as two-thirds empty page. */
+.cards .cn-card { align-self: start; }
+.cn-num {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 28px; height: 28px; border-radius: 50%; flex: none;
+  background: linear-gradient(120deg, oklch(0.53 0.2 3), oklch(0.54 0.14 51));
+  color: #fff; font-size: 14px; font-weight: 700;
+}
+.cn-fine { margin-top: 10px; }
+.cn-mock { border: 1px solid var(--line); border-radius: 10px; background: var(--surface); margin: 10px 0; max-width: 430px; box-shadow: 0 1px 2px rgb(0 0 0 / 0.04); }
+.cn-mock-bar { display: flex; align-items: center; padding: 7px 12px; border-bottom: 1px solid var(--line-soft); color: var(--ink-4); font-size: 11.5px; }
+.cn-mock-dots { width: 8px; height: 8px; border-radius: 50%; flex: none; background: oklch(0.72 0.17 25); box-shadow: 13px 0 0 oklch(0.83 0.14 85), 26px 0 0 oklch(0.72 0.17 145); margin-right: 44px; }
+.cn-mock-row { padding: 9px 12px 3px; }
+.cn-mock-row:last-child { padding-bottom: 12px; }
+.cn-mock-label { font-size: 11.5px; font-weight: 600; color: var(--ink-3); margin-bottom: 4px; }
+.cn-mock-field { display: flex; align-items: center; gap: 8px; border: 1px dashed var(--line); border-radius: 8px; padding: 6px 10px; background: var(--surface-2); font-size: 12.5px; color: var(--ink-3); font-style: italic; }
+.cn-chip { display: inline-flex; align-items: center; justify-content: center; width: 20px; height: 20px; border-radius: 50%; flex: none; background: linear-gradient(120deg, oklch(0.53 0.2 3), oklch(0.54 0.14 51)); color: #fff; font-size: 11.5px; font-weight: 700; font-style: normal; }
+.cn-ask { display: inline-flex; flex-wrap: wrap; gap: 4px; align-items: baseline; margin: 8px 0 2px; padding: 8px 14px; border-radius: 14px 14px 14px 4px; background: var(--surface-2); border: 1px solid var(--line); font-size: 12.5px; color: var(--ink-2); }
 /* inline flag/env names in hints never wrap mid-token: a --flag broken
    across lines reads as "- -flag" to the non-technical audience this page
    addresses. */

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -2557,8 +2557,6 @@ button { font-family: inherit; }
 .cards .card .hstat-muted, .cards .card .hstale { color: var(--ink-2); }
 .cards .card .hstale { border-top-color: oklch(0.5 0.05 320 / 0.22); }
 
-/* the Connect AI step list: a real <ol> so the order is structural, not
-   prose — the audience is Claude users following it literally. */
 /* Connect AI, simple pass: the step number is a badge, the two Claude fields
    are a drawn dialog, and everything conditional folds into <details>. */
 .cn-title { display: flex; align-items: center; gap: 10px; }
@@ -2572,7 +2570,12 @@ button { font-family: inherit; }
   color: #fff; font-size: 14px; font-weight: 700;
 }
 .cn-fine { margin-top: 10px; }
-.cn-mock { border: 1px solid var(--line); border-radius: 10px; background: var(--surface); margin: 10px 0; max-width: 430px; box-shadow: 0 1px 2px rgb(0 0 0 / 0.04); }
+/* The mock and the ask bubble sit INSIDE a tinted config card, where the
+   --line family drowns (1.08 on the violet tint); they take the same stronger
+   hairline the file already gives .stg-code insets on tints, and the bubble
+   fills white so its identity clears the two-grounds floor on ANY tint, not
+   just the violet it lands on today. */
+.cn-mock { border: 1px solid oklch(0.5 0.05 320 / 0.22); border-radius: 10px; background: var(--surface); margin: 10px 0; max-width: 430px; box-shadow: 0 1px 2px rgb(0 0 0 / 0.04); }
 .cn-mock-bar { display: flex; align-items: center; padding: 7px 12px; border-bottom: 1px solid var(--line-soft); color: var(--ink-4); font-size: 11.5px; }
 .cn-mock-dots { width: 8px; height: 8px; border-radius: 50%; flex: none; background: oklch(0.72 0.17 25); box-shadow: 13px 0 0 oklch(0.83 0.14 85), 26px 0 0 oklch(0.72 0.17 145); margin-right: 44px; }
 .cn-mock-row { padding: 9px 12px 3px; }
@@ -2580,7 +2583,7 @@ button { font-family: inherit; }
 .cn-mock-label { font-size: 11.5px; font-weight: 600; color: var(--ink-3); margin-bottom: 4px; }
 .cn-mock-field { display: flex; align-items: center; gap: 8px; border: 1px dashed var(--line); border-radius: 8px; padding: 6px 10px; background: var(--surface-2); font-size: 12.5px; color: var(--ink-3); font-style: italic; }
 .cn-chip { display: inline-flex; align-items: center; justify-content: center; width: 20px; height: 20px; border-radius: 50%; flex: none; background: linear-gradient(120deg, oklch(0.53 0.2 3), oklch(0.54 0.14 51)); color: #fff; font-size: 11.5px; font-weight: 700; font-style: normal; }
-.cn-ask { display: inline-flex; flex-wrap: wrap; gap: 4px; align-items: baseline; margin: 8px 0 2px; padding: 8px 14px; border-radius: 14px 14px 14px 4px; background: var(--surface-2); border: 1px solid var(--line); font-size: 12.5px; color: var(--ink-2); }
+.cn-ask { display: inline-flex; flex-wrap: wrap; gap: 4px; align-items: baseline; margin: 8px 0 2px; padding: 8px 14px; border-radius: 14px 14px 14px 4px; background: var(--surface); border: 1px solid oklch(0.5 0.05 320 / 0.22); font-size: 12.5px; color: var(--ink-2); }
 /* inline flag/env names in hints never wrap mid-token: a --flag broken
    across lines reads as "- -flag" to the non-technical audience this page
    addresses. */

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -3628,6 +3628,17 @@ try {
   await page.waitForFunction(() => location.pathname === "/connect"
     && document.querySelectorAll(".view .cn-card").length === 3, { timeout: 15000 })
     .catch(() => {});
+  // The mock's field labels come from the REAL bundle manifest, not from a
+  // second hand-maintained copy: renaming either side alone rings below. A
+  // failed read degrades to null titles (a loud label mismatch carrying the
+  // error) instead of throwing here, which would abort 17f and 18 with it.
+  // globalThis.URL because this file shadows URL with the console's
+  // base-address string.
+  let mcpbTitles = [null, null], mcpbReadErr = "";
+  try {
+    const mcpbCfg = JSON.parse(readFileSync(new globalThis.URL("../../build/packaging/mcpb/manifest.template.json", import.meta.url), "utf8")).user_config;
+    mcpbTitles = [mcpbCfg.console_url.title, mcpbCfg.token.title];
+  } catch (e) { mcpbReadErr = String(e); }
   const cn = await page.evaluate(() => {
     const badges = Array.from(document.querySelectorAll(".view .card .cn-num")).map((n) => n.textContent).join("");
     const labels = Array.from(document.querySelectorAll(".cn-mock .cn-mock-label")).map((n) => n.textContent);
@@ -3645,23 +3656,18 @@ try {
       downloadLinks: document.querySelectorAll('.view a[href*="/releases/download/"]').length,
     };
   });
-  // The mock's field labels come from the REAL bundle manifest, not from a
-  // second hand-maintained copy: renaming either side alone rings here.
-  // globalThis.URL: this file shadows URL with the console's base-address
-  // string (line ~20), so the bare constructor here is a string, not URL.
-  const mcpbCfg = JSON.parse(readFileSync(new globalThis.URL("../../build/packaging/mcpb/manifest.template.json", import.meta.url), "utf8")).user_config;
-  const mcpbTitles = [mcpbCfg.console_url.title, mcpbCfg.token.title];
   (cn.badges === "123")
     ? ok("connect: three numbered step badges in order")
     : bad("connect: three numbered step badges in order", JSON.stringify(cn.badges));
   (cn.labels.length === 2 && cn.labels[0] === mcpbTitles[0] && cn.labels[1] === mcpbTitles[1])
     ? ok("connect: the drawn dialog carries the manifest's field names verbatim")
-    : bad("connect: the drawn dialog carries the manifest's field names verbatim", JSON.stringify({ drawn: cn.labels, manifest: mcpbTitles }));
+    : bad("connect: the drawn dialog carries the manifest's field names verbatim", JSON.stringify({ drawn: cn.labels, manifest: mcpbTitles, readErr: mcpbReadErr }));
   (cn.visibleChars > 0 && cn.visibleChars < 1500 && cn.fine >= 1)
     ? ok("connect: visible text stays under budget with fine print folded")
     : bad("connect: visible text stays under budget with fine print folded", "chars " + cn.visibleChars + " fine " + cn.fine);
-  // "shown only once" is carried by BOTH non-minted token states (fresh and
-  // managed); this run exercises the fresh one (no scenario mints a token).
+  // "shown only once" is carried by the fresh state and the managed state
+  // (except managed read_only, which drops the Lost-it clause and the phrase
+  // with it); this run exercises the fresh one (no scenario mints a token).
   (cn.once && cn.addrCopy && cn.downloadLinks === 0)
     ? ok("connect: one-time warning visible, address one click to copy, no 404able download link")
     : bad("connect: one-time warning visible, address one click to copy, no 404able download link", JSON.stringify({ once: cn.once, addrCopy: cn.addrCopy, downloadLinks: cn.downloadLinks }));
@@ -3984,15 +3990,21 @@ try {
     return {
       warnCount: document.querySelectorAll("#ev-warnings .warn-item").length,
       warnText: w ? w.textContent : "",
+      warnTexts: Array.from(document.querySelectorAll("#ev-warnings .warn-item")).map((n) => n.textContent),
       hasIcon: w ? !!w.querySelector("svg") : false,
       bg: cs ? cs.backgroundColor : "",
       border: cs ? cs.borderTopStyle : "",
       noteCount: document.querySelectorAll("#ev-notes .note-item").length,
     };
   }, { since: ARC_GAP_SINCE, until: ARC_GAP_UNTIL });
-  arcWarn.warnCount >= 1 && /rotated and not archived/.test(arcWarn.warnText)
-    ? ok("severity split: a real coverage-gap warning renders")
-    : bad("severity split: a real coverage-gap warning renders", JSON.stringify(arcWarn));
+  // The matcher that found `w` makes /rotated and not archived/ true by
+  // construction, so the real claim here is the second half: once the gap
+  // warning is up, no phase-1 transient (scope=live partial, background-read
+  // notice) and no failed-archive-read notice may share the box with it.
+  (arcWarn.warnCount >= 1 && /rotated and not archived/.test(arcWarn.warnText)
+    && !arcWarn.warnTexts.some((t) => /Reading archived history in the background|archive read FAILED|scope=live/.test(t)))
+    ? ok("severity split: a real coverage-gap warning renders, with no transient sharing the box")
+    : bad("severity split: a real coverage-gap warning renders, with no transient sharing the box", JSON.stringify(arcWarn));
   (arcWarn.hasIcon && arcWarn.bg !== "rgba(0, 0, 0, 0)" && arcWarn.border === "solid")
     ? ok("severity split: the gap warning keeps the alert register (⚠, amber, border)")
     : bad("severity split: the gap warning keeps the alert register (⚠, amber, border)", `icon=${arcWarn.hasIcon} bg=${arcWarn.bg} border=${arcWarn.border}`);

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -3597,37 +3597,54 @@ try {
     ? ok("tropical: config cards rotate through the home's tint palette")
     : bad("tropical: config cards rotate through the home's tint palette", JSON.stringify(tints));
 
-  // ── Scenario 17g — Connect AI reads as steps, not as jargon. The page's
-  // audience is Claude users, mostly non-technical; the rewrite turned the
-  // three cards into an explicit Step 1/2/3 with a literal ordered list.
-  // Structure is the guard (titles, the <ol>, the one-time warning), so a
-  // future copy edit can rewrite words but not silently dissolve the steps.
+  // ── Scenario 17g — Connect AI is three short steps with a drawn dialog ──
+  // The audience is Claude users, mostly non-technical. The first rewrite
+  // (#1430) made the steps explicit but drowned them in prose; the verdict on
+  // the live page was "demasiado texto". This pass folds every contingency
+  // into <details> and DRAWS the install dialog instead of describing it.
+  // Guards: the three numbered badges in order, the mock whose field labels
+  // are VERBATIM from build/packaging/mcpb/manifest.template.json, and a hard
+  // budget on the VISIBLE text. innerText is the budget's measuring stick on
+  // purpose: it skips closed <details>, so fine print stays free while
+  // anything unfolded on the open page counts against the cap. The cap (1500)
+  // sits ~60% above the measured page (849-916 chars across the token states)
+  // and 35% below the pre-simplify page (2304 measured, RED verified), so a
+  // copy edit breathes but a wall of text rings.
   // Limit worth naming: run.sh builds without -ldflags, so this only ever
-  // exercises the UNVERSIONED bundle arm; the released arm's copy is not
-  // photographed here.
+  // photographs the UNVERSIONED bundle arm.
   await page.evaluate(() => navigate("connect"));
+  // Wait on .cn-card, a connect-only marker: ".card" is satisfied by the
+  // PREVIOUS view's cards while renderConnect's fetches are still in flight
+  // (navigate flips the pathname immediately), which photographed a half-built
+  // page in the preview loop for this scenario.
   await page.waitForFunction(() => location.pathname === "/connect"
-    && document.querySelectorAll(".view .card").length >= 3, { timeout: 10000 });
+    && document.querySelectorAll(".view .cn-card").length === 3, { timeout: 10000 });
   const cn = await page.evaluate(() => {
-    const titles = Array.from(document.querySelectorAll(".view .card .card-title")).map((n) => n.textContent);
-    const addrCard = Array.from(document.querySelectorAll(".view .card")).find((c) =>
-      /Step 2/.test((c.querySelector(".card-title") || {}).textContent || ""));
+    const badges = Array.from(document.querySelectorAll(".view .card .cn-num")).map((n) => n.textContent).join("");
+    const labels = Array.from(document.querySelectorAll(".cn-mock .cn-mock-label")).map((n) => n.textContent);
+    const addrCard = document.querySelectorAll(".view .cn-card")[1];
+    const visible = (document.querySelector(".view") || { innerText: "" }).innerText;
     return {
-      steps: titles.filter((t) => /^Step [123] · /.test(t)).length,
-      olItems: document.querySelectorAll(".cn-steps li").length,
-      subOnce: /shown only once/.test((document.querySelector(".page-sub") || {}).textContent || ""),
+      badges,
+      labels,
+      visibleChars: visible.length,
+      fine: document.querySelectorAll(".view details.cn-fine").length,
       addrCopy: addrCard ? Array.from(addrCard.querySelectorAll("button")).some((b) => b.textContent === "Copy") : false,
+      once: /shown only once/.test(visible),
     };
   });
-  (cn.steps === 3)
-    ? ok("connect: the three cards are literal steps 1, 2 and 3")
-    : bad("connect: the three cards are literal steps 1, 2 and 3", JSON.stringify(cn));
-  (cn.olItems >= 5)
-    ? ok("connect: step 3 is an ordered list a non-technical user can follow")
-    : bad("connect: step 3 is an ordered list a non-technical user can follow", "items " + cn.olItems);
-  (cn.subOnce && cn.addrCopy)
-    ? ok("connect: the one-time-token warning leads the page and the address is one click to copy")
-    : bad("connect: the one-time-token warning leads the page and the address is one click to copy", JSON.stringify(cn));
+  (cn.badges === "123")
+    ? ok("connect: three numbered step badges in order")
+    : bad("connect: three numbered step badges in order", JSON.stringify(cn.badges));
+  (cn.labels.length === 2 && cn.labels[0] === "Console / MCP endpoint URL" && cn.labels[1] === "Access token")
+    ? ok("connect: the drawn dialog carries the manifest's field names verbatim")
+    : bad("connect: the drawn dialog carries the manifest's field names verbatim", JSON.stringify(cn.labels));
+  (cn.visibleChars > 0 && cn.visibleChars < 1500 && cn.fine >= 1)
+    ? ok("connect: visible text stays under budget with fine print folded")
+    : bad("connect: visible text stays under budget with fine print folded", "chars " + cn.visibleChars + " fine " + cn.fine);
+  (cn.once && cn.addrCopy)
+    ? ok("connect: the one-time warning is visible and the address is one click to copy")
+    : bad("connect: the one-time warning is visible and the address is one click to copy", JSON.stringify({ once: cn.once, addrCopy: cn.addrCopy }));
 
   // ── Scenario 17f — the Events skeleton is visible (#1397) ──
   //

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -3647,7 +3647,9 @@ try {
   });
   // The mock's field labels come from the REAL bundle manifest, not from a
   // second hand-maintained copy: renaming either side alone rings here.
-  const mcpbCfg = JSON.parse(readFileSync(new URL("../../build/packaging/mcpb/manifest.template.json", import.meta.url), "utf8")).user_config;
+  // globalThis.URL: this file shadows URL with the console's base-address
+  // string (line ~20), so the bare constructor here is a string, not URL.
+  const mcpbCfg = JSON.parse(readFileSync(new globalThis.URL("../../build/packaging/mcpb/manifest.template.json", import.meta.url), "utf8")).user_config;
   const mcpbTitles = [mcpbCfg.console_url.title, mcpbCfg.token.title];
   (cn.badges === "123")
     ? ok("connect: three numbered step badges in order")

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -3609,7 +3609,7 @@ try {
   // purpose: it skips a closed <details>' folded content (each summary line
   // still counts), so fine print stays free while anything unfolded on the
   // open page counts against the cap. The cap (1500)
-  // sits ~60% above the measured page (849-916 chars across the token states)
+  // sits ~50% above the measured page (869-985 chars across the token states)
   // and 35% below the pre-simplify page (2304 measured, RED verified), so a
   // copy edit breathes but a wall of text rings.
   // Limit worth naming: run.sh builds without -ldflags, so this only ever

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -3621,8 +3621,13 @@ try {
   // for) can satisfy it, and the preview loop for this scenario photographed
   // exactly one such half-built page. .cn-card can only exist after
   // buildConnect ran, and === 3 also rings if a card is dropped.
+  // Tolerant wait: against a page with no .cn-card at all (the M1 mutation,
+  // assets reverted to the pre-simplify page) a bare waitForFunction timeout
+  // ABORTS the suite at this line, hiding the four assertions below and every
+  // later scenario. Catch it and let the assertions report the actual shape.
   await page.waitForFunction(() => location.pathname === "/connect"
-    && document.querySelectorAll(".view .cn-card").length === 3, { timeout: 10000 });
+    && document.querySelectorAll(".view .cn-card").length === 3, { timeout: 15000 })
+    .catch(() => {});
   const cn = await page.evaluate(() => {
     const badges = Array.from(document.querySelectorAll(".view .card .cn-num")).map((n) => n.textContent).join("");
     const labels = Array.from(document.querySelectorAll(".cn-mock .cn-mock-label")).map((n) => n.textContent);

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -3803,7 +3803,10 @@ try {
   const skelPulseWorst = skelPhases.every(skelEnough)
     ? skelPhases.reduce((w, s) => (!w || s.ratio < w.ratio ? s : w), null)
     : null;
-  const skelR = (s) => s && +s.ratio.toFixed(3);
+  // ratio can be ABSENT (a phase whose screenshot sampled no bars spreads {}
+  // into the entry) — and this reporter runs precisely when that happens, so
+  // it must render the hole as null, not abort the whole suite reporting it.
+  const skelR = (s) => (s && s.ratio != null) ? +s.ratio.toFixed(3) : null;
   const skelDetail = () => JSON.stringify({
     bars: skelBars,
     rest: Object.fromEntries(skelShots.map(([d, s]) => [d, skelR(s)])),

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -3966,11 +3966,18 @@ try {
     f.elements.until.value = until;
     f.elements.limit.value = "50";
     f.requestSubmit();
-    for (let i = 0; i < 60; i++) {
+    // Progressive events (#1414) answer in two phases, and phase 1 paints its
+    // own TRANSIENT scope=live partial warning before phase 2 replaces it
+    // with the final set. Breaking on ANY .warn-item samples whichever phase
+    // got there first — a race this scenario lost twice in one session — so
+    // wait for the warning the assertions below are actually about.
+    let w = null;
+    for (let i = 0; i < 120; i++) {
       await new Promise((r) => setTimeout(r, 50));
-      if (document.querySelectorAll("#ev-warnings .warn-item").length) break;
+      w = Array.from(document.querySelectorAll("#ev-warnings .warn-item"))
+        .find((n) => /rotated and not archived/.test(n.textContent)) || null;
+      if (w) break;
     }
-    const w = document.querySelector("#ev-warnings .warn-item");
     const cs = w ? getComputedStyle(w) : null;
     return {
       warnCount: document.querySelectorAll("#ev-warnings .warn-item").length,

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -14,6 +14,7 @@
 // playwright-managed chromium).
 import { chromium } from "playwright";
 import zlib from "node:zlib";
+import { readFileSync } from "node:fs";
 import { execSync } from "node:child_process";
 
 const URL = process.env.CONSOLE_URL || "http://127.0.0.1:8090";
@@ -3605,18 +3606,21 @@ try {
   // Guards: the three numbered badges in order, the mock whose field labels
   // are VERBATIM from build/packaging/mcpb/manifest.template.json, and a hard
   // budget on the VISIBLE text. innerText is the budget's measuring stick on
-  // purpose: it skips closed <details>, so fine print stays free while
-  // anything unfolded on the open page counts against the cap. The cap (1500)
+  // purpose: it skips a closed <details>' folded content (each summary line
+  // still counts), so fine print stays free while anything unfolded on the
+  // open page counts against the cap. The cap (1500)
   // sits ~60% above the measured page (849-916 chars across the token states)
   // and 35% below the pre-simplify page (2304 measured, RED verified), so a
   // copy edit breathes but a wall of text rings.
   // Limit worth naming: run.sh builds without -ldflags, so this only ever
   // photographs the UNVERSIONED bundle arm.
   await page.evaluate(() => navigate("connect"));
-  // Wait on .cn-card, a connect-only marker: ".card" is satisfied by the
-  // PREVIOUS view's cards while renderConnect's fetches are still in flight
-  // (navigate flips the pathname immediately), which photographed a half-built
-  // page in the preview loop for this scenario.
+  // Wait on .cn-card, a connect-only marker. ".card" is not connect-specific:
+  // anything else that paints cards into the shared #view container (another
+  // view's late async paint — the route-clobber class scenario 17c exists
+  // for) can satisfy it, and the preview loop for this scenario photographed
+  // exactly one such half-built page. .cn-card can only exist after
+  // buildConnect ran, and === 3 also rings if a card is dropped.
   await page.waitForFunction(() => location.pathname === "/connect"
     && document.querySelectorAll(".view .cn-card").length === 3, { timeout: 10000 });
   const cn = await page.evaluate(() => {
@@ -3631,20 +3635,29 @@ try {
       fine: document.querySelectorAll(".view details.cn-fine").length,
       addrCopy: addrCard ? Array.from(addrCard.querySelectorAll("button")).some((b) => b.textContent === "Copy") : false,
       once: /shown only once/.test(visible),
+      // The 404-honesty rule's photographable half: this run is the
+      // unversioned arm, where a direct release-asset link can only 404.
+      downloadLinks: document.querySelectorAll('.view a[href*="/releases/download/"]').length,
     };
   });
+  // The mock's field labels come from the REAL bundle manifest, not from a
+  // second hand-maintained copy: renaming either side alone rings here.
+  const mcpbCfg = JSON.parse(readFileSync(new URL("../../build/packaging/mcpb/manifest.template.json", import.meta.url), "utf8")).user_config;
+  const mcpbTitles = [mcpbCfg.console_url.title, mcpbCfg.token.title];
   (cn.badges === "123")
     ? ok("connect: three numbered step badges in order")
     : bad("connect: three numbered step badges in order", JSON.stringify(cn.badges));
-  (cn.labels.length === 2 && cn.labels[0] === "Console / MCP endpoint URL" && cn.labels[1] === "Access token")
+  (cn.labels.length === 2 && cn.labels[0] === mcpbTitles[0] && cn.labels[1] === mcpbTitles[1])
     ? ok("connect: the drawn dialog carries the manifest's field names verbatim")
-    : bad("connect: the drawn dialog carries the manifest's field names verbatim", JSON.stringify(cn.labels));
+    : bad("connect: the drawn dialog carries the manifest's field names verbatim", JSON.stringify({ drawn: cn.labels, manifest: mcpbTitles }));
   (cn.visibleChars > 0 && cn.visibleChars < 1500 && cn.fine >= 1)
     ? ok("connect: visible text stays under budget with fine print folded")
     : bad("connect: visible text stays under budget with fine print folded", "chars " + cn.visibleChars + " fine " + cn.fine);
-  (cn.once && cn.addrCopy)
-    ? ok("connect: the one-time warning is visible and the address is one click to copy")
-    : bad("connect: the one-time warning is visible and the address is one click to copy", JSON.stringify({ once: cn.once, addrCopy: cn.addrCopy }));
+  // "shown only once" is carried by BOTH non-minted token states (fresh and
+  // managed); this run exercises the fresh one (no scenario mints a token).
+  (cn.once && cn.addrCopy && cn.downloadLinks === 0)
+    ? ok("connect: one-time warning visible, address one click to copy, no 404able download link")
+    : bad("connect: one-time warning visible, address one click to copy, no 404able download link", JSON.stringify({ once: cn.once, addrCopy: cn.addrCopy, downloadLinks: cn.downloadLinks }));
 
   // ── Scenario 17f — the Events skeleton is visible (#1397) ──
   //


### PR DESCRIPTION
The Connect AI page said everything and showed nothing: three step cards carrying dense paragraphs, a five-item ordered list, and every contingency spelled out in the open. Feedback on a live deployment was blunt: far too much text.

This pass keeps every fact but changes how they are carried:

- **Step numbers are badges**, not prose. Each card is one action plus one short line per state.
- **The Claude Desktop install dialog is drawn, not described**: a miniature dialog (`claudeAskMock`) shows the two fields with numbered chips pointing back at steps 1 and 2. The field labels are quoted verbatim from `build/packaging/mcpb/manifest.template.json`, and e2e 17g now reads the manifest's `user_config` titles at run time and compares the drawn labels against them, so renaming either side alone fails the suite.
- **Everything conditional folds into `<details>` fine print** (Intel Mac, Windows, claude.ai-in-the-browser, static tokens, multi-server addressing). Visible text drops from 2304 chars to 869-985 across token states.
- Honesty rules carried from #1430 stay: no download link that can only 404 (now pinned by a `downloadLinks === 0` assertion in the photographed arm), the Windows arms state the reachability precondition inline, and the dev build on Windows no longer suggests a download at all.

Guards (all seen red first):
- 17g asserts the three badges in order, the manifest-tied mock labels, and a hard budget on `innerText` (closed `<details>` content is unrendered and does not count): cap 1500, measured page 869-985, pre-simplify page 2304. Against the old page the suite fails; label rename, badge renumber, and default-open fine print were each caught by their target assertion.
- 17g's wait targets `.cn-card` (connect-only marker) and tolerates timeout so a dissolved page reports as four precise assertion failures instead of aborting the run.

Drive-by e2e fixes, each observed failing first:
- 17f's failure reporter crashed (`undefined.toFixed`) on a phase whose screenshot sampled no bars, aborting the suite exactly when it had something to report; it now renders the hole as null.
- Scenario 18's wait broke on the first `.warn-item`, which under progressive events (#1414) can be the transient phase-1 `scope=live` partial warning; it now waits for the gap warning it asserts, and additionally requires that no transient shares the box once it lands.
- The manifest read uses `globalThis.URL` (the file shadows `URL` with a string) and degrades to a loud label mismatch instead of aborting on a read failure.

`docs/connect-ai.md` card-name references updated. Full console e2e: 320/320.
