### PR TITLE
console: session policies carry direct table/column restrictions

### DIFF
--- a/ext/consolepolicy.go
+++ b/ext/consolepolicy.go
@@ -106,7 +106,11 @@ type SessionRestrictions struct {
 	// AllowTables, when non-empty, withholds every table NOT listed.
 	AllowTables []TableRef
 	// AllowColumns, for each table appearing in it, nulls every column of that
-	// table's row images NOT listed for it.
+	// table's row images NOT listed for it. It scopes COLUMNS of the tables
+	// it names and does not by itself withhold other tables — a provider
+	// wanting table-level allow-listing sets AllowTables as well (the usual
+	// pairing: AllowTables says which tables, AllowColumns narrows within
+	// them).
 	AllowColumns []TableColumnRef
 }
 

--- a/ext/consolepolicy.go
+++ b/ext/consolepolicy.go
@@ -75,9 +75,52 @@ func AllPermissions() []Permission {
 	return out
 }
 
+// TableRef names one table by schema and table name.
+type TableRef struct{ Schema, Table string }
+
+// TableColumnRef names one column by schema, table and column name.
+type TableColumnRef struct{ Schema, Table, Column string }
+
+// SessionRestrictions scopes what ROW DATA a session reads, attached directly to
+// its AccessPolicy by the auth provider that minted it (#1449). It is the
+// label-free sibling of the Profile name: a provider whose authorization source
+// already knows the concrete tables and columns can say so here, without first
+// materializing flag/profile/access labels into every server's index.
+//
+// Enforcement is the console's, in the SAME pass that applies session profiles,
+// with the same consequences: deny/allow at the query layer, column values
+// nulled in row images, query_text/query_hash withheld (#699), archives off,
+// and every surface that cannot honor per-column redaction refused outright. A
+// session carrying a non-empty restriction set counts as restricted exactly as
+// a profiled session does.
+//
+// Deny composes over allow: a table both allowed and denied yields nothing.
+// AllowTables non-empty switches the session to allow-list mode — tables not
+// listed are withheld — so a provider expressing "only these tables" does not
+// need to enumerate the universe it wants excluded.
+type SessionRestrictions struct {
+	// DenyTables withholds every row event of these tables.
+	DenyTables []TableRef
+	// RedactColumns nulls these column values in returned row images.
+	RedactColumns []TableColumnRef
+	// AllowTables, when non-empty, withholds every table NOT listed.
+	AllowTables []TableRef
+	// AllowColumns, for each table appearing in it, nulls every column of that
+	// table's row images NOT listed for it.
+	AllowColumns []TableColumnRef
+}
+
+// Empty reports whether r restricts nothing. Nil-safe, so callers can hold a
+// nil *SessionRestrictions and never branch on it.
+func (r *SessionRestrictions) Empty() bool {
+	return r == nil ||
+		(len(r.DenyTables) == 0 && len(r.RedactColumns) == 0 &&
+			len(r.AllowTables) == 0 && len(r.AllowColumns) == 0)
+}
+
 // AccessPolicy is the optional authorization an external auth provider attaches
-// to the console session it mints (see ConsoleSessionIssuer). It has two
-// orthogonal dimensions:
+// to the console session it mints (see ConsoleSessionIssuer). It has three
+// dimensions; the first gates ROUTES, the other two scope DATA:
 //
 //   - Permissions — the capability strings this session holds, gating which
 //     routes it may call. Enforced by the OSS core, per route.
