### PR TITLE
console/mcp: tolerate trailing slashes on /mcp and fix the bridge's early-notification crash

### DIFF
--- a/cmd/bintrail-mcp/bridge.go
+++ b/cmd/bintrail-mcp/bridge.go
@@ -229,7 +229,7 @@ func authHint(err error) string {
 	msg := err.Error()
 	if strings.Contains(msg, "401") || strings.Contains(msg, "403") ||
 		strings.Contains(msg, "Unauthorized") || strings.Contains(msg, "Forbidden") {
-		return " (authentication rejected — check --token)"
+		return " (authentication rejected; check --token)"
 	}
 	return ""
 }

--- a/cmd/bintrail-mcp/bridge.go
+++ b/cmd/bintrail-mcp/bridge.go
@@ -81,11 +81,22 @@ func (t *bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 // side) and a remote client session (HTTP side).
 type bridge struct {
 	endpoint string
-	session  *mcp.ClientSession
 	server   *mcp.Server
 
-	mu    sync.Mutex
-	tools map[string]bool // tool names currently registered on the local server
+	mu      sync.Mutex
+	session *mcp.ClientSession // nil until Connect returns inside newBridge
+	tools   map[string]bool    // tool names currently registered on the local server
+}
+
+// remoteSession returns the connected session, or nil while Connect is still
+// in flight. The ToolListChangedHandler can fire on the session's receive
+// loop BEFORE newBridge's assignment runs (a buffered reverse proxy shifts
+// delivery timing enough to hit it live, 2026-08-23), so every use from a
+// handler goroutine goes through here instead of reading the field bare.
+func (b *bridge) remoteSession() *mcp.ClientSession {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.session
 }
 
 // newBridge connects to the remote endpoint, mirrors its tool set onto a
@@ -124,7 +135,9 @@ func newBridge(ctx context.Context, endpoint, token string) (*bridge, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot connect to %s: %w%s", endpoint, err, authHint(err))
 	}
+	b.mu.Lock()
 	b.session = session
+	b.mu.Unlock()
 
 	// Mirror the remote server's instructions so the stdio client sees the
 	// same guidance it would get connecting directly.
@@ -144,7 +157,7 @@ func newBridge(ctx context.Context, endpoint, token string) (*bridge, error) {
 }
 
 // Close terminates the remote session.
-func (b *bridge) Close() error { return b.session.Close() }
+func (b *bridge) Close() error { return b.remoteSession().Close() }
 
 // toolCount returns the number of currently mirrored tools.
 func (b *bridge) toolCount() int {
@@ -157,8 +170,17 @@ func (b *bridge) toolCount() int {
 // set: every remote tool is (re-)registered verbatim with a forwarding
 // handler, and local tools that disappeared from the remote are removed.
 func (b *bridge) resync(ctx context.Context) error {
+	session := b.remoteSession()
+	if session == nil {
+		// tools/list_changed arrived while Connect was still in flight: the
+		// explicit resync newBridge runs right after Connect covers the same
+		// tool set, so skipping the early notification loses nothing. Before
+		// this guard, that ordering was a nil dereference PANIC, reproduced
+		// through any response-buffering proxy in front of the console.
+		return nil
+	}
 	var remote []*mcp.Tool
-	for tool, err := range b.session.Tools(ctx, nil) {
+	for tool, err := range session.Tools(ctx, nil) {
 		if err != nil {
 			return err
 		}
@@ -205,7 +227,7 @@ func (b *bridge) forward(name string) mcp.ToolHandler {
 		if len(req.Params.Arguments) > 0 {
 			params.Arguments = json.RawMessage(req.Params.Arguments)
 		}
-		return b.session.CallTool(ctx, params)
+		return b.remoteSession().CallTool(ctx, params)
 	}
 }
 
@@ -223,13 +245,18 @@ func isObjectSchema(schema any) bool {
 	return m["type"] == "object"
 }
 
+// authRejectedMarker is OUR OWN wording (nothing in the SDK or the console
+// emits it); bridgeHint keys its follow-up line on the same constant, so the
+// two can only drift together.
+const authRejectedMarker = "authentication rejected"
+
 // authHint appends a token hint when the remote rejected the request with an
 // auth-shaped status, so the one-line stderr message is actionable.
 func authHint(err error) string {
 	msg := err.Error()
 	if strings.Contains(msg, "401") || strings.Contains(msg, "403") ||
 		strings.Contains(msg, "Unauthorized") || strings.Contains(msg, "Forbidden") {
-		return " (authentication rejected; check --token)"
+		return " (" + authRejectedMarker + "; check --token)"
 	}
 	return ""
 }

--- a/cmd/bintrail-mcp/bridge.go
+++ b/cmd/bintrail-mcp/bridge.go
@@ -135,10 +135,6 @@ func newBridge(ctx context.Context, endpoint, token string) (*bridge, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot connect to %s: %w%s", endpoint, err, authHint(err))
 	}
-	b.mu.Lock()
-	b.session = session
-	b.mu.Unlock()
-
 	// Mirror the remote server's instructions so the stdio client sees the
 	// same guidance it would get connecting directly.
 	instructions := ""
@@ -148,6 +144,19 @@ func newBridge(ctx context.Context, endpoint, token string) (*bridge, error) {
 	b.server = mcp.NewServer(&mcp.Implementation{Name: "bintrail", Version: mcpVersion}, &mcp.ServerOptions{
 		Instructions: instructions,
 	})
+
+	// ORDER IS LOAD-BEARING: the session is published LAST, after b.server is
+	// built. The list_changed handler races every line of this function (the
+	// SDK's receive loop is live before Connect returns, and the console arms
+	// a ~10ms tool-notification debounce per fresh session), and its resync
+	// gates only on the session: a reader that observes session != nil under
+	// b.mu is guaranteed by the mutex's release/acquire edge to see the
+	// completed b.server write; a reader that observes nil returns before
+	// touching either. Publishing the session first re-opens a nil b.server
+	// dereference inside AddTool.
+	b.mu.Lock()
+	b.session = session
+	b.mu.Unlock()
 
 	if err := b.resync(connectCtx); err != nil {
 		session.Close()

--- a/cmd/bintrail-mcp/bridge_test.go
+++ b/cmd/bintrail-mcp/bridge_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -64,5 +65,18 @@ func TestAuthHint(t *testing.T) {
 	}
 	if hint := authHint(errors.New("dial tcp: connection refused")); hint != "" {
 		t.Errorf("network error produced a token hint: %q", hint)
+	}
+}
+
+// The console emits tools/list_changed as soon as the session exists, and the
+// SDK can deliver it on the receive loop BEFORE Client.Connect returns — so
+// the handler's resync can run while newBridge has not assigned the session
+// yet. A buffered reverse proxy shifts timing enough to hit this live
+// (2026-08-23: nil dereference panic through nginx with default buffering).
+// The bridge must treat that early notification as a no-op, not a crash.
+func TestResyncBeforeConnectIsANoOp(t *testing.T) {
+	b := &bridge{endpoint: "test", tools: map[string]bool{}}
+	if err := b.resync(context.Background()); err != nil {
+		t.Fatalf("resync with no session yet: %v (want nil no-op)", err)
 	}
 }

--- a/cmd/bintrail-mcp/main.go
+++ b/cmd/bintrail-mcp/main.go
@@ -50,6 +50,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
@@ -113,6 +114,23 @@ func standaloneConfig(resolve mcptools.ResolveTarget) mcptools.Config {
 	}
 }
 
+// bridgeHint turns the two connect failures a person can actually fix into a
+// plain-words next step. String matching on the SDK's error text is fine
+// here: this decorates a fatal log line, it never drives behavior.
+func bridgeHint(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	if strings.Contains(msg, `unsupported content type "text/html"`) {
+		return "the address answered a web page, not the MCP endpoint. Check --connect: it should end in /mcp or /mcp/<server> (a trailing slash on an older console, or the console's root URL, lands on the web page)."
+	}
+	if strings.Contains(msg, "authentication rejected") {
+		return "the console refused the token. Paste the token value alone (no name= prefix), and remember every New token replaces the old one: only the newest value works."
+	}
+	return ""
+}
+
 func main() {
 	httpAddr := flag.String("http", "", "HTTP listen address (e.g. :8080); omit to use stdio")
 	tenantDSNsFile := flag.String("tenant-dsns", "", "JSON file mapping tenant IDs to index DSNs (multi-tenant mode)")
@@ -137,6 +155,9 @@ func main() {
 		}
 		// One clear line on stderr: Claude Desktop surfaces this in its logs.
 		fmt.Fprintf(os.Stderr, "bintrail-mcp: bridge failed: %v\n", err)
+		if hint := bridgeHint(err); hint != "" {
+			fmt.Fprintf(os.Stderr, "bintrail-mcp: %s\n", hint)
+		}
 		os.Exit(1)
 	}
 

--- a/cmd/bintrail-mcp/main.go
+++ b/cmd/bintrail-mcp/main.go
@@ -115,8 +115,10 @@ func standaloneConfig(resolve mcptools.ResolveTarget) mcptools.Config {
 }
 
 // bridgeHint turns the two connect failures a person can actually fix into a
-// plain-words next step. String matching on the SDK's error text is fine
-// here: this decorates a fatal log line, it never drives behavior.
+// plain-words next step. It decorates a fatal log line and never drives
+// behavior, so string matching is acceptable; matcher 1 is the SDK's exact
+// wording (stable across the pinned go-sdk versions), matcher 2 is our own
+// authRejectedMarker from authHint in bridge.go.
 func bridgeHint(err error) string {
 	if err == nil {
 		return ""
@@ -125,8 +127,8 @@ func bridgeHint(err error) string {
 	if strings.Contains(msg, `unsupported content type "text/html"`) {
 		return "the address answered a web page, not the MCP endpoint. Check --connect: it should end in /mcp or /mcp/<server> (a trailing slash on an older console, or the console's root URL, lands on the web page)."
 	}
-	if strings.Contains(msg, "authentication rejected") {
-		return "the console refused the token. Paste the token value alone (no name= prefix), and remember every New token replaces the old one: only the newest value works."
+	if strings.Contains(msg, authRejectedMarker) {
+		return "the console did not accept the credential. Paste only the token value, with nothing before or after it; on a console started with a fixed token, that fixed value is the one to use; and every managed token minted on the Connect AI page replaces the previous one, so only the newest works. If the console has no token configured at all, create one on its Connect AI page first."
 	}
 	return ""
 }

--- a/cmd/bintrail-mcp/main_test.go
+++ b/cmd/bintrail-mcp/main_test.go
@@ -503,9 +503,10 @@ func TestMCPBManifestToolsMatchServer(t *testing.T) {
 	}
 }
 
-// bridgeHint's two matchers are pinned to the failure signatures observed
-// live: the SDK's content-type error when an address lands on the web page,
-// and the console's authentication-rejected wording. Anything else stays
+// bridgeHint's matchers: the SDK's content-type error when an address lands
+// on the web page (observed live), and OUR OWN authHint decoration from
+// bridge.go — its fixture is built by calling the real producer, so
+// rewording authHint without bridgeHint flips this red. Anything else stays
 // hint-free so the raw error is the whole story.
 func TestBridgeHint(t *testing.T) {
 	cases := []struct {
@@ -514,7 +515,7 @@ func TestBridgeHint(t *testing.T) {
 	}{
 		{nil, ""},
 		{errors.New(`calling "initialize": sending "initialize": unsupported content type "text/html"`), "web page"},
-		{errors.New(`sending "initialize": Unauthorized (authentication rejected — check --token)`), "refused the token"},
+		{errors.New(`sending "initialize": Unauthorized` + authHint(errors.New("401 Unauthorized"))), "did not accept the credential"},
 		{errors.New("dial tcp 127.0.0.1:18091: connect: connection refused"), ""},
 	}
 	for _, c := range cases {

--- a/cmd/bintrail-mcp/main_test.go
+++ b/cmd/bintrail-mcp/main_test.go
@@ -502,3 +502,28 @@ func TestMCPBManifestToolsMatchServer(t *testing.T) {
 			manifestNames, serverNames)
 	}
 }
+
+// bridgeHint's two matchers are pinned to the failure signatures observed
+// live: the SDK's content-type error when an address lands on the web page,
+// and the console's authentication-rejected wording. Anything else stays
+// hint-free so the raw error is the whole story.
+func TestBridgeHint(t *testing.T) {
+	cases := []struct {
+		err  error
+		want string
+	}{
+		{nil, ""},
+		{errors.New(`calling "initialize": sending "initialize": unsupported content type "text/html"`), "web page"},
+		{errors.New(`sending "initialize": Unauthorized (authentication rejected — check --token)`), "refused the token"},
+		{errors.New("dial tcp 127.0.0.1:18091: connect: connection refused"), ""},
+	}
+	for _, c := range cases {
+		got := bridgeHint(c.err)
+		if c.want == "" && got != "" {
+			t.Errorf("bridgeHint(%v) = %q, want no hint", c.err, got)
+		}
+		if c.want != "" && !strings.Contains(got, c.want) {
+			t.Errorf("bridgeHint(%v) = %q, want it to mention %q", c.err, got, c.want)
+		}
+	}
+}

--- a/docs/console.md
+++ b/docs/console.md
@@ -894,7 +894,10 @@ server {
 
         # Backup and SQL-export downloads are written straight to the
         # response as they are built. With buffering on, nginx spools the
-        # whole archive to disk before sending a byte of it.
+        # whole archive to disk before sending a byte of it. The /mcp
+        # endpoint needs this line too: an AI client connecting through a
+        # buffering proxy sees its stream held back and stalls or drops
+        # during the handshake.
         proxy_buffering off;
     }
 }

--- a/internal/console/mcp_integration_test.go
+++ b/internal/console/mcp_integration_test.go
@@ -295,13 +295,8 @@ func mintManagedMCPToken(t *testing.T, ts *httptest.Server, bearer string) strin
 	return minted.Token
 }
 
-// TestIntegrationMCPTokenGrants pins #1124 end to end over the real HTTP /mcp
-// endpoint: a managed token is capped at the permission grants of the session
-// that minted it, so the MCP door and the /api door to the same data enforce
-// the same permission model. A full-access mint (and, byte-identically, a
-// token file from before grants were recorded) keeps the full read surface.
 // A trailing slash is the most common hand-edit a pasted address suffers,
-// and before the {$} routes below existed, "/mcp/" fell through to the SPA
+// and before the {$} routes in server.go existed, "/mcp/" fell through to the SPA
 // catch-all: the bridge received the console's HTML page with a 200 and
 // died on "unsupported content type" (observed live, 2026-08-23). The
 // discriminating claim is that these paths reach the MCP handler (401 with
@@ -348,6 +343,11 @@ func TestIntegrationMCPTrailingSlashRoutes(t *testing.T) {
 	}
 }
 
+// TestIntegrationMCPTokenGrants pins #1124 end to end over the real HTTP /mcp
+// endpoint: a managed token is capped at the permission grants of the session
+// that minted it, so the MCP door and the /api door to the same data enforce
+// the same permission model. A full-access mint (and, byte-identically, a
+// token file from before grants were recorded) keeps the full read surface.
 func TestIntegrationMCPTokenGrants(t *testing.T) {
 	srv, _, _ := seedMCPConsole(t)
 	ts := httptest.NewServer(srv.Handler())

--- a/internal/console/mcp_integration_test.go
+++ b/internal/console/mcp_integration_test.go
@@ -300,6 +300,54 @@ func mintManagedMCPToken(t *testing.T, ts *httptest.Server, bearer string) strin
 // that minted it, so the MCP door and the /api door to the same data enforce
 // the same permission model. A full-access mint (and, byte-identically, a
 // token file from before grants were recorded) keeps the full read surface.
+// A trailing slash is the most common hand-edit a pasted address suffers,
+// and before the {$} routes below existed, "/mcp/" fell through to the SPA
+// catch-all: the bridge received the console's HTML page with a 200 and
+// died on "unsupported content type" (observed live, 2026-08-23). The
+// discriminating claim is that these paths reach the MCP handler (401 with
+// a bad token, JSON-family content) and never the asset handler (200 html).
+func TestIntegrationMCPTrailingSlashRoutes(t *testing.T) {
+	srv, _, dbName := seedMCPConsole(t)
+	reg, err := LoadRegistry("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reg.Add(ServerEntry{Name: "reg-target", DSN: testutil.SnapshotDSN(dbName), NoArchive: true}); err != nil {
+		t.Fatal(err)
+	}
+	srv.cm.reg = reg
+
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	for _, path := range []string{"/mcp/", "/mcp/reg-target/"} {
+		req, err := http.NewRequest(http.MethodPost, ts.URL+path,
+			strings.NewReader(`{"jsonrpc":"2.0","id":0,"method":"initialize","params":{}}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer wrong-token")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("POST %s: %v", path, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("POST %s with a bad token: status %d, want 401 (the MCP handler); 200 means the SPA swallowed it", path, resp.StatusCode)
+		}
+		if ct := resp.Header.Get("Content-Type"); strings.Contains(ct, "text/html") {
+			t.Errorf("POST %s answered %q — the web page, not the MCP endpoint", path, ct)
+		}
+	}
+
+	// The positive half: a real session through the slashed default route.
+	session := mcpConnect(t, ts.URL+"/mcp/", intToken)
+	if _, err := session.ListTools(context.Background(), nil); err != nil {
+		t.Fatalf("ListTools via /mcp/: %v", err)
+	}
+}
+
 func TestIntegrationMCPTokenGrants(t *testing.T) {
 	srv, _, _ := seedMCPConsole(t)
 	ts := httptest.NewServer(srv.Handler())

--- a/internal/console/mcp_test.go
+++ b/internal/console/mcp_test.go
@@ -88,7 +88,10 @@ func TestMCP_routingUnknownServer404(t *testing.T) {
 	for _, path := range []string{"/mcp/no-such-server", "/mcp/no-such-server/"} {
 		rec := doMCP(t, s, path, "t")
 		if rec.Code != 404 {
-			t.Fatalf("%s = %d, want 404; body: %s", path, rec.Code, rec.Body.String())
+			// Errorf, not Fatalf: the slashed case is the one that catches a
+			// renamed wildcard, and a failure on the bare path must not hide it.
+			t.Errorf("%s = %d, want 404; body: %s", path, rec.Code, rec.Body.String())
+			continue
 		}
 		if !strings.Contains(rec.Body.String(), "unknown server") {
 			t.Errorf("%s 404 body should say unknown server, got: %s", path, rec.Body.String())
@@ -114,10 +117,12 @@ func TestMCP_routingByIDNameAndDefault(t *testing.T) {
 	// Initialize never opens the server's connection, so a routing accept
 	// (200) proves selector resolution without a live MySQL.
 	// The slashed forms ride the {$} routes: "/mcp/" must resolve like bare
-	// /mcp (empty PathValue) and "/mcp/<sel>/" like "/mcp/<sel>" — pinning
-	// the wildcard NAME on the trailing-slash patterns, which the
-	// integration test's bad-token probes cannot see (401 fires before
-	// PathValue is read).
+	// /mcp (empty PathValue) and "/mcp/<sel>/" like "/mcp/<sel>". This loop
+	// alone cannot pin the wildcard NAME on the trailing-slash pattern (a
+	// renamed wildcard yields an empty selector, which this fixture's boot
+	// bundle happily serves as 200) — the slashed case in
+	// TestMCP_routingUnknownServer404 is what kills that mutation, by
+	// resolving to the healthy default instead of 404 (verified red).
 	for _, path := range []string{"/mcp", "/mcp/" + entry.ID, "/mcp/prod", "/mcp/default", "/mcp/", "/mcp/" + entry.ID + "/", "/mcp/prod/", "/mcp/default/"} {
 		if rec := doMCP(t, s, path, "t"); rec.Code != 200 {
 			t.Errorf("%s initialize = %d, want 200; body: %s", path, rec.Code, rec.Body.String())

--- a/internal/console/mcp_test.go
+++ b/internal/console/mcp_test.go
@@ -85,12 +85,14 @@ func TestMCP_routingUnknownServer404(t *testing.T) {
 	defer closer()
 	s := newBootServer(db)
 
-	rec := doMCP(t, s, "/mcp/no-such-server", "t")
-	if rec.Code != 404 {
-		t.Fatalf("/mcp/no-such-server = %d, want 404; body: %s", rec.Code, rec.Body.String())
-	}
-	if !strings.Contains(rec.Body.String(), "unknown server") {
-		t.Errorf("404 body should say unknown server, got: %s", rec.Body.String())
+	for _, path := range []string{"/mcp/no-such-server", "/mcp/no-such-server/"} {
+		rec := doMCP(t, s, path, "t")
+		if rec.Code != 404 {
+			t.Fatalf("%s = %d, want 404; body: %s", path, rec.Code, rec.Body.String())
+		}
+		if !strings.Contains(rec.Body.String(), "unknown server") {
+			t.Errorf("%s 404 body should say unknown server, got: %s", path, rec.Body.String())
+		}
 	}
 }
 
@@ -111,7 +113,12 @@ func TestMCP_routingByIDNameAndDefault(t *testing.T) {
 
 	// Initialize never opens the server's connection, so a routing accept
 	// (200) proves selector resolution without a live MySQL.
-	for _, path := range []string{"/mcp", "/mcp/" + entry.ID, "/mcp/prod", "/mcp/default"} {
+	// The slashed forms ride the {$} routes: "/mcp/" must resolve like bare
+	// /mcp (empty PathValue) and "/mcp/<sel>/" like "/mcp/<sel>" — pinning
+	// the wildcard NAME on the trailing-slash patterns, which the
+	// integration test's bad-token probes cannot see (401 fires before
+	// PathValue is read).
+	for _, path := range []string{"/mcp", "/mcp/" + entry.ID, "/mcp/prod", "/mcp/default", "/mcp/", "/mcp/" + entry.ID + "/", "/mcp/prod/", "/mcp/default/"} {
 		if rec := doMCP(t, s, path, "t"); rec.Code != 200 {
 			t.Errorf("%s initialize = %d, want 200; body: %s", path, rec.Code, rec.Body.String())
 		}

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -672,6 +672,15 @@ func (s *Server) buildHandler() http.Handler {
 	mcpH := s.mcpHandler()
 	root.Handle("/mcp", mcpH)
 	root.Handle("/mcp/{server}", mcpH)
+	// Trailing-slash tolerance: {server} requires a NON-EMPTY segment, so
+	// without these two patterns "/mcp/" and "/mcp/<name>/" fell through to
+	// the SPA catch-all below — and an MCP client that got the web page with
+	// a 200 died on "unsupported content type" (the most common hand-edit a
+	// pasted address suffers; observed live 2026-08-23). {$} pins the empty
+	// tail to the same handler; PathValue("server") is "" on the first (the
+	// default server, same as bare /mcp) and the name on the second.
+	root.Handle("/mcp/{$}", mcpH)
+	root.Handle("/mcp/{server}/{$}", mcpH)
 	root.Handle("/", assetHandler()) // static shell + assets
 
 	return s.hostGuard(securityHeaders(root))


### PR DESCRIPTION
Two failures observed live on 2026-08-23, from a Claude Desktop bridge pointed at a console behind nginx, both fixed here with their guards seen red first.

**1. A trailing slash on the MCP address served the web page.** Go 1.22 ServeMux `{server}` requires a non-empty segment, so `/mcp/` and `/mcp/<name>/` matched neither MCP route and fell through to the SPA catch-all: the bridge received HTML with a 200 and died on `unsupported content type "text/html"`. Two new patterns (`/mcp/{$}`, `/mcp/{server}/{$}`) pin the slashed forms to the MCP handler, which carries its own auth and inherits hostGuard and securityHeaders unchanged. Unit routing tests cover the slashed selector resolution and the slashed unknown-server 404 (the case that catches a renamed wildcard, mutation verified); an integration test drives a full MCP session through `/mcp/` and pins that neither slashed path ever answers HTML.

**2. The bridge crashed through any response-buffering proxy.** The console arms a short tools/list_changed debounce per fresh session, and the SDK's receive loop is live before `Client.Connect` returns, so the notification handler's resync could run while `newBridge` had not yet assigned the session: a nil dereference panic, reproduced through nginx with default buffering (a buffered proxy shifts delivery timing into the race window). The session now lives under the bridge mutex, resync treats a nil session as a no-op (the explicit post-Connect resync covers the same tool set, so nothing is lost), and the session is published last so an observer that sees it non-nil also sees the completed proxy server. The regression test reproduces the literal panic against the old code.

Also: `bridgeHint` turns the two connect failures a person can fix into plain-words next steps on the fatal stderr line (web-page content type; credential rejected, keyed to the bridge's own `authRejectedMarker` so the wording cannot drift apart); the nginx recipe in docs/console.md names the MCP symptom under its existing `proxy_buffering off` line; and one leftover em dash in `authHint` is gone.