@@ -86,6 +129,9 @@ func AllPermissions() []Permission {
 //     what DATA the session sees. This struct only CARRIES the name; enforcing it
 //     (deny/redact, archive and reconstruct gates) is a separate concern the
 //     console wires per request.
+//   - Restrictions — direct table/column restrictions carried by the policy
+//     itself (#1449), for providers whose rules do not live in the index as
+//     labels. Enforced alongside Profile; both apply when both are set.
 //
 // A nil *AccessPolicy means "no policy" — a full-access session, exactly what the
 // password login and the static token mint today. The OSS build never constructs
@@ -98,6 +144,16 @@ type AccessPolicy struct {
 	Permissions []Permission
 	// Profile is the data-profile name to enforce, or "" for none.
 	Profile string
+	// Restrictions are direct data restrictions, or nil for none.
+	Restrictions *SessionRestrictions
+}
+
+// DataRestricted reports whether the policy scopes what data the session sees —
+// a data profile name, direct restrictions, or both. It is the predicate the
+// console's raw-data surface gates key on; nil-safe (no policy restricts
+// nothing).
+func (p *AccessPolicy) DataRestricted() bool {
+	return p != nil && (p.Profile != "" || !p.Restrictions.Empty())
 }
 
 // Allows reports whether the policy grants p. A nil policy allows everything (no

--- a/ext/consolepolicy_test.go
+++ b/ext/consolepolicy_test.go
@@ -1,0 +1,67 @@
+package ext
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestSessionRestrictionsEmpty pins the nil-safety of Empty: a nil or
+// zero-value restriction set restricts nothing.
+func TestSessionRestrictionsEmpty(t *testing.T) {
+	var nilR *SessionRestrictions
+	if !nilR.Empty() {
+		t.Error("nil *SessionRestrictions must be Empty")
+	}
+	if !(&SessionRestrictions{}).Empty() {
+		t.Error("zero-value SessionRestrictions must be Empty")
+	}
+}
+
+// TestSessionRestrictionsEmptyCoversEveryField derives the per-field cases by
+// reflection instead of hand-listing them: for EVERY slice field of the
+// struct, a value with only that field populated must be non-Empty. The
+// hazard this guards is a field added later and forgotten in Empty — such a
+// restriction would silently read as unrestricted, which is the direction
+// that serves data it should not.
+func TestSessionRestrictionsEmptyCoversEveryField(t *testing.T) {
+	typ := reflect.TypeOf(SessionRestrictions{})
+	for i := 0; i < typ.NumField(); i++ {
+		f := typ.Field(i)
+		v := reflect.New(typ).Elem()
+		fv := v.Field(i)
+		if fv.Kind() != reflect.Slice {
+			t.Fatalf("SessionRestrictions grew non-slice field %s; teach Empty (and this test) its emptiness rule", f.Name)
+		}
+		fv.Set(reflect.Append(fv, reflect.New(fv.Type().Elem()).Elem()))
+		if v.Addr().Interface().(*SessionRestrictions).Empty() {
+			t.Errorf("SessionRestrictions{%s: one element}.Empty() = true — Empty was not taught about this field", f.Name)
+		}
+	}
+}
+
+// TestDataRestricted pins the console gate predicate: a session is
+// data-restricted by a profile name, by direct restrictions, or by both — and
+// NOT by permissions alone, nor by a non-nil-but-empty restriction struct (a
+// provider that constructs the struct unconditionally must not accidentally
+// lock its full-access sessions out of the raw-data surfaces).
+func TestDataRestricted(t *testing.T) {
+	cases := []struct {
+		name string
+		pol  *AccessPolicy
+		want bool
+	}{
+		{"nil policy", nil, false},
+		{"permissions only", &AccessPolicy{Permissions: AllPermissions()}, false},
+		{"empty restrictions struct", &AccessPolicy{Restrictions: &SessionRestrictions{}}, false},
+		{"profile", &AccessPolicy{Profile: "sensitive"}, true},
+		{"restrictions", &AccessPolicy{Restrictions: &SessionRestrictions{DenyTables: []TableRef{{Schema: "s", Table: "t"}}}}, true},
+		{"profile and restrictions", &AccessPolicy{Profile: "p", Restrictions: &SessionRestrictions{AllowTables: []TableRef{{Schema: "s", Table: "t"}}}}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.pol.DataRestricted(); got != tc.want {
+				t.Errorf("DataRestricted = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/console/activity_api.go
+++ b/internal/console/activity_api.go
@@ -507,12 +507,13 @@ func buildActivitySQL(since, until time.Time, deny, allow []query.SchemaTable) (
 	sb.WriteString("SELECT schema_name, table_name, event_type, COUNT(*) AS n FROM binlog_events" +
 		" WHERE event_timestamp >= ? AND event_timestamp < ?")
 	args := []any{since, until}
-	// Allow-list mode (#1449) mirrors buildQuery: only the listed tables
-	// survive; deny still composes over it below.
+	// Allow-list mode (#1449) mirrors buildQuery, BINARY included: a
+	// case-insensitive allow would also count a distinct same-name-other-case
+	// table (see buildQuery's allow clause for the full rationale).
 	if len(allow) > 0 {
 		ors := make([]string, len(allow))
 		for i, at := range allow {
-			ors[i] = "(schema_name = ? AND table_name = ?)"
+			ors[i] = "(BINARY schema_name = ? AND BINARY table_name = ?)"
 			args = append(args, at.Schema, at.Table)
 		}
 		sb.WriteString(" AND (" + strings.Join(ors, " OR ") + ")")

--- a/internal/console/activity_api.go
+++ b/internal/console/activity_api.go
@@ -154,12 +154,14 @@ func (s *Server) handleActivity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// RBAC: the same deny rules every read on this server carries — startup
-	// floor plus the request session's profile. Denied tables are excluded from
-	// the SQL, so they contribute to neither the counts nor the table list (a
-	// table NAME is exactly what a deny profile withholds elsewhere). The cache
-	// is keyed by the resolved deny set for the same reason: two sessions under
-	// different profiles must never share a materialization.
+	// RBAC: the same deny AND allow rules every read on this server carries —
+	// startup floor plus the request session's profile and policy restrictions
+	// (#1449). Denied tables are excluded from the SQL and, in allow-list
+	// mode, so is every table not listed — they contribute to neither the
+	// counts nor the table list (a table NAME is exactly what a restricted
+	// session is withheld elsewhere). The cache is keyed by the resolved
+	// deny+allow scope for the same reason: two sessions under different
+	// policies must never share a materialization.
 	opts, err := s.applySessionProfile(r.Context(), r, b, query.Options{
 		DenyTables:    s.denyTables,
 		RedactColumns: s.redactCols,
@@ -170,7 +172,7 @@ func (s *Server) handleActivity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := b.activityFor(r.Context(), opts.DenyTables)
+	resp, err := b.activityFor(r.Context(), opts.DenyTables, opts.AllowTables)
 	if err != nil {
 		writeFetchError(w, err)
 		return
@@ -183,29 +185,29 @@ func (s *Server) handleActivity(w http.ResponseWriter, r *http.Request) {
 // concurrent misses share one computation) and serving the cached copy —
 // with its original refreshed_at — while a stale one recomputes in the
 // background.
-func (b *bundle) activityFor(ctx context.Context, deny []query.SchemaTable) (activityResponse, error) {
+func (b *bundle) activityFor(ctx context.Context, deny, allow []query.SchemaTable) (activityResponse, error) {
 	compute := func(cctx context.Context) (activityResponse, error) {
-		return computeActivity(cctx, b.db, b.dbName, deny)
+		return computeActivity(cctx, b.db, b.dbName, deny, allow)
 	}
 	if b.activity == nil {
 		// Test-constructed bundles only: every production bundle gets its cache
 		// in newBundleDerived (pinned by TestBundleAlwaysCarriesActivityCache).
 		return compute(ctx)
 	}
-	return b.activity.get(ctx, activityDenyKey(deny), compute)
+	return b.activity.get(ctx, activityScopeKey(deny, allow), compute)
 }
 
 // computeActivity is one materialization flight: derive the live-retention
 // window, run the aggregate over live binlog_events, fold, and stamp the
 // result. This is the ONLY data path behind /api/activity — there is no
 // archive read to fall back to (see the #1352 header comment).
-func computeActivity(ctx context.Context, db *sql.DB, dbName string, deny []query.SchemaTable) (activityResponse, error) {
+func computeActivity(ctx context.Context, db *sql.DB, dbName string, deny, allow []query.SchemaTable) (activityResponse, error) {
 	until := time.Now().UTC().Truncate(time.Second)
 	since, label, err := liveWindow(ctx, db, dbName, until)
 	if err != nil {
 		return activityResponse{}, err
 	}
-	agg, err := collectActivity(ctx, db, since, until, deny)
+	agg, err := collectActivity(ctx, db, since, until, deny, allow)
 	if err != nil {
 		return activityResponse{}, err
 	}
@@ -278,16 +280,27 @@ func windowLabel(d time.Duration) string {
 	return fmt.Sprintf("~%d d", (hrs+12)/24)
 }
 
-// activityDenyKey canonicalizes a deny set into a cache key: same tables in any
-// order → same key, so a session's counts are shared per PROFILE, not per
-// request ordering.
-func activityDenyKey(deny []query.SchemaTable) string {
-	if len(deny) == 0 {
+// activityScopeKey canonicalizes the resolved deny+allow scope into a cache
+// key: same tables in any order → same key, so a session's counts are shared
+// per POLICY, not per request ordering. The two halves are keyed separately
+// and joined with a distinct separator, so a deny of X can never share a
+// materialization with an allow of X — and an allow-list session (whose deny
+// half is typically empty) can never share the full-access entry, which is
+// the cross-trust-boundary collision the old deny-only key allowed.
+func activityScopeKey(deny, allow []query.SchemaTable) string {
+	if len(deny) == 0 && len(allow) == 0 {
 		return ""
 	}
-	keys := make([]string, len(deny))
-	for i, dt := range deny {
-		keys[i] = dt.Schema + "\x00" + dt.Table
+	return tableSetKey(deny) + "\x02" + tableSetKey(allow)
+}
+
+func tableSetKey(set []query.SchemaTable) string {
+	if len(set) == 0 {
+		return ""
+	}
+	keys := make([]string, len(set))
+	for i, st := range set {
+		keys[i] = st.Schema + "\x00" + st.Table
 	}
 	sort.Strings(keys)
 	return strings.Join(keys, "\x01")
@@ -489,11 +502,21 @@ func (a *activityAgg) response(label string, since, until time.Time) activityRes
 // The upper bound is not optional either: a >=-only predicate would sweep in
 // clock-skewed future rows sitting in p_future and count them under a label
 // that says they are inside the window.
-func buildActivitySQL(since, until time.Time, deny []query.SchemaTable) (string, []any) {
+func buildActivitySQL(since, until time.Time, deny, allow []query.SchemaTable) (string, []any) {
 	var sb strings.Builder
 	sb.WriteString("SELECT schema_name, table_name, event_type, COUNT(*) AS n FROM binlog_events" +
 		" WHERE event_timestamp >= ? AND event_timestamp < ?")
 	args := []any{since, until}
+	// Allow-list mode (#1449) mirrors buildQuery: only the listed tables
+	// survive; deny still composes over it below.
+	if len(allow) > 0 {
+		ors := make([]string, len(allow))
+		for i, at := range allow {
+			ors[i] = "(schema_name = ? AND table_name = ?)"
+			args = append(args, at.Schema, at.Table)
+		}
+		sb.WriteString(" AND (" + strings.Join(ors, " OR ") + ")")
+	}
 	for _, dt := range deny {
 		sb.WriteString(" AND NOT (schema_name = ? AND table_name = ?)")
 		args = append(args, dt.Schema, dt.Table)
@@ -503,8 +526,8 @@ func buildActivitySQL(since, until time.Time, deny []query.SchemaTable) (string,
 }
 
 // collectActivity runs the aggregate and folds it.
-func collectActivity(ctx context.Context, db *sql.DB, since, until time.Time, deny []query.SchemaTable) (*activityAgg, error) {
-	q, args := buildActivitySQL(since, until, deny)
+func collectActivity(ctx context.Context, db *sql.DB, since, until time.Time, deny, allow []query.SchemaTable) (*activityAgg, error) {
+	q, args := buildActivitySQL(since, until, deny, allow)
 	rows, err := db.QueryContext(ctx, q, args...)
 	if err != nil {
 		return nil, err

--- a/internal/console/activity_api_test.go
+++ b/internal/console/activity_api_test.go
@@ -321,8 +321,8 @@ func TestBuildActivitySQL_allowList(t *testing.T) {
 	allow := []query.SchemaTable{{Schema: "app", Table: "users"}, {Schema: "app", Table: "orders"}}
 	deny := []query.SchemaTable{{Schema: "app", Table: "orders"}}
 	q, args := buildActivitySQL(since, since.Add(time.Hour), deny, allow)
-	if !strings.Contains(q, "AND ((schema_name = ? AND table_name = ?) OR (schema_name = ? AND table_name = ?))") {
-		t.Errorf("allow-list clause missing: %s", q)
+	if !strings.Contains(q, "AND ((BINARY schema_name = ? AND BINARY table_name = ?) OR (BINARY schema_name = ? AND BINARY table_name = ?))") {
+		t.Errorf("exact-match allow-list clause missing: %s", q)
 	}
 	if !strings.Contains(q, "AND NOT (schema_name = ? AND table_name = ?)") {
 		t.Errorf("deny clause must still compose over the allow list: %s", q)

--- a/internal/console/activity_api_test.go
+++ b/internal/console/activity_api_test.go
@@ -290,14 +290,45 @@ func TestActivityStaleCacheServesOldAndRefreshes(t *testing.T) {
 func TestActivityDenyKey(t *testing.T) {
 	a := []query.SchemaTable{{Schema: "shop", Table: "secrets"}, {Schema: "hr", Table: "salaries"}}
 	b := []query.SchemaTable{{Schema: "hr", Table: "salaries"}, {Schema: "shop", Table: "secrets"}}
-	if activityDenyKey(a) != activityDenyKey(b) {
+	if activityScopeKey(a, nil) != activityScopeKey(b, nil) {
 		t.Error("same deny set in different order produced different cache keys")
 	}
-	if activityDenyKey(a) == activityDenyKey(a[:1]) {
+	if activityScopeKey(a, nil) == activityScopeKey(a[:1], nil) {
 		t.Error("different deny sets share a cache key — a redaction bypass via the cache")
 	}
-	if activityDenyKey(nil) != "" || activityDenyKey(nil) == activityDenyKey(a) {
-		t.Error("the empty deny set must key separately from every profile")
+	if activityScopeKey(nil, nil) != "" || activityScopeKey(nil, nil) == activityScopeKey(a, nil) {
+		t.Error("the empty scope must key separately from every profile")
+	}
+	// The #1449 dimensions: an allow of X must never share with a deny of X
+	// (opposite meanings), and an allow-list session must never share the
+	// full-access entry — the cross-trust-boundary collision the deny-only
+	// key allowed.
+	if activityScopeKey(a, nil) == activityScopeKey(nil, a) {
+		t.Error("deny(X) and allow(X) share a cache key — opposite scopes, one materialization")
+	}
+	if activityScopeKey(nil, a) == activityScopeKey(nil, nil) {
+		t.Error("an allow-list scope shares the full-access cache entry")
+	}
+	if activityScopeKey(nil, a) != activityScopeKey(nil, b) {
+		t.Error("same allow set in different order produced different cache keys")
+	}
+}
+
+// TestBuildActivitySQL_allowList pins allow-list mode on the aggregate: the
+// clause mirrors buildQuery's, and deny still composes over it.
+func TestBuildActivitySQL_allowList(t *testing.T) {
+	since := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	allow := []query.SchemaTable{{Schema: "app", Table: "users"}, {Schema: "app", Table: "orders"}}
+	deny := []query.SchemaTable{{Schema: "app", Table: "orders"}}
+	q, args := buildActivitySQL(since, since.Add(time.Hour), deny, allow)
+	if !strings.Contains(q, "AND ((schema_name = ? AND table_name = ?) OR (schema_name = ? AND table_name = ?))") {
+		t.Errorf("allow-list clause missing: %s", q)
+	}
+	if !strings.Contains(q, "AND NOT (schema_name = ? AND table_name = ?)") {
+		t.Errorf("deny clause must still compose over the allow list: %s", q)
+	}
+	if len(args) != 2+4+2 {
+		t.Errorf("args = %d, want window(2) + allow(4) + deny(2): %v", len(args), args)
 	}
 }
 
@@ -327,7 +358,7 @@ func TestBundleAlwaysCarriesActivityCache(t *testing.T) {
 func TestActivitySQLPrunesPartitions(t *testing.T) {
 	since := time.Date(2026, 8, 9, 10, 0, 0, 0, time.UTC)
 	until := since.Add(24 * time.Hour)
-	q, args := buildActivitySQL(since, until, nil)
+	q, args := buildActivitySQL(since, until, nil, nil)
 
 	if !strings.Contains(q, "event_timestamp >= ?") {
 		t.Errorf("missing bare-column lower bound in %q", q)
@@ -355,7 +386,7 @@ func TestActivitySQLPrunesPartitions(t *testing.T) {
 func TestActivitySQLExcludesDeniedTables(t *testing.T) {
 	since := time.Date(2026, 8, 9, 10, 0, 0, 0, time.UTC)
 	deny := []query.SchemaTable{{Schema: "shop", Table: "secrets"}, {Schema: "hr", Table: "salaries"}}
-	q, args := buildActivitySQL(since, since.Add(time.Hour), deny)
+	q, args := buildActivitySQL(since, since.Add(time.Hour), deny, nil)
 
 	if n := strings.Count(q, "NOT (schema_name = ? AND table_name = ?)"); n != 2 {
 		t.Errorf("deny clauses = %d, want 2 in %q", n, q)

--- a/internal/console/api.go
+++ b/internal/console/api.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -969,7 +970,7 @@ func filterSchemas(names []string, allow []query.SchemaTable) []string {
 	for _, at := range allow {
 		allowed[at.Schema] = true
 	}
-	var out []string
+	out := []string{} // never null on the wire, matching handleProfiles
 	for _, n := range names {
 		if allowed[n] {
 			out = append(out, n)
@@ -981,14 +982,18 @@ func filterSchemas(names []string, allow []query.SchemaTable) []string {
 // filterTables withholds table names the resolved scope would withhold as
 // rows: denied tables are dropped, and in allow-list mode only the listed
 // tables of this schema survive. Deny composes over allow, as everywhere.
+// The two matches are asymmetric like the SQL clauses (see buildQuery's
+// allow clause): allow matches EXACTLY (a case-insensitive allow fails open),
+// deny matches case-insensitively (withholding more is the safe direction,
+// and it mirrors what the column-collation deny clause withholds as rows).
 func filterTables(schema string, tables []string, deny, allow []query.SchemaTable) []string {
 	if len(deny) == 0 && len(allow) == 0 {
 		return tables
 	}
-	denied := make(map[string]bool, len(deny))
+	var denied []string
 	for _, dt := range deny {
-		if dt.Schema == schema {
-			denied[dt.Table] = true
+		if strings.EqualFold(dt.Schema, schema) {
+			denied = append(denied, dt.Table)
 		}
 	}
 	var allowed map[string]bool
@@ -1000,9 +1005,9 @@ func filterTables(schema string, tables []string, deny, allow []query.SchemaTabl
 			}
 		}
 	}
-	var out []string
+	out := []string{} // never null on the wire, matching handleProfiles
 	for _, t := range tables {
-		if denied[t] {
+		if slices.ContainsFunc(denied, func(d string) bool { return strings.EqualFold(d, t) }) {
 			continue
 		}
 		if allowed != nil && !allowed[t] {
@@ -1180,6 +1185,13 @@ func atoiDefault(s string, def int) int {
 // ALTER — is confined to the command-line DSN), so instead of a cryptic 500 we
 // return an actionable 422 telling the operator how to migrate.
 func writeFetchError(w http.ResponseWriter, err error) {
+	// A policy refusal, not a fault: the changed-column filter is withheld
+	// under column-level redaction (#1449; the engine's sentinel carries the
+	// full reasoning). 403 like every other policy refusal on this surface.
+	if errors.Is(err, query.ErrChangedColumnUnderRedaction) {
+		writeJSONError(w, http.StatusForbidden, err.Error())
+		return
+	}
 	var myErr *mysql.MySQLError
 	if errors.As(err, &myErr) && myErr.Number == 1054 &&
 		(strings.Contains(myErr.Message, "connection_id") ||

--- a/internal/console/api.go
+++ b/internal/console/api.go
@@ -383,10 +383,46 @@ func anchorMissedWarning(opts query.Options, rowCount int) []string {
 	}
 	return []string{fmt.Sprintf(
 		"The selected event (id %d at %s UTC) was not found. It may fall outside the time range "+
-			"on this form, be withheld by your access profile, be held only in an archive this "+
+			"on this form, be withheld by your access policy, be held only in an archive this "+
 			"read did not reach, or belong to a different server; event ids are per-index. "+
 			"This is NOT evidence that the row has no history.",
 		opts.EventAnchor.EventID, opts.EventAnchor.Timestamp.UTC().Format("2006-01-02 15:04:05"))}
+}
+
+// columnRedactionWarning reports, for a recover response, that the generated
+// script covers a table whose column values the resolved scope nulls — via
+// explicit RedactColumns or via a column allow list (#1449). Empty when no
+// matched row's table is covered: a policy that redacts elsewhere does not
+// taint this script.
+func columnRedactionWarning(opts query.Options, rows []query.ResultRow) string {
+	if len(opts.RedactColumns) == 0 && len(opts.AllowColumns) == 0 {
+		return ""
+	}
+	covered := make(map[query.SchemaTable]bool, len(opts.RedactColumns)+len(opts.AllowColumns))
+	for _, c := range opts.RedactColumns {
+		covered[query.SchemaTable{Schema: c.Schema, Table: c.Table}] = true
+	}
+	for _, c := range opts.AllowColumns {
+		covered[query.SchemaTable{Schema: c.Schema, Table: c.Table}] = true
+	}
+	hit := map[string]bool{}
+	for i := range rows {
+		if covered[query.SchemaTable{Schema: rows[i].SchemaName, Table: rows[i].TableName}] {
+			hit[rows[i].SchemaName+"."+rows[i].TableName] = true
+		}
+	}
+	if len(hit) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(hit))
+	for n := range hit {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return "Your access policy hides some column values on " + strings.Join(names, ", ") +
+		", and hidden values appear as NULL in the script below: applying it would write NULL " +
+		"over those columns. Have an operator without column restrictions generate the reversal " +
+		"if a faithful restore is needed."
 }
 
 // handleEvents serves GET /api/events — the events browser.
@@ -659,6 +695,15 @@ func (s *Server) handleRecover(w http.ResponseWriter, r *http.Request) {
 	}
 	rows = query.MergeResults(rows, 0, "ASC")
 
+	// A reversal built from redacted row images writes NULL where the policy
+	// hides the value (#1449 made this the allow-list DEFAULT rather than a
+	// per-column opt-in): reversed DELETEs re-insert NULLs, reversed UPDATEs
+	// set them. That script is not a faithful restore, and the reviewer of an
+	// undo script must see it stated — prepended, like the cascade warnings.
+	if msg := columnRedactionWarning(opts, rows); msg != "" {
+		warnings = append([]string{msg}, warnings...)
+	}
+
 	// Per-bundle dialect (the console is multi-server): MySQLDialect covers MySQL +
 	// MariaDB, PostgresDialect a PG-flavored index. Read once and reused below.
 	dialect := recovery.DialectForIndex(b.db)
@@ -870,6 +915,20 @@ func (s *Server) handleSchemas(w http.ResponseWriter, r *http.Request) {
 	if b == nil {
 		return
 	}
+	// The resolved deny/allow scope (startup floor + session profile + policy
+	// restrictions, #1449) filters the NAME listings below: a table name is
+	// exactly what a deny withholds elsewhere, and in allow-list mode the
+	// unfiltered picker would leak the whole inventory EXCEPT the allowed
+	// handful — the inverse of what "only these tables" means.
+	opts, err := s.applySessionProfile(r.Context(), r, b, query.Options{
+		DenyTables:    s.denyTables,
+		RedactColumns: s.redactCols,
+		ProfileActive: s.profileActive,
+	})
+	if err != nil {
+		writeSessionProfileError(w, r, err)
+		return
+	}
 	schema := r.URL.Query().Get("schema")
 	if schema == "" {
 		restricted := sessionRestricted(r)
@@ -879,7 +938,7 @@ func (s *Server) handleSchemas(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		writeJSON(w, http.StatusOK, schemasResponse{
-			Schemas:      names,
+			Schemas:      filterSchemas(names, opts.AllowTables),
 			SnapshotOnly: snapshotOnly,
 			// Suppressed under noArchive and under a profiled session: there the
 			// snapshot half is skipped by design (archives unreachable), so a
@@ -894,7 +953,64 @@ func (s *Server) handleSchemas(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	writeJSON(w, http.StatusOK, tablesResponse{Schema: schema, Tables: tables})
+	writeJSON(w, http.StatusOK, tablesResponse{Schema: schema, Tables: filterTables(schema, tables, opts.DenyTables, opts.AllowTables)})
+}
+
+// filterSchemas applies allow-list mode to the schema listing: with a
+// non-empty allow set, only schemas that hold at least one allowed table are
+// listed. Deny rules do not hide a schema — they are table-scoped, and a
+// schema with one denied table still has listable siblings (filterTables
+// withholds the denied names).
+func filterSchemas(names []string, allow []query.SchemaTable) []string {
+	if len(allow) == 0 {
+		return names
+	}
+	allowed := make(map[string]bool, len(allow))
+	for _, at := range allow {
+		allowed[at.Schema] = true
+	}
+	var out []string
+	for _, n := range names {
+		if allowed[n] {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+// filterTables withholds table names the resolved scope would withhold as
+// rows: denied tables are dropped, and in allow-list mode only the listed
+// tables of this schema survive. Deny composes over allow, as everywhere.
+func filterTables(schema string, tables []string, deny, allow []query.SchemaTable) []string {
+	if len(deny) == 0 && len(allow) == 0 {
+		return tables
+	}
+	denied := make(map[string]bool, len(deny))
+	for _, dt := range deny {
+		if dt.Schema == schema {
+			denied[dt.Table] = true
+		}
+	}
+	var allowed map[string]bool
+	if len(allow) > 0 {
+		allowed = make(map[string]bool, len(allow))
+		for _, at := range allow {
+			if at.Schema == schema {
+				allowed[at.Table] = true
+			}
+		}
+	}
+	var out []string
+	for _, t := range tables {
+		if denied[t] {
+			continue
+		}
+		if allowed != nil && !allowed[t] {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
 }
 
 // handleHealthz serves GET /api/healthz — an unauthenticated liveness probe.

--- a/internal/console/api_test.go
+++ b/internal/console/api_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http/httptest"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -667,4 +668,33 @@ func TestLoadResolverUnavailable(t *testing.T) {
 			t.Errorf("loadResolver = (%v, %v), want (nil, false)", r, unavailable)
 		}
 	})
+}
+
+// TestFilterTablesAndSchemas is the always-running pin of the picker
+// filters' asymmetry: allow matches exactly (case-insensitive allow fails
+// OPEN), deny matches case-insensitively (withholding more is safe). The
+// end-to-end behavior lives in the integration tier, which skips without
+// MySQL; this one cannot skip.
+func TestFilterTablesAndSchemas(t *testing.T) {
+	deny := []query.SchemaTable{{Schema: "App", Table: "Secrets"}}
+	allow := []query.SchemaTable{{Schema: "app", Table: "users"}}
+
+	got := filterTables("app", []string{"users", "Users", "secrets", "orders"}, deny, nil)
+	if slices.Contains(got, "secrets") || !slices.Contains(got, "users") {
+		t.Errorf("deny must match case-insensitively and spare siblings: %v", got)
+	}
+	got = filterTables("app", []string{"users", "Users", "orders"}, nil, allow)
+	if !slices.Equal(got, []string{"users"}) {
+		t.Errorf("allow must match exactly (Users is a DIFFERENT table): %v", got)
+	}
+	if got := filterTables("app", []string{"users"}, deny, nil); got == nil {
+		t.Error("a filtered result must never be nil on the wire")
+	}
+	schemas := filterSchemas([]string{"app", "App", "hr"}, allow)
+	if !slices.Equal(schemas, []string{"app"}) {
+		t.Errorf("schema allow-list must match exactly: %v", schemas)
+	}
+	if got := filterSchemas([]string{"hr"}, allow); got == nil {
+		t.Error("a fully-filtered schema list must never be nil on the wire")
+	}
 }

--- a/internal/console/api_test.go
+++ b/internal/console/api_test.go
@@ -596,6 +596,18 @@ func TestHandleSchemasSnapshotUnavailable(t *testing.T) {
 				t.Fatalf("sqlmock: %v", err)
 			}
 			defer db.Close()
+			if c.profiled {
+				// handleSchemas resolves the session profile like every other
+				// data read (its name listings are filtered by the resolved
+				// scope), so the profile must exist — with no rules, since this
+				// test is about the snapshot flag, not filtering.
+				mock.ExpectQuery(`SELECT EXISTS\(SELECT 1 FROM profiles`).
+					WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+				mock.ExpectQuery(`SELECT DISTINCT tf.schema_name, tf.table_name\s+FROM access_rules`).
+					WillReturnRows(sqlmock.NewRows([]string{"schema_name", "table_name"}))
+				mock.ExpectQuery(`SELECT DISTINCT tf.schema_name, tf.table_name, tf.column_name`).
+					WillReturnRows(sqlmock.NewRows([]string{"schema_name", "table_name", "column_name"}))
+			}
 			mock.ExpectQuery("SELECT DISTINCT schema_name FROM binlog_events").
 				WillReturnRows(sqlmock.NewRows([]string{"schema_name"}))
 

--- a/internal/console/events_scope_live_test.go
+++ b/internal/console/events_scope_live_test.go
@@ -232,8 +232,8 @@ func TestLiveScopeAdvisories(t *testing.T) {
 			if tc.wantNote == "" && strings.Contains(jn, "complete answer") {
 				t.Errorf("notes = %q — 'complete' claimed on a scope that excluded the archives", jn)
 			}
-			if tc.excl.profile && !strings.Contains(jw, "profile") {
-				t.Errorf("warnings = %q, want the profile exclusion still announced", jw)
+			if tc.excl.profile && !strings.Contains(jw, "Your session carries") {
+				t.Errorf("warnings = %q, want the session-policy exclusion still announced", jw)
 			}
 		})
 	}

--- a/internal/console/extview.go
+++ b/internal/console/extview.go
@@ -89,6 +89,12 @@ func (s *Server) consoleQueryContext(r *http.Request) (ext.ConsoleQueryContext, 
 // console's own surfaces solved the same problem.
 func (s *Server) consoleFetch(b *bundle) func(ctx context.Context, opts query.Options) ([]query.ResultRow, *query.QueryPlan, error) {
 	return func(ctx context.Context, opts query.Options) ([]query.ResultRow, *query.QueryPlan, error) {
+		// STARTUP floor only. This closure has no *http.Request, so session
+		// scoping — the profile since #1075, and policy restrictions since
+		// #1449 — structurally cannot be attached here; rbacViewGuard is what
+		// keeps a restricted session away from every provider handler that
+		// could reach this fetch. The defense-in-depth this closure provides
+		// covers exactly the process-global posture, nothing session-scoped.
 		opts.DenyTables = s.denyTables
 		opts.RedactColumns = s.redactCols
 		opts.ProfileActive = s.profileActive

--- a/internal/console/mcptoken_api.go
+++ b/internal/console/mcptoken_api.go
@@ -63,6 +63,17 @@ var mcpTokenMutateMu sync.Mutex
 // minter (nil policy — the static token, a password login, every OSS
 // session) records no cap.
 func (s *Server) handleMCPTokenGenerate(w http.ResponseWriter, r *http.Request) {
+	// A DATA-restricted session (profile or policy restrictions, #1449) is
+	// refused outright: the token file records permission grants only, so a
+	// minted token would read the same index through /mcp with the session's
+	// redaction gone — the permission cap below cannot express a data scope.
+	// Same posture as every surface that cannot honor redaction.
+	if pol := policyFrom(r.Context()); pol.DataRestricted() {
+		recordProfileGateDeny(r, "mcp-token")
+		writeJSONError(w, http.StatusForbidden,
+			"an MCP token cannot be generated from a session with a data access policy: the token would read the index without your session's redaction. Ask an operator without data restrictions to manage the MCP token.")
+		return
+	}
 	mcpTokenMutateMu.Lock()
 	defer mcpTokenMutateMu.Unlock()
 	var grants []ext.Permission

--- a/internal/console/session_profile.go
+++ b/internal/console/session_profile.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/dbtrail/dbtrail/ext"
 	"github.com/dbtrail/dbtrail/internal/query"
 )
 
@@ -39,13 +40,24 @@ func sessionProfileName(r *http.Request) string {
 	return ""
 }
 
-// sessionRestricted reports whether the request's session carries a data
-// profile. It is the single predicate the raw/baseline-data gates key on
-// (reconstruct, baselines, recover-cascade, verify, extension views): those
-// surfaces cannot honor per-column redaction, so a profiled session is refused
-// outright rather than shown unredacted data.
+// sessionRestrictions returns the direct table/column restrictions the
+// request's session policy carries (#1449), or nil. Nil-safe on both ends —
+// SessionRestrictions methods accept a nil receiver.
+func sessionRestrictions(r *http.Request) *ext.SessionRestrictions {
+	if p := policyFrom(r.Context()); p != nil {
+		return p.Restrictions
+	}
+	return nil
+}
+
+// sessionRestricted reports whether the request's session scopes what data it
+// may read — a data profile, direct policy restrictions (#1449), or both. It
+// is the single predicate the raw/baseline-data gates key on (reconstruct,
+// baselines, recover-cascade, verify, extension views): those surfaces cannot
+// honor per-column redaction, so a restricted session is refused outright
+// rather than shown unredacted data.
 func sessionRestricted(r *http.Request) bool {
-	return sessionProfileName(r) != ""
+	return policyFrom(r.Context()).DataRestricted()
 }
 
 // rbacActiveFor folds the request's session profile into the process-global
@@ -185,28 +197,56 @@ func (c *profileRuleCache) invalidate(id string) {
 	}
 }
 
-// applySessionProfile unions the request session's data-profile rules — resolved
-// against the selected server's index — onto opts, on top of the startup floor
-// buildOptions already set, and forces ProfileActive so query_text/query_hash
-// stay withheld (#699). A profile that does not exist on the selected server is a
-// *profileNotFoundError (handler → 403). No session profile → opts unchanged.
+// applySessionProfile unions the request session's data restrictions onto opts,
+// on top of the startup floor buildOptions already set, and forces
+// ProfileActive so query_text/query_hash stay withheld (#699). Two sources,
+// both applied when both are present:
+//
+//   - a data-profile NAME (resolved against the selected server's index at
+//     request time; nonexistent → *profileNotFoundError, handler → 403);
+//   - direct policy restrictions (#1449), carried by the session itself and
+//     needing no index resolution.
+//
+// Neither present → opts unchanged.
 func (s *Server) applySessionProfile(ctx context.Context, r *http.Request, b *bundle, opts query.Options) (query.Options, error) {
 	profile := sessionProfileName(r)
-	if profile == "" {
+	rest := sessionRestrictions(r)
+	if profile == "" && rest.Empty() {
 		return opts, nil
-	}
-	e, err := s.sessionProfiles.load(ctx, s.selectedID(r)+"\x00"+profile, b.db, profile)
-	if err != nil {
-		return opts, fmt.Errorf("resolve session profile %q: %w", profile, err)
-	}
-	if !e.exists {
-		return opts, &profileNotFoundError{profile}
 	}
 	// Union with the startup floor: the startup profile is the floor, a session
 	// profile can only narrow further. Copy rather than append-in-place so the
 	// startup slices (shared across requests) are never mutated.
-	opts.DenyTables = append(append([]query.SchemaTable(nil), opts.DenyTables...), e.deny...)
-	opts.RedactColumns = append(append([]query.SchemaTableColumn(nil), opts.RedactColumns...), e.redact...)
+	opts.DenyTables = append([]query.SchemaTable(nil), opts.DenyTables...)
+	opts.RedactColumns = append([]query.SchemaTableColumn(nil), opts.RedactColumns...)
+	if profile != "" {
+		e, err := s.sessionProfiles.load(ctx, s.selectedID(r)+"\x00"+profile, b.db, profile)
+		if err != nil {
+			return opts, fmt.Errorf("resolve session profile %q: %w", profile, err)
+		}
+		if !e.exists {
+			return opts, &profileNotFoundError{profile}
+		}
+		opts.DenyTables = append(opts.DenyTables, e.deny...)
+		opts.RedactColumns = append(opts.RedactColumns, e.redact...)
+	}
+	if !rest.Empty() {
+		for _, t := range rest.DenyTables {
+			opts.DenyTables = append(opts.DenyTables, query.SchemaTable{Schema: t.Schema, Table: t.Table})
+		}
+		for _, c := range rest.RedactColumns {
+			opts.RedactColumns = append(opts.RedactColumns, query.SchemaTableColumn{Schema: c.Schema, Table: c.Table, Column: c.Column})
+		}
+		// The allow lists have no startup-floor counterpart (nothing else sets
+		// them on console options), so these are plain conversions, copied so
+		// the session policy's slices are never aliased into query options.
+		for _, t := range rest.AllowTables {
+			opts.AllowTables = append(opts.AllowTables, query.SchemaTable{Schema: t.Schema, Table: t.Table})
+		}
+		for _, c := range rest.AllowColumns {
+			opts.AllowColumns = append(opts.AllowColumns, query.SchemaTableColumn{Schema: c.Schema, Table: c.Table, Column: c.Column})
+		}
+	}
 	opts.ProfileActive = true
 	return opts, nil
 }

--- a/internal/console/session_profile.go
+++ b/internal/console/session_profile.go
@@ -237,9 +237,13 @@ func (s *Server) applySessionProfile(ctx context.Context, r *http.Request, b *bu
 		for _, c := range rest.RedactColumns {
 			opts.RedactColumns = append(opts.RedactColumns, query.SchemaTableColumn{Schema: c.Schema, Table: c.Table, Column: c.Column})
 		}
-		// The allow lists have no startup-floor counterpart (nothing else sets
-		// them on console options), so these are plain conversions, copied so
-		// the session policy's slices are never aliased into query options.
+		// The allow lists have no startup-floor counterpart today (nothing
+		// else sets them on console options), but they get the same
+		// copy-before-append discipline as the deny slices anyway: the next
+		// caller who DOES pre-populate them from a shared slice must not
+		// discover cross-request mutation the hard way.
+		opts.AllowTables = append([]query.SchemaTable(nil), opts.AllowTables...)
+		opts.AllowColumns = append([]query.SchemaTableColumn(nil), opts.AllowColumns...)
 		for _, t := range rest.AllowTables {
 			opts.AllowTables = append(opts.AllowTables, query.SchemaTable{Schema: t.Schema, Table: t.Table})
 		}
@@ -326,7 +330,9 @@ type archiveExclusion struct {
 	// server: the whole console excludes archives (--no-archive, or a startup
 	// --profile, which implies it — see consoleapp/serve.go).
 	server bool
-	// profile: THIS session carries a data profile.
+	// profile: THIS session carries a data access policy — a profile name,
+	// direct restrictions (#1449), or both (sessionRestricted's verdict; the
+	// field keeps its original name).
 	profile bool
 }
 
@@ -369,10 +375,10 @@ func (e archiveExclusion) notice() string {
 			"implies it), so archived (rotated) hours are not searched. A short or empty result does not " +
 			"mean nothing happened in that window."
 	case e.profile:
-		return "Your session carries a data profile, so these results come from the LIVE INDEX ONLY: " +
+		return "Your session carries a data access policy, so these results come from the LIVE INDEX ONLY: " +
 			"archived (rotated) hours are not searched, because the archive path cannot apply the " +
-			"redaction your profile requires. A short or empty result does not mean nothing happened " +
-			"in that window; ask an operator without a data profile, or use the CLI, to search the archives."
+			"redaction your policy requires. A short or empty result does not mean nothing happened " +
+			"in that window; ask an operator without data restrictions, or use the CLI, to search the archives."
 	}
 	return ""
 }

--- a/internal/console/session_profile_test.go
+++ b/internal/console/session_profile_test.go
@@ -29,6 +29,12 @@ func TestSessionRestricted(t *testing.T) {
 		{"no policy (OSS)", nil, false},
 		{"policy, no profile", &ext.AccessPolicy{Permissions: ext.AllPermissions()}, false},
 		{"policy with profile", &ext.AccessPolicy{Profile: "sensitive"}, true},
+		{"policy with restrictions (#1449)", &ext.AccessPolicy{
+			Restrictions: &ext.SessionRestrictions{DenyTables: []ext.TableRef{{Schema: "s", Table: "t"}}},
+		}, true},
+		{"policy with EMPTY restrictions struct", &ext.AccessPolicy{
+			Restrictions: &ext.SessionRestrictions{},
+		}, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -71,6 +77,47 @@ func TestApplySessionProfileNoOp(t *testing.T) {
 	}
 	if out.ProfileActive != false || len(out.DenyTables) != 1 {
 		t.Errorf("no-profile session must leave opts unchanged, got %+v", out)
+	}
+}
+
+// TestApplySessionPolicyRestrictions pins the #1449 path: a session whose
+// policy carries direct restrictions (no profile name) gets them unioned onto
+// the startup floor — converted to query types, allow lists included — with
+// ProfileActive forced so query_text/query_hash stay withheld. No profile
+// name means no index round trip: the bundle carries no DB here, so reaching
+// for one would panic this test.
+func TestApplySessionPolicyRestrictions(t *testing.T) {
+	s := &Server{sessionProfiles: newProfileRuleCache()}
+	pol := &ext.AccessPolicy{Restrictions: &ext.SessionRestrictions{
+		DenyTables:    []ext.TableRef{{Schema: "hr", Table: "payroll"}},
+		RedactColumns: []ext.TableColumnRef{{Schema: "hr", Table: "people", Column: "ssn"}},
+		AllowTables:   []ext.TableRef{{Schema: "shop", Table: "orders"}},
+		AllowColumns:  []ext.TableColumnRef{{Schema: "shop", Table: "orders", Column: "id"}},
+	}}
+	in := query.Options{DenyTables: []query.SchemaTable{{Schema: "floor", Table: "f"}}}
+	out, err := s.applySessionProfile(context.Background(), reqWithPolicy(pol), &bundle{}, in)
+	if err != nil {
+		t.Fatalf("applySessionProfile err = %v", err)
+	}
+	if !out.ProfileActive {
+		t.Error("restrictions must force ProfileActive (query_text/query_hash withholding)")
+	}
+	wantDeny := []query.SchemaTable{{Schema: "floor", Table: "f"}, {Schema: "hr", Table: "payroll"}}
+	if len(out.DenyTables) != 2 || out.DenyTables[0] != wantDeny[0] || out.DenyTables[1] != wantDeny[1] {
+		t.Errorf("DenyTables = %v, want startup floor + policy deny (%v)", out.DenyTables, wantDeny)
+	}
+	if len(out.RedactColumns) != 1 || out.RedactColumns[0] != (query.SchemaTableColumn{Schema: "hr", Table: "people", Column: "ssn"}) {
+		t.Errorf("RedactColumns = %v, want the policy's converted entry", out.RedactColumns)
+	}
+	if len(out.AllowTables) != 1 || out.AllowTables[0] != (query.SchemaTable{Schema: "shop", Table: "orders"}) {
+		t.Errorf("AllowTables = %v, want the policy's converted entry", out.AllowTables)
+	}
+	if len(out.AllowColumns) != 1 || out.AllowColumns[0] != (query.SchemaTableColumn{Schema: "shop", Table: "orders", Column: "id"}) {
+		t.Errorf("AllowColumns = %v, want the policy's converted entry", out.AllowColumns)
+	}
+	// The startup floor slice the caller handed in must not have been mutated.
+	if len(in.DenyTables) != 1 || in.DenyTables[0] != (query.SchemaTable{Schema: "floor", Table: "f"}) {
+		t.Errorf("caller's options were mutated: %v", in.DenyTables)
 	}
 }
 

--- a/internal/console/session_restrictions_integration_test.go
+++ b/internal/console/session_restrictions_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/dbtrail/dbtrail/ext"
 	"github.com/dbtrail/dbtrail/internal/testutil"
@@ -74,6 +75,150 @@ func TestIntegrationSessionRestrictionsAllowList(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), "alice@example") {
 		t.Errorf("allowed column email must remain: %s", rec.Body.String())
+	}
+}
+
+// TestIntegrationSessionRestrictionsActivity pins the Overview aggregate:
+// allow-list mode scopes the counts AND the table-name inventory, and the
+// materialization cache never crosses the trust boundary (the full-access
+// read on the same server still sees everything, from its own cache entry).
+func TestIntegrationSessionRestrictionsActivity(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	srv := newProfileIndexServer(t)
+	// The Overview window is live retention (24h fallback here); the shared
+	// fixture's events sit outside it, so the aggregate needs events of its
+	// own, inside the window.
+	recent := time.Now().UTC().Add(-time.Hour).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, srv.cm.boot.db, "bin.000002", 4, 40, recent, nil,
+		"app", "users", 1 /*INSERT*/, "9",
+		nil, nil, []byte(`{"id":9,"email":"bob@example","ssn":"ssn-999"}`))
+	testutil.InsertEvent(t, srv.cm.boot.db, "bin.000002", 40, 80, recent, nil,
+		"app", "secrets", 1 /*INSERT*/, "9",
+		nil, nil, []byte(`{"id":9,"value":"topsecret2"}`))
+	scoped := restrictedBearer(t, srv, &ext.SessionRestrictions{
+		AllowTables: []ext.TableRef{{Schema: "app", Table: "users"}},
+	})
+
+	rec := getPath(t, srv, "127.0.0.1:8090", "/api/activity", scoped)
+	if rec.Code != 200 {
+		t.Fatalf("activity = %d: %s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "secrets") {
+		t.Errorf("a table outside the allow list surfaced in the activity aggregate: %s", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "users") {
+		t.Errorf("the allowed table must still be counted: %s", rec.Body.String())
+	}
+	// Full access on the same server: its own materialization, unscoped.
+	rec = getPath(t, srv, "127.0.0.1:8090", "/api/activity", "static-tok")
+	if !strings.Contains(rec.Body.String(), "secrets") {
+		t.Errorf("the full-access aggregate must not inherit the restricted session's scope: %s", rec.Body.String())
+	}
+}
+
+// TestIntegrationSessionRestrictionsSchemaListing pins the picker inventory:
+// table (and schema) NAMES are filtered by the resolved scope — under
+// allow-list mode the unfiltered listing would leak everything EXCEPT the
+// allowed handful, the inverse of the restriction's meaning.
+func TestIntegrationSessionRestrictionsSchemaListing(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	srv := newProfileIndexServer(t)
+	testutil.InsertEvent(t, srv.cm.boot.db, "bin.000001", 80, 120, "2026-06-01 12:02:00", nil,
+		"hr", "salaries", 1 /*INSERT*/, "1",
+		nil, nil, []byte(`{"id":1,"amount":100}`))
+	scoped := restrictedBearer(t, srv, &ext.SessionRestrictions{
+		AllowTables: []ext.TableRef{{Schema: "app", Table: "users"}},
+	})
+
+	rec := getPath(t, srv, "127.0.0.1:8090", "/api/schemas", scoped)
+	if strings.Contains(rec.Body.String(), "hr") {
+		t.Errorf("a schema outside the allow list surfaced in the listing: %s", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "app") {
+		t.Errorf("the allowed table's schema must be listed: %s", rec.Body.String())
+	}
+	rec = getPath(t, srv, "127.0.0.1:8090", "/api/schemas?schema=app", scoped)
+	if strings.Contains(rec.Body.String(), "secrets") {
+		t.Errorf("a table outside the allow list surfaced in the table picker: %s", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "users") {
+		t.Errorf("the allowed table must be listed: %s", rec.Body.String())
+	}
+
+	// Deny mode: the denied name disappears, siblings stay.
+	denied := restrictedBearer(t, srv, &ext.SessionRestrictions{
+		DenyTables: []ext.TableRef{{Schema: "app", Table: "secrets"}},
+	})
+	rec = getPath(t, srv, "127.0.0.1:8090", "/api/schemas?schema=app", denied)
+	if strings.Contains(rec.Body.String(), "secrets") || !strings.Contains(rec.Body.String(), "users") {
+		t.Errorf("deny filtering wrong in the table picker: %s", rec.Body.String())
+	}
+	// The unrestricted static token keeps the full inventory.
+	rec = getPath(t, srv, "127.0.0.1:8090", "/api/schemas?schema=app", "static-tok")
+	if !strings.Contains(rec.Body.String(), "secrets") {
+		t.Errorf("the full-access picker must keep every table: %s", rec.Body.String())
+	}
+}
+
+// TestIntegrationSessionRestrictionsMCPTokenMint pins the laundering door
+// shut: a data-restricted session cannot mint the managed MCP token, because
+// the token records permission grants only and would read the index through
+// /mcp with the session's redaction gone.
+func TestIntegrationSessionRestrictionsMCPTokenMint(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	srv := newProfileIndexServer(t)
+	scoped := restrictedBearer(t, srv, &ext.SessionRestrictions{
+		RedactColumns: []ext.TableColumnRef{{Schema: "app", Table: "users", Column: "ssn"}},
+	})
+	rec := postJSON(t, srv, "/api/mcp-token", scoped, "")
+	if rec.Code != http.StatusForbidden || !strings.Contains(rec.Body.String(), "data access policy") {
+		t.Errorf("restricted mint = %d %s, want 403 naming the data policy", rec.Code, rec.Body.String())
+	}
+	// A profiled session is refused through the same door (the pre-existing
+	// half of the hole).
+	profiled := scopedBearer(t, srv, "sensitive")
+	seedSensitiveProfile(t, srv)
+	rec = postJSON(t, srv, "/api/mcp-token", profiled, "")
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("profiled mint = %d, want 403", rec.Code)
+	}
+}
+
+// TestIntegrationSessionRestrictionsVerifyStatus pins the fourth verify verb:
+// status carries the per-table verdict inventory, so it refuses a restricted
+// session like trigger/explain/history do — with the policy answer, not the
+// not-enabled one.
+func TestIntegrationSessionRestrictionsVerifyStatus(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	srv := newProfileIndexServer(t)
+	scoped := restrictedBearer(t, srv, &ext.SessionRestrictions{
+		DenyTables: []ext.TableRef{{Schema: "app", Table: "secrets"}},
+	})
+	rec := getPath(t, srv, "127.0.0.1:8090", "/api/servers/default/verify", scoped)
+	if rec.Code != http.StatusForbidden || !strings.Contains(rec.Body.String(), "access-control profile") {
+		t.Errorf("restricted verify status = %d %s, want 403 with the policy refusal", rec.Code, rec.Body.String())
+	}
+}
+
+// TestIntegrationSessionRestrictionsRecoverWarns pins the write-side honesty:
+// a reversal generated from column-redacted rows says so, because redacted
+// values land in the script as NULL.
+func TestIntegrationSessionRestrictionsRecoverWarns(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	srv := newProfileIndexServer(t)
+	scoped := restrictedBearer(t, srv, &ext.SessionRestrictions{
+		AllowTables:  []ext.TableRef{{Schema: "app", Table: "users"}},
+		AllowColumns: []ext.TableColumnRef{{Schema: "app", Table: "users", Column: "id"}},
+	})
+	rec := postJSON(t, srv, "/api/recover", scoped, `{"schema":"app","table":"users"}`)
+	if rec.Code != 200 {
+		t.Fatalf("recover = %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "hides some column values") {
+		t.Errorf("a script built from redacted rows must warn about the NULLs it writes: %s", rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "ssn-12345") {
+		t.Errorf("redacted value leaked into the reversal script: %s", rec.Body.String())
 	}
 }
 

--- a/internal/console/session_restrictions_integration_test.go
+++ b/internal/console/session_restrictions_integration_test.go
@@ -61,6 +61,13 @@ func TestIntegrationSessionRestrictionsRedaction(t *testing.T) {
 func TestIntegrationSessionRestrictionsAllowList(t *testing.T) {
 	testutil.SkipIfNoMySQL(t)
 	srv := newProfileIndexServer(t)
+	// A DISTINCT table whose name differs only by case: the allow match must
+	// be exact (the columns' collation is case-insensitive, and a
+	// case-insensitive allow would serve this table too — the fail-open
+	// direction).
+	testutil.InsertEvent(t, srv.cm.boot.db, "bin.000001", 120, 160, "2026-06-01 12:03:00", nil,
+		"app", "Users", 1 /*INSERT*/, "1",
+		nil, nil, []byte(`{"id":1,"value":"topsecret-case"}`))
 	scoped := restrictedBearer(t, srv, &ext.SessionRestrictions{
 		AllowTables:  []ext.TableRef{{Schema: "app", Table: "users"}},
 		AllowColumns: []ext.TableColumnRef{{Schema: "app", Table: "users", Column: "id"}, {Schema: "app", Table: "users", Column: "email"}},
@@ -68,6 +75,9 @@ func TestIntegrationSessionRestrictionsAllowList(t *testing.T) {
 
 	if rec := getPath(t, srv, "127.0.0.1:8090", "/api/events?schema=app&table=secrets", scoped); strings.Contains(rec.Body.String(), "topsecret") {
 		t.Errorf("table outside the allow list leaked to a restricted session: %s", rec.Body.String())
+	}
+	if rec := getPath(t, srv, "127.0.0.1:8090", "/api/events?schema=app&table=Users", scoped); strings.Contains(rec.Body.String(), "topsecret-case") {
+		t.Errorf("a case-variant table leaked through the allow list: %s", rec.Body.String())
 	}
 	rec := getPath(t, srv, "127.0.0.1:8090", "/api/events?schema=app&table=users", scoped)
 	if strings.Contains(rec.Body.String(), "ssn-12345") {

--- a/internal/console/session_restrictions_integration_test.go
+++ b/internal/console/session_restrictions_integration_test.go
@@ -1,0 +1,99 @@
+//go:build integration
+
+package console
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/ext"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// restrictedBearer mints a session holding all permissions plus the given
+// direct restrictions (#1449) — and deliberately NO profile name, because the
+// point of the seam is that nothing needs to exist in the index for the
+// restriction to enforce.
+func restrictedBearer(t *testing.T, srv *Server, rest *ext.SessionRestrictions) string {
+	t.Helper()
+	tok, _, err := srv.sessions.IssueWithPolicy("test-user",
+		&ext.AccessPolicy{Permissions: ext.AllPermissions(), Restrictions: rest})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tok
+}
+
+// TestIntegrationSessionRestrictionsRedaction pins the label-free half of the
+// redaction contract: a session whose POLICY carries deny/redact entries is
+// enforced against an index holding no profiles, no table_flags and no
+// access_rules rows — while the static token on the same server still reads
+// raw (per-session, not process-global).
+func TestIntegrationSessionRestrictionsRedaction(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	srv := newProfileIndexServer(t)
+	scoped := restrictedBearer(t, srv, &ext.SessionRestrictions{
+		DenyTables:    []ext.TableRef{{Schema: "app", Table: "secrets"}},
+		RedactColumns: []ext.TableColumnRef{{Schema: "app", Table: "users", Column: "ssn"}},
+	})
+
+	if rec := getPath(t, srv, "127.0.0.1:8090", "/api/events?schema=app&table=secrets", scoped); strings.Contains(rec.Body.String(), "topsecret") {
+		t.Errorf("policy-denied table app.secrets leaked to a restricted session: %s", rec.Body.String())
+	}
+	if rec := getPath(t, srv, "127.0.0.1:8090", "/api/events?schema=app&table=secrets", "static-tok"); !strings.Contains(rec.Body.String(), "topsecret") {
+		t.Errorf("policy-less credential should see the raw table; per-session restriction leaked to the process: %s", rec.Body.String())
+	}
+	rec := getPath(t, srv, "127.0.0.1:8090", "/api/events?schema=app&table=users", scoped)
+	if strings.Contains(rec.Body.String(), "ssn-12345") {
+		t.Errorf("policy-redacted column ssn leaked to a restricted session: %s", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "alice@example") {
+		t.Errorf("non-redacted column email must remain: %s", rec.Body.String())
+	}
+}
+
+// TestIntegrationSessionRestrictionsAllowList pins allow-list mode end to end:
+// AllowTables withholds every table it does not name (no deny entry needed for
+// app.secrets), and AllowColumns nulls the columns it does not name for the
+// tables it covers.
+func TestIntegrationSessionRestrictionsAllowList(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	srv := newProfileIndexServer(t)
+	scoped := restrictedBearer(t, srv, &ext.SessionRestrictions{
+		AllowTables:  []ext.TableRef{{Schema: "app", Table: "users"}},
+		AllowColumns: []ext.TableColumnRef{{Schema: "app", Table: "users", Column: "id"}, {Schema: "app", Table: "users", Column: "email"}},
+	})
+
+	if rec := getPath(t, srv, "127.0.0.1:8090", "/api/events?schema=app&table=secrets", scoped); strings.Contains(rec.Body.String(), "topsecret") {
+		t.Errorf("table outside the allow list leaked to a restricted session: %s", rec.Body.String())
+	}
+	rec := getPath(t, srv, "127.0.0.1:8090", "/api/events?schema=app&table=users", scoped)
+	if strings.Contains(rec.Body.String(), "ssn-12345") {
+		t.Errorf("column outside the allow list leaked: %s", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "alice@example") {
+		t.Errorf("allowed column email must remain: %s", rec.Body.String())
+	}
+}
+
+// TestIntegrationSessionRestrictionsGatesRawSurfaces pins that a restrictions-
+// carrying session is refused the baseline-reading surfaces exactly as a
+// profiled one is: those reads bypass redaction, so serving them would make
+// the restriction a fiction.
+func TestIntegrationSessionRestrictionsGatesRawSurfaces(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	srv := newProfileIndexServer(t)
+	scoped := restrictedBearer(t, srv, &ext.SessionRestrictions{
+		RedactColumns: []ext.TableColumnRef{{Schema: "app", Table: "users", Column: "ssn"}},
+	})
+
+	for _, path := range []string{
+		"/api/reconstruct?schema=app&table=users&pk=1",
+		"/api/baselines",
+	} {
+		if rec := getPath(t, srv, "127.0.0.1:8090", path, scoped); rec.Code != http.StatusForbidden {
+			t.Errorf("restricted session GET %s = %d, want 403: %s", path, rec.Code, rec.Body.String())
+		}
+	}
+}

--- a/internal/console/session_restrictions_integration_test.go
+++ b/internal/console/session_restrictions_integration_test.go
@@ -86,6 +86,12 @@ func TestIntegrationSessionRestrictionsAllowList(t *testing.T) {
 	if !strings.Contains(rec.Body.String(), "alice@example") {
 		t.Errorf("allowed column email must remain: %s", rec.Body.String())
 	}
+	// The changed-column existence oracle is refused at the HTTP layer under
+	// column-level rules (the engine's sentinel mapped to 403).
+	rec = getPath(t, srv, "127.0.0.1:8090", "/api/events?schema=app&table=users&changed_column=ssn", scoped)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("changed_column under a column allow list = %d, want 403: %s", rec.Code, rec.Body.String())
+	}
 }
 
 // TestIntegrationSessionRestrictionsActivity pins the Overview aggregate:

--- a/internal/console/testhelpers_test.go
+++ b/internal/console/testhelpers_test.go
@@ -15,7 +15,10 @@ import (
 // s.cm.boot for per-test tweaks (baseline gates, resolver, ...). noArchive is
 // true, matching the old tests' default (no planner / archive discovery).
 func newBootServer(db *sql.DB) *Server {
-	s := &Server{token: "t", cm: newConnManager(nil, false)}
+	// sessionProfiles is set like production (server.go New) — handlers that
+	// resolve a session's profile per request (events, activity, schemas)
+	// reach the cache even in handler-level tests.
+	s := &Server{token: "t", cm: newConnManager(nil, false), sessionProfiles: newProfileRuleCache()}
 	s.cm.boot = &bundle{db: db, engine: query.New(db), noArchive: true, activity: newActivityCache()}
 	s.mux = s.buildHandler()
 	return s

--- a/internal/console/verify_trigger.go
+++ b/internal/console/verify_trigger.go
@@ -306,6 +306,19 @@ func (s *Server) handleVerifyTrigger(w http.ResponseWriter, r *http.Request) {
 // handleVerifyStatus reports the latest verify run state for the selected
 // server (for the frontend to poll while a run is in flight).
 func (s *Server) handleVerifyStatus(w http.ResponseWriter, r *http.Request) {
+	// Same gate as trigger/explain/history, checked FIRST (before the
+	// enabled-at-all check, so a restricted session always gets the policy
+	// answer): the status payload carries the per-table verdict inventory —
+	// schema and table names with mismatch findings — which can cover tables
+	// the session's policy withholds.
+	if s.rbacActiveFor(r) {
+		if sessionRestricted(r) {
+			recordProfileGateDeny(r, "verify-status")
+		}
+		writeJSONError(w, http.StatusForbidden,
+			"verification isn't available while an access-control profile is active: baseline reads aren't redacted")
+		return
+	}
 	if s.verifyCtrl == nil {
 		writeJSONError(w, http.StatusForbidden,
 			"verify from the console is not enabled; start the watch daemon with BINTRAIL_CONSOLE_VERIFY_TRIGGER=1 or a --verify-interval schedule")

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -485,11 +485,28 @@ func (o Options) RedactionActive() bool {
 var ErrQueryHashUnderProfile = errors.New(
 	"statement-digest filter unavailable while an RBAC profile is active: the digest is withheld from every returned row, so filtering on it would confirm the statement that redaction hides")
 
+// ErrChangedColumnUnderRedaction is returned when a changed-column filter is
+// combined with COLUMN-LEVEL redaction rules (RedactColumns or AllowColumns,
+// #1449). The reasoning is ErrQueryHashUnderProfile's, transferred: the
+// redaction pass nulls a hidden column's VALUES, but honouring a filter on
+// "rows where <hidden column> changed" confirms that column's existence,
+// change timing and affected PKs one candidate at a time — the answer the
+// nulling withholds. Deny-table-only rules do not trip this: no column is
+// hidden there, only whole tables, which the table clauses already enforce.
+//
+// The message names no CLI flag, for the same MCP-client reason as the
+// digest refusal.
+var ErrChangedColumnUnderRedaction = errors.New(
+	"changed-column filter unavailable while column-level redaction is active: hidden columns are nulled in every returned row, so filtering on one would confirm the changes that redaction hides")
+
 // ValidateStatementFilter rejects option combinations the redaction contract
 // cannot honour. Called by Fetch, so every engine path is covered.
 func (o Options) ValidateStatementFilter() error {
 	if o.QueryHash != "" && o.RedactionActive() {
 		return ErrQueryHashUnderProfile
+	}
+	if o.ChangedColumn != "" && (len(o.RedactColumns) > 0 || len(o.AllowColumns) > 0) {
+		return ErrChangedColumnUnderRedaction
 	}
 	return nil
 }
@@ -840,9 +857,17 @@ func buildQuery(opts Options) (string, []any) {
 		// Allow-list mode (#1449): only the listed tables survive. Emitted
 		// BEFORE the deny clauses so the composed WHERE reads allow-then-deny,
 		// though AND makes the order semantically irrelevant — deny always wins.
+		//
+		// BINARY, asymmetrically on purpose: the columns' collation is the
+		// server default, commonly case-insensitive, and a case-insensitive
+		// ALLOW fails open — an entry for `users` would also serve a distinct
+		// `Users` table's rows (lower_case_table_names=0 hosts). Deny stays on
+		// the column collation: case-insensitive there withholds MORE, the
+		// safe direction. BINARY rather than a COLLATE clause so an index
+		// whose columns are not utf8mb4 cannot error the comparison.
 		ors := make([]string, len(opts.AllowTables))
 		for i, at := range opts.AllowTables {
-			ors[i] = "(schema_name = ? AND table_name = ?)"
+			ors[i] = "(BINARY schema_name = ? AND BINARY table_name = ?)"
 			args = append(args, at.Schema, at.Table)
 		}
 		where = append(where, "("+strings.Join(ors, " OR ")+")")
@@ -962,6 +987,20 @@ func applyRedaction(rows []ResultRow, redact, allow []SchemaTableColumn) {
 			if null(col) {
 				r.RowAfter[col] = nil
 			}
+		}
+		// ChangedColumns carries column NAMES, and a hidden column's name is
+		// itself what the restriction withholds — under an allow list every
+		// unlisted column of the table would otherwise be enumerated by name
+		// on every UPDATE row. Strip the hidden names; rows of tables with no
+		// column rule are untouched.
+		if r.ChangedColumns != nil && (allowListed || len(set) > 0) {
+			kept := r.ChangedColumns[:0:0]
+			for _, col := range r.ChangedColumns {
+				if !null(col) {
+					kept = append(kept, col)
+				}
+			}
+			r.ChangedColumns = kept
 		}
 	}
 }

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -350,6 +350,16 @@ type Options struct {
 
 	DenyTables    []SchemaTable       // tables excluded by RBAC profile
 	RedactColumns []SchemaTableColumn // column values nulled out by RBAC profile
+	// AllowTables, when non-empty, switches to allow-list mode: only rows from
+	// the listed tables are returned (session-policy restrictions, #1449).
+	// DenyTables still composes over it — a table both allowed and denied
+	// yields nothing.
+	AllowTables []SchemaTable
+	// AllowColumns is the column-level allow list: for each table appearing in
+	// it, every column of that table's row images NOT listed is nulled by the
+	// redaction pass (the complement of RedactColumns, which names the columns
+	// to null). Tables not appearing in it are untouched by this rule.
+	AllowColumns []SchemaTableColumn
 	// ProfileActive is set by callers whenever a profile NAME was supplied,
 	// even if it resolved to zero deny/redact rules (a nonexistent or empty
 	// profile). It forces the redaction pass so QueryText/QueryHash are
@@ -439,7 +449,7 @@ func (e *Engine) Fetch(ctx context.Context, opts Options) ([]ResultRow, error) {
 	// so rows of an ALLOWED table can carry a statement whose literals
 	// belong to a denied sibling table — see applyRedaction (#699).
 	if opts.RedactionActive() {
-		applyRedaction(results, opts.RedactColumns)
+		applyRedaction(results, opts.RedactColumns, opts.AllowColumns)
 	}
 	return results, nil
 }
@@ -454,7 +464,8 @@ func (e *Engine) Fetch(ctx context.Context, opts Options) ([]ResultRow, error) {
 // Server.rbacActive and mcptools recover-cascade — which cannot call this
 // method; they are known, not overlooked.)
 func (o Options) RedactionActive() bool {
-	return o.ProfileActive || len(o.RedactColumns) > 0 || len(o.DenyTables) > 0
+	return o.ProfileActive || len(o.RedactColumns) > 0 || len(o.DenyTables) > 0 ||
+		len(o.AllowTables) > 0 || len(o.AllowColumns) > 0
 }
 
 // ErrQueryHashUnderProfile is returned when a statement-digest filter is
@@ -825,6 +836,17 @@ func buildQuery(opts Options) (string, []any) {
 			  AND table_flags.flag        = ?)`)
 		args = append(args, opts.Flag)
 	}
+	if len(opts.AllowTables) > 0 {
+		// Allow-list mode (#1449): only the listed tables survive. Emitted
+		// BEFORE the deny clauses so the composed WHERE reads allow-then-deny,
+		// though AND makes the order semantically irrelevant — deny always wins.
+		ors := make([]string, len(opts.AllowTables))
+		for i, at := range opts.AllowTables {
+			ors[i] = "(schema_name = ? AND table_name = ?)"
+			args = append(args, at.Schema, at.Table)
+		}
+		where = append(where, "("+strings.Join(ors, " OR ")+")")
+	}
 	for _, dt := range opts.DenyTables {
 		where = append(where, "NOT (schema_name = ? AND table_name = ?)")
 		args = append(args, dt.Schema, dt.Table)
@@ -897,23 +919,47 @@ func buildQuery(opts Options) (string, []any) {
 // values. This mirrors the codebase's "a surface that cannot honor redaction
 // is disabled entirely under a profile" pattern (archives, cascade,
 // reconstruct).
-func applyRedaction(rows []ResultRow, redact []SchemaTableColumn) {
+// The allow parameter is the column-level allow list (Options.AllowColumns,
+// #1449): for a table appearing in it, every row-image column NOT listed for
+// that table is nulled — the complement of redact, composed so that an
+// explicit redact entry wins even over a column the allow list names.
+func applyRedaction(rows []ResultRow, redact, allow []SchemaTableColumn) {
 	type colKey struct{ schema, table, column string }
+	type tblKey struct{ schema, table string }
 	set := make(map[colKey]struct{}, len(redact))
 	for _, r := range redact {
 		set[colKey{r.Schema, r.Table, r.Column}] = struct{}{}
+	}
+	allowed := make(map[tblKey]map[string]struct{}, len(allow))
+	for _, a := range allow {
+		k := tblKey{a.Schema, a.Table}
+		if allowed[k] == nil {
+			allowed[k] = make(map[string]struct{})
+		}
+		allowed[k][a.Column] = struct{}{}
 	}
 	for i := range rows {
 		r := &rows[i]
 		r.QueryText = nil
 		r.QueryHash = nil
+		allowSet, allowListed := allowed[tblKey{r.SchemaName, r.TableName}]
+		null := func(col string) bool {
+			if _, deny := set[colKey{r.SchemaName, r.TableName, col}]; deny {
+				return true
+			}
+			if allowListed {
+				_, ok := allowSet[col]
+				return !ok
+			}
+			return false
+		}
 		for col := range r.RowBefore {
-			if _, ok := set[colKey{r.SchemaName, r.TableName, col}]; ok {
+			if null(col) {
 				r.RowBefore[col] = nil
 			}
 		}
 		for col := range r.RowAfter {
-			if _, ok := set[colKey{r.SchemaName, r.TableName, col}]; ok {
+			if null(col) {
 				r.RowAfter[col] = nil
 			}
 		}

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -579,7 +579,7 @@ func TestApplyRedaction(t *testing.T) {
 	redact := []SchemaTableColumn{
 		{Schema: "mydb", Table: "orders", Column: "amount"},
 	}
-	applyRedaction(rows, redact)
+	applyRedaction(rows, redact, nil)
 
 	if rows[0].RowBefore["amount"] != nil {
 		t.Errorf("expected RowBefore[amount] to be nil, got %v", rows[0].RowBefore["amount"])
@@ -888,7 +888,7 @@ func TestApplyRedaction_blanksQueryTextEverywhere(t *testing.T) {
 	redact := []SchemaTableColumn{
 		{Schema: "mydb", Table: "orders", Column: "amount"},
 	}
-	applyRedaction(rows, redact)
+	applyRedaction(rows, redact, nil)
 
 	for i := range rows {
 		if rows[i].QueryText != nil {
@@ -910,7 +910,7 @@ func TestApplyRedaction_wrongTable(t *testing.T) {
 	redact := []SchemaTableColumn{
 		{Schema: "mydb", Table: "orders", Column: "amount"}, // different table
 	}
-	applyRedaction(rows, redact)
+	applyRedaction(rows, redact, nil)
 
 	// Values must be unchanged — redaction only applies to the matching table.
 	if rows[0].RowBefore["amount"] != float64(50) {

--- a/internal/query/restrictions_test.go
+++ b/internal/query/restrictions_test.go
@@ -17,9 +17,12 @@ func TestBuildQuery_allowTables(t *testing.T) {
 	}
 	q, args := buildQuery(opts)
 
-	want := "((schema_name = ? AND table_name = ?) OR (schema_name = ? AND table_name = ?))"
+	// BINARY is load-bearing: the columns' collation is commonly
+	// case-insensitive, and a case-insensitive ALLOW fails open (it would
+	// also serve a distinct same-name-other-case table).
+	want := "((BINARY schema_name = ? AND BINARY table_name = ?) OR (BINARY schema_name = ? AND BINARY table_name = ?))"
 	if !strings.Contains(q, want) {
-		t.Errorf("expected allow-list clause %q in query: %s", want, q)
+		t.Errorf("expected exact-match allow-list clause %q in query: %s", want, q)
 	}
 	if len(args) != 4 {
 		t.Fatalf("expected 4 args for 2 allow tables, got %d: %v", len(args), args)
@@ -42,11 +45,13 @@ func TestBuildQuery_allowAndDenyCompose(t *testing.T) {
 		DenyTables:  []SchemaTable{{Schema: "db", Table: "t"}},
 	}
 	q, _ := buildQuery(opts)
-	if !strings.Contains(q, "(schema_name = ? AND table_name = ?)") {
+	if !strings.Contains(q, "(BINARY schema_name = ? AND BINARY table_name = ?)") {
 		t.Errorf("expected allow clause in query: %s", q)
 	}
+	// Deny deliberately stays on the column collation (case-insensitive
+	// withholds MORE, the safe direction) — no BINARY here.
 	if !strings.Contains(q, "NOT (schema_name = ? AND table_name = ?)") {
-		t.Errorf("expected deny clause in query: %s", q)
+		t.Errorf("expected collation-matched deny clause in query: %s", q)
 	}
 }
 
@@ -139,5 +144,74 @@ func TestRedactionActive_perField(t *testing.T) {
 	}
 	if (Options{}).RedactionActive() {
 		t.Error("zero Options must not report RedactionActive")
+	}
+}
+
+// TestChangedColumnFilterUnderColumnRules pins the #1449 sibling of the
+// digest refusal: a changed-column filter under COLUMN-level rules is an
+// existence oracle over exactly the hidden columns, so it is refused — while
+// deny-table-only rules (no hidden column anywhere) keep the filter.
+func TestChangedColumnFilterUnderColumnRules(t *testing.T) {
+	base := Options{ChangedColumn: "ssn"}
+
+	refused := []struct {
+		name string
+		opts Options
+	}{
+		{"RedactColumns", Options{ChangedColumn: "ssn", RedactColumns: []SchemaTableColumn{{Schema: "s", Table: "t", Column: "ssn"}}}},
+		{"AllowColumns", Options{ChangedColumn: "ssn", AllowColumns: []SchemaTableColumn{{Schema: "s", Table: "t", Column: "id"}}}},
+	}
+	for _, tc := range refused {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.opts.ValidateStatementFilter(); !errors.Is(err, ErrChangedColumnUnderRedaction) {
+				t.Errorf("err = %v, want ErrChangedColumnUnderRedaction", err)
+			}
+		})
+	}
+	allowedCases := []struct {
+		name string
+		opts Options
+	}{
+		{"no rules", base},
+		{"deny tables only", Options{ChangedColumn: "ssn", DenyTables: []SchemaTable{{Schema: "s", Table: "t"}}}},
+		{"named profile, zero rules", Options{ChangedColumn: "ssn", ProfileActive: true}},
+		{"allow tables only", Options{ChangedColumn: "ssn", AllowTables: []SchemaTable{{Schema: "s", Table: "t"}}}},
+	}
+	for _, tc := range allowedCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.opts.ValidateStatementFilter(); err != nil {
+				t.Errorf("err = %v, want nil (no column is hidden here)", err)
+			}
+		})
+	}
+}
+
+// TestApplyRedaction_stripsHiddenChangedColumns pins that hidden column NAMES
+// are removed from ChangedColumns: values are nulled by the pass, but the
+// name list would otherwise enumerate the withheld schema on every UPDATE
+// row. Untouched tables keep their list.
+func TestApplyRedaction_stripsHiddenChangedColumns(t *testing.T) {
+	rows := []ResultRow{
+		{
+			SchemaName:     "mydb",
+			TableName:      "employees",
+			ChangedColumns: []string{"name", "salary", "ssn"},
+		},
+		{
+			SchemaName:     "mydb",
+			TableName:      "orders",
+			ChangedColumns: []string{"amount"},
+		},
+	}
+	allow := []SchemaTableColumn{{Schema: "mydb", Table: "employees", Column: "name"}}
+	redact := []SchemaTableColumn{{Schema: "mydb", Table: "employees", Column: "name"}}
+	// name is allowed AND redacted: redact wins, so it is stripped too.
+	applyRedaction(rows, redact, allow)
+
+	if len(rows[0].ChangedColumns) != 0 {
+		t.Errorf("hidden column names leaked through changed_columns: %v", rows[0].ChangedColumns)
+	}
+	if len(rows[1].ChangedColumns) != 1 || rows[1].ChangedColumns[0] != "amount" {
+		t.Errorf("a table with no column rules must keep its changed_columns: %v", rows[1].ChangedColumns)
 	}
 }

--- a/internal/query/restrictions_test.go
+++ b/internal/query/restrictions_test.go
@@ -1,0 +1,143 @@
+package query
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// ─── Session-policy restrictions (#1449): allow-list mode ─────────────────────
+
+func TestBuildQuery_allowTables(t *testing.T) {
+	opts := Options{
+		AllowTables: []SchemaTable{
+			{Schema: "db1", Table: "t1"},
+			{Schema: "db2", Table: "t2"},
+		},
+	}
+	q, args := buildQuery(opts)
+
+	want := "((schema_name = ? AND table_name = ?) OR (schema_name = ? AND table_name = ?))"
+	if !strings.Contains(q, want) {
+		t.Errorf("expected allow-list clause %q in query: %s", want, q)
+	}
+	if len(args) != 4 {
+		t.Fatalf("expected 4 args for 2 allow tables, got %d: %v", len(args), args)
+	}
+	got := []any{args[0], args[1], args[2], args[3]}
+	for i, w := range []any{"db1", "t1", "db2", "t2"} {
+		if got[i] != w {
+			t.Errorf("args[%d] = %v, want %v", i, got[i], w)
+		}
+	}
+}
+
+// TestBuildQuery_allowAndDenyCompose pins that deny composes over allow: a
+// table both allowed and denied emits BOTH clauses, and their AND yields
+// nothing for that table (the EE compiles a full-table deny this way rather
+// than pre-subtracting, so the SQL itself must carry the deny-wins rule).
+func TestBuildQuery_allowAndDenyCompose(t *testing.T) {
+	opts := Options{
+		AllowTables: []SchemaTable{{Schema: "db", Table: "t"}},
+		DenyTables:  []SchemaTable{{Schema: "db", Table: "t"}},
+	}
+	q, _ := buildQuery(opts)
+	if !strings.Contains(q, "(schema_name = ? AND table_name = ?)") {
+		t.Errorf("expected allow clause in query: %s", q)
+	}
+	if !strings.Contains(q, "NOT (schema_name = ? AND table_name = ?)") {
+		t.Errorf("expected deny clause in query: %s", q)
+	}
+}
+
+func TestBuildQuery_noAllowTablesNoClause(t *testing.T) {
+	q, _ := buildQuery(Options{Schema: "db"})
+	if strings.Contains(q, " OR (schema_name") {
+		t.Errorf("no allow tables must emit no allow-list clause: %s", q)
+	}
+}
+
+// ─── Session-policy restrictions (#1449): column allow list ───────────────────
+
+func TestApplyRedaction_allowColumns(t *testing.T) {
+	rows := []ResultRow{
+		{
+			SchemaName: "mydb",
+			TableName:  "employees",
+			RowBefore:  map[string]any{"id": float64(1), "name": "ann", "salary": float64(9)},
+			RowAfter:   map[string]any{"id": float64(1), "name": "ann", "salary": float64(10)},
+		},
+		{
+			SchemaName: "mydb",
+			TableName:  "orders", // no allow entries: untouched by the allow rule
+			RowAfter:   map[string]any{"amount": float64(5)},
+		},
+	}
+	allow := []SchemaTableColumn{
+		{Schema: "mydb", Table: "employees", Column: "id"},
+		{Schema: "mydb", Table: "employees", Column: "name"},
+	}
+	applyRedaction(rows, nil, allow)
+
+	if rows[0].RowBefore["salary"] != nil || rows[0].RowAfter["salary"] != nil {
+		t.Errorf("column outside the allow list must be nulled, got before=%v after=%v",
+			rows[0].RowBefore["salary"], rows[0].RowAfter["salary"])
+	}
+	if rows[0].RowBefore["id"] == nil || rows[0].RowAfter["name"] != "ann" {
+		t.Errorf("allowed columns must be preserved, got %+v", rows[0])
+	}
+	if rows[1].RowAfter["amount"] != float64(5) {
+		t.Errorf("a table with no allow entries must be untouched, got %v", rows[1].RowAfter["amount"])
+	}
+}
+
+// TestApplyRedaction_redactWinsOverAllow pins the composition rule: an
+// explicit redact entry nulls the column even when the allow list names it
+// (deny wins, mirroring the table-level rule).
+func TestApplyRedaction_redactWinsOverAllow(t *testing.T) {
+	rows := []ResultRow{{
+		SchemaName: "mydb",
+		TableName:  "employees",
+		RowAfter:   map[string]any{"name": "ann"},
+	}}
+	allow := []SchemaTableColumn{{Schema: "mydb", Table: "employees", Column: "name"}}
+	redact := []SchemaTableColumn{{Schema: "mydb", Table: "employees", Column: "name"}}
+	applyRedaction(rows, redact, allow)
+	if rows[0].RowAfter["name"] != nil {
+		t.Errorf("redact must win over allow, got %v", rows[0].RowAfter["name"])
+	}
+}
+
+// ─── RedactionActive must see every restriction field ─────────────────────────
+
+// TestRedactionActive_perField pins that EACH options field carrying a data
+// restriction activates the redaction pass on its own. The fields feed
+// Fetch's applyRedaction call AND ValidateStatementFilter's digest refusal —
+// one forgotten here means row images served with query_text intact and the
+// digest filter answering under a restriction.
+func TestRedactionActive_perField(t *testing.T) {
+	cases := []struct {
+		name string
+		opts Options
+	}{
+		{"ProfileActive", Options{ProfileActive: true}},
+		{"DenyTables", Options{DenyTables: []SchemaTable{{Schema: "s", Table: "t"}}}},
+		{"RedactColumns", Options{RedactColumns: []SchemaTableColumn{{Schema: "s", Table: "t", Column: "c"}}}},
+		{"AllowTables", Options{AllowTables: []SchemaTable{{Schema: "s", Table: "t"}}}},
+		{"AllowColumns", Options{AllowColumns: []SchemaTableColumn{{Schema: "s", Table: "t", Column: "c"}}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !tc.opts.RedactionActive() {
+				t.Errorf("Options with %s set must report RedactionActive", tc.name)
+			}
+			tc.opts.QueryHash = strings.Repeat("a", 64)
+			if err := tc.opts.ValidateStatementFilter(); !errors.Is(err, ErrQueryHashUnderProfile) {
+				t.Errorf("digest filter under %s: err = %v, want ErrQueryHashUnderProfile", tc.name, err)
+			}
+		})
+	}
+	if (Options{}).RedactionActive() {
+		t.Error("zero Options must not report RedactionActive")
+	}
+}


### PR DESCRIPTION
Closes #1449.

An installed console auth provider can now attach table/column restrictions DIRECTLY to the `ext.AccessPolicy` it mints, without first materializing `flag`/`profile`/`access` labels into every server's index.

## What changed

- **`ext`**: `SessionRestrictions{DenyTables, RedactColumns, AllowTables, AllowColumns}` + `AccessPolicy.Restrictions`. `Empty()` is nil-safe; `AccessPolicy.DataRestricted()` is the one predicate for "this session scopes data" (profile name, restrictions, or both).
- **`internal/query`**: `Options.AllowTables` (allow-list mode: unlisted tables are withheld, at the SQL layer like `DenyTables`) and `Options.AllowColumns` (per-table column allow list: unlisted columns nulled by `applyRedaction`, with an explicit redact entry winning over an allow). `RedactionActive()` covers the new fields, so the redaction pass and the `ErrQueryHashUnderProfile` refusal both fire on them.
- **`internal/console`**: `sessionRestricted` now keys on `DataRestricted()`, so EVERY existing raw-data surface gate (reconstruct, baselines, recover-cascade, verify, extension views, SQL panel/export, coverage table names, views.sql) refuses a restrictions-carrying session exactly as it refuses a profiled one, and archives stay off with the standing exclusion notice. `applySessionProfile` unions the policy's restrictions onto the startup floor next to the profile rules and forces `ProfileActive` (`query_text`/`query_hash` withheld, #699).

## Semantics

- Deny composes over allow: a table both allowed and denied yields nothing (pinned by test; the SQL carries the rule, callers need not pre-subtract).
- A non-nil but EMPTY restrictions struct restricts nothing (a provider constructing it unconditionally does not lock its full-access sessions out).
- OSS behavior unchanged: nothing in this repo constructs restrictions; every predicate is inert without an installed provider.

## Tests

- `ext`: nil-safety, per-field `Empty` coverage derived by reflection (a field added later and forgotten in `Empty` fails the guard), `DataRestricted` table.
- `query`: allow-list SQL clause + arg order, allow/deny composition, column allow-list nulling, redact-wins-over-allow, per-field `RedactionActive` + digest refusal.
- `console`: `sessionRestricted` cases, `applySessionProfile` union/conversion with caller-slice aliasing check.
- Integration (real MySQL): label-free deny/redact enforcement per session, allow-list end to end, raw-surface gates — siblings of the session-profile suite, all run (not skipped) locally.
- Mutation drill: 6 targeted mutations (drop each wiring site) each turn exactly their guard red.
- `go vet -tags integration ./...` clean; `-race` clean on the touched packages.
