### PR TITLE
console: pin the S3 region its own reads use, and say when it cannot (#1462, #1463)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A console-generated `views.sql` now pins the same S3 region the daemon's
+  own reads use** (#1462). The console filled no region at all, while archive
+  reads pin a region detected from the bucket, so a downloaded file described a
+  different read than the one this process performs: a store that checks the
+  signing region answered 403 (Ceph) or 301 `PermanentRedirect` (a
+  cross-region AWS bucket) to whoever ran the file. The same value now also
+  reaches the SQL panel's own DuckDB session, which was equally unpinned.
+  Detection is memoized per bucket, since the panel rebuilds this on every
+  query and a bucket's region is fixed for its lifetime. When the archives and
+  baselines a file reads sit in buckets whose regions differ, nothing is
+  pinned (one secret cannot name two) and the file says so, rather than
+  looking unpinned by accident.
+
 ### Added
 - **S3-compatible object stores (MinIO, Wasabi, LocalStack) for every S3
   path** (#1453, #1454). `BINTRAIL_S3_ENDPOINT=scheme://host[:port]` points

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,18 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **A console-generated `views.sql` now pins the same S3 region the daemon's
-  own reads use** (#1462). The console filled no region at all, while archive
-  reads pin a region detected from the bucket, so a downloaded file described a
-  different read than the one this process performs: a store that checks the
-  signing region answered 403 (Ceph) or 301 `PermanentRedirect` (a
-  cross-region AWS bucket) to whoever ran the file. The same value now also
-  reaches the SQL panel's own DuckDB session, which was equally unpinned.
-  Detection is memoized per bucket, since the panel rebuilds this on every
-  query and a bucket's region is fixed for its lifetime. When the archives and
-  baselines a file reads sit in buckets whose regions differ, nothing is
-  pinned (one secret cannot name two) and the file says so, rather than
-  looking unpinned by accident.
+- **A console-generated `views.sql` pins the S3 region when it is known**
+  (#1462). The console filled no region at all, while archive reads pin one
+  detected from the bucket, so a downloaded file described a different read
+  than the one this process performs: a store that checks the signing region
+  rejected what the recipient sent. The SQL panel's own DuckDB session gets the
+  same treatment, and is resolved separately because the download names
+  archives portably while the panel is local-first. Only a region actually
+  **detected** is pinned: `s3:GetBucketLocation` is deliberately outside
+  bintrail's documented minimal IAM policy, so falling back to the daemon's
+  ambient region is the common case, and writing that guess into a file would
+  override a correct configuration on a machine bintrail cannot see, where
+  pinning nothing lets the reader's own credential chain resolve it. Detection
+  is memoized per bucket, so it stays off the SQL panel's per-query path;
+  failures expire, since a blip is not a property of a bucket. When two buckets
+  are each detected in a different region, nothing is pinned (one secret cannot
+  name two) and the file says so.
 
 ### Added
 - **S3-compatible object stores (MinIO, Wasabi, LocalStack) for every S3

--- a/internal/console/bucketregion.go
+++ b/internal/console/bucketregion.go
@@ -2,6 +2,8 @@ package console
 
 import (
 	"context"
+	"log/slog"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 
@@ -9,70 +11,133 @@ import (
 	"github.com/dbtrail/dbtrail/internal/views"
 )
 
-// archiveRegion resolves the region to pin in a generated views.sql, and in the
-// SQL panel's own DuckDB session, for the layout in `in`.
+// negativeRegionTTL bounds how long a FAILED detection is remembered. Successes
+// never expire (a bucket's region is fixed for its lifetime); a failure is not a
+// property of the bucket at all, and the cheap causes are transient — a
+// credential refresh, a network blip, or the operator closing the download tab,
+// which cancels the request context. Caching those forever would leave the
+// daemon and the files it hands out disagreeing until someone restarts it.
+const negativeRegionTTL = 5 * time.Minute
+
+type bucketRegionEntry struct {
+	region   string
+	detected bool
+	at       time.Time
+}
+
+// archiveRegion resolves the region to pin for the layout in `in` — which is
+// the downloadable views.sql, and separately the SQL panel's own DuckDB
+// session. Separately, not identically: the download resolves its archives
+// portably (S3 wherever registered) and the panel local-first, so on a daemon
+// holding local copies the file names a bucket the panel does not, and the
+// panel legitimately stays unpinned.
 //
 // It exists because those two used to pin NOTHING while the daemon's own
-// archive reads pin a DETECTED bucket region (#511): the file described a
-// different read than the one this process performs, and a store that checks
-// the signing region answers 403 (Ceph) or 301 PermanentRedirect (a
-// cross-region AWS bucket) to the recipient of a file that works here.
+// archive reads pin a DETECTED bucket region (#511), so the file described a
+// different read than this process performs and a store that checks the signing
+// region answered 403 or 301 PermanentRedirect to the recipient.
 //
-// Returns ("", true) when the layout's buckets do NOT agree on one region. One
-// secret and one s3_region cannot describe two regions, so pinning either would
-// be worse than pinning none: with none, the reader's own credential chain
-// still resolves a region, and only the odd bucket out fails. The caller
-// surfaces that so the file says which case it is instead of looking unpinned
-// by accident.
+// It pins ONLY what was actually detected, and only when every bucket agrees.
+// A guess is worse than silence here, which is the opposite of the read path's
+// trade-off: s3:GetBucketLocation is deliberately absent from bintrail's
+// documented minimal IAM policy, so the fallback is the COMMON case, and where
+// this file pins nothing the reader's own credential chain resolves the right
+// region unaided. Pinning an ambient region we never confirmed would override
+// a correct configuration on someone else's machine, hours later, with nothing
+// pointing back here.
 //
-// Cached because buildViewsInput runs on every SQL panel query, and this would
-// otherwise add a GetBucketLocation round trip to a latched hot path. A
-// bucket's region is fixed for its lifetime, so the entry never needs to
-// expire.
+// Returns ("", true) only when two DETECTIONS disagree — never when one bucket
+// merely could not be asked. One secret and one s3_region cannot name two
+// regions, and the caller renders that as a stated fact, so it must be one.
 func (s *Server) archiveRegion(ctx context.Context, in views.Input) (region string, ambiguous bool) {
 	buckets := layoutBuckets(in)
 	if len(buckets) == 0 {
 		return "", false
 	}
-	cfg, err := storage.LoadAWSConfig(ctx, "")
-	if err != nil {
-		// Best-effort: a region is a hint, and the read paths each load their
-		// own config anyway. Rendering no region leaves today's behavior.
-		return "", false
-	}
-	seen := ""
+	var (
+		cfg    aws.Config
+		loaded bool
+		seen   string
+		missed bool
+	)
 	for _, b := range buckets {
-		r := s.cachedBucketRegion(ctx, cfg, b)
-		if r == "" {
+		r, ok := s.cachedBucketRegion(ctx, &cfg, &loaded, b)
+		if !ok {
+			// Contributes neither a pin nor an ambiguity claim: an
+			// undetectable bucket is not evidence that the regions differ.
+			missed = true
 			continue
 		}
-		if seen == "" {
+		switch {
+		case seen == "":
 			seen = r
-			continue
-		}
-		if r != seen {
+		case r != seen:
 			return "", true
 		}
+	}
+	if missed {
+		// Partial knowledge is not a basis for pinning: the value would be
+		// right for the buckets we asked about and a guess for the rest.
+		return "", false
 	}
 	return seen, false
 }
 
-func (s *Server) cachedBucketRegion(ctx context.Context, cfg aws.Config, bucket string) string {
+// cachedBucketRegion memoizes detection per bucket. buildViewsInput runs on
+// every SQL panel query, so this must not put a network round trip on that path
+// in the steady state.
+//
+// The mutex is held ONLY around the map, never across the RPC: sync.Mutex is
+// not context-aware, so a goroutine blocked acquiring it cannot be released by
+// the SQL panel's setup deadline, and one hung GetBucketLocation on the
+// deadline-free download path would stall unrelated requests while the panel's
+// single-flight latch turned that into 429s for everyone. Two callers racing
+// the same bucket just make the same call twice, which is harmless.
+//
+// cfg is loaded lazily and at most once per call, and only when some bucket
+// actually needs asking — LoadAWSConfig reads ~/.aws/config from disk and can
+// pay an IMDS timeout, which does not belong on a fully cached path.
+func (s *Server) cachedBucketRegion(ctx context.Context, cfg *aws.Config, loaded *bool, bucket string) (string, bool) {
 	s.bucketRegionMu.Lock()
-	defer s.bucketRegionMu.Unlock()
+	e, ok := s.bucketRegions[bucket]
+	s.bucketRegionMu.Unlock()
+	if ok && (e.detected || time.Since(e.at) < negativeRegionTTL) {
+		return e.region, e.detected
+	}
+
+	if !*loaded {
+		c, err := storage.LoadAWSConfig(ctx, "")
+		if err != nil {
+			// The file will pin no region. Logged because the file is what
+			// leaves the host and the log is what stays: without this, "no
+			// REGION clause" has no explanation anywhere, and it is the one
+			// case the file itself cannot describe.
+			slog.Warn("could not resolve an AWS region for the generated views.sql; it will pin none",
+				"bucket", bucket, "error", err)
+			return "", false
+		}
+		*cfg, *loaded = c, true
+	}
+
+	r, detected := storage.DetectBucketRegion(ctx, *cfg, bucket)
+	if !detected {
+		// Once per bucket per TTL, not per request: the operator's remedy is
+		// to grant s3:GetBucketLocation or accept that readers resolve their
+		// own region, and neither is helped by a line on every download.
+		slog.Warn("S3 bucket region not detected; the generated views.sql will pin no region and readers will resolve their own",
+			"bucket", bucket)
+	}
+	s.bucketRegionMu.Lock()
 	if s.bucketRegions == nil {
-		s.bucketRegions = map[string]string{}
+		s.bucketRegions = map[string]bucketRegionEntry{}
 	}
-	if r, ok := s.bucketRegions[bucket]; ok {
-		return r
-	}
-	r := storage.DetectBucketRegion(ctx, cfg, bucket)
-	s.bucketRegions[bucket] = r
-	return r
+	s.bucketRegions[bucket] = bucketRegionEntry{region: r, detected: detected, at: time.Now()}
+	s.bucketRegionMu.Unlock()
+	return r, detected
 }
 
-// layoutBuckets returns the distinct S3 buckets the rendered file will read,
-// in a stable order. Both halves count: archives and baselines can live in
+// layoutBuckets returns the distinct S3 buckets the rendered file will read, in
+// a stable order. Both halves count: archives and baselines can live in
 // different buckets, and the views read both.
 func layoutBuckets(in views.Input) []string {
 	var out []string

--- a/internal/console/bucketregion.go
+++ b/internal/console/bucketregion.go
@@ -112,8 +112,16 @@ func (s *Server) cachedBucketRegion(ctx context.Context, cfg *aws.Config, loaded
 			// leaves the host and the log is what stays: without this, "no
 			// REGION clause" has no explanation anywhere, and it is the one
 			// case the file itself cannot describe.
-			slog.Warn("could not resolve an AWS region for the generated views.sql; it will pin none",
+			slog.Warn("could not resolve an AWS region for this server's S3 layout; no region will be pinned",
 				"bucket", bucket, "error", err)
+			// Cached like any other failure, and for the same reason its
+			// sibling below is: the reachable cause here is a malformed
+			// ~/.aws/config or a missing AWS_PROFILE, which is persistent, and
+			// the endpoint-config class already 502s upstream. Re-reading a
+			// broken file on every SQL panel query is the cost the
+			// memoization exists to avoid; the TTL is what lets a fixed
+			// config heal without a restart.
+			s.rememberBucketRegion(bucket, "", false)
 			return "", false
 		}
 		*cfg, *loaded = c, true
@@ -124,16 +132,23 @@ func (s *Server) cachedBucketRegion(ctx context.Context, cfg *aws.Config, loaded
 		// Once per bucket per TTL, not per request: the operator's remedy is
 		// to grant s3:GetBucketLocation or accept that readers resolve their
 		// own region, and neither is helped by a line on every download.
-		slog.Warn("S3 bucket region not detected; the generated views.sql will pin no region and readers will resolve their own",
+		// Names no consumer: both the download and the SQL panel reach this,
+		// and telling a panel user about a file they never asked for is worse
+		// than saying less.
+		slog.Warn("S3 bucket region not detected (grant s3:GetBucketLocation to pin it); no region will be pinned",
 			"bucket", bucket)
 	}
+	s.rememberBucketRegion(bucket, r, detected)
+	return r, detected
+}
+
+func (s *Server) rememberBucketRegion(bucket, region string, detected bool) {
 	s.bucketRegionMu.Lock()
+	defer s.bucketRegionMu.Unlock()
 	if s.bucketRegions == nil {
 		s.bucketRegions = map[string]bucketRegionEntry{}
 	}
-	s.bucketRegions[bucket] = bucketRegionEntry{region: r, detected: detected, at: time.Now()}
-	s.bucketRegionMu.Unlock()
-	return r, detected
+	s.bucketRegions[bucket] = bucketRegionEntry{region: region, detected: detected, at: time.Now()}
 }
 
 // layoutBuckets returns the distinct S3 buckets the rendered file will read, in

--- a/internal/console/bucketregion.go
+++ b/internal/console/bucketregion.go
@@ -1,0 +1,95 @@
+package console
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+
+	"github.com/dbtrail/dbtrail/internal/storage"
+	"github.com/dbtrail/dbtrail/internal/views"
+)
+
+// archiveRegion resolves the region to pin in a generated views.sql, and in the
+// SQL panel's own DuckDB session, for the layout in `in`.
+//
+// It exists because those two used to pin NOTHING while the daemon's own
+// archive reads pin a DETECTED bucket region (#511): the file described a
+// different read than the one this process performs, and a store that checks
+// the signing region answers 403 (Ceph) or 301 PermanentRedirect (a
+// cross-region AWS bucket) to the recipient of a file that works here.
+//
+// Returns ("", true) when the layout's buckets do NOT agree on one region. One
+// secret and one s3_region cannot describe two regions, so pinning either would
+// be worse than pinning none: with none, the reader's own credential chain
+// still resolves a region, and only the odd bucket out fails. The caller
+// surfaces that so the file says which case it is instead of looking unpinned
+// by accident.
+//
+// Cached because buildViewsInput runs on every SQL panel query, and this would
+// otherwise add a GetBucketLocation round trip to a latched hot path. A
+// bucket's region is fixed for its lifetime, so the entry never needs to
+// expire.
+func (s *Server) archiveRegion(ctx context.Context, in views.Input) (region string, ambiguous bool) {
+	buckets := layoutBuckets(in)
+	if len(buckets) == 0 {
+		return "", false
+	}
+	cfg, err := storage.LoadAWSConfig(ctx, "")
+	if err != nil {
+		// Best-effort: a region is a hint, and the read paths each load their
+		// own config anyway. Rendering no region leaves today's behavior.
+		return "", false
+	}
+	seen := ""
+	for _, b := range buckets {
+		r := s.cachedBucketRegion(ctx, cfg, b)
+		if r == "" {
+			continue
+		}
+		if seen == "" {
+			seen = r
+			continue
+		}
+		if r != seen {
+			return "", true
+		}
+	}
+	return seen, false
+}
+
+func (s *Server) cachedBucketRegion(ctx context.Context, cfg aws.Config, bucket string) string {
+	s.bucketRegionMu.Lock()
+	defer s.bucketRegionMu.Unlock()
+	if s.bucketRegions == nil {
+		s.bucketRegions = map[string]string{}
+	}
+	if r, ok := s.bucketRegions[bucket]; ok {
+		return r
+	}
+	r := storage.DetectBucketRegion(ctx, cfg, bucket)
+	s.bucketRegions[bucket] = r
+	return r
+}
+
+// layoutBuckets returns the distinct S3 buckets the rendered file will read,
+// in a stable order. Both halves count: archives and baselines can live in
+// different buckets, and the views read both.
+func layoutBuckets(in views.Input) []string {
+	var out []string
+	seen := map[string]bool{}
+	add := func(p string) {
+		bucket, _, err := storage.ParseS3URL(p)
+		if err != nil || bucket == "" || seen[bucket] {
+			return
+		}
+		seen[bucket] = true
+		out = append(out, bucket)
+	}
+	for _, src := range in.ArchiveSources {
+		add(src)
+	}
+	for _, b := range in.Baselines {
+		add(b.Path)
+	}
+	return out
+}

--- a/internal/console/bucketregion_test.go
+++ b/internal/console/bucketregion_test.go
@@ -4,14 +4,27 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
 
 	"github.com/dbtrail/dbtrail/internal/views"
 )
 
+func detected(r string) bucketRegionEntry {
+	return bucketRegionEntry{region: r, detected: true, at: time.Now()}
+}
+
+// A failed detection returns cfg.Region, NOT "" — that is the whole hazard, so
+// the fixtures must carry a plausible region with detected=false. An earlier
+// version of this test seeded "" for "unresolvable", a value production cannot
+// produce, and so asserted the desired behavior for a case it never exercised.
+func fellBack(ambient string) bucketRegionEntry {
+	return bucketRegionEntry{region: ambient, detected: false, at: time.Now()}
+}
+
 // TestLayoutBuckets: both halves of a layout count, because archives and
 // baselines can sit in different buckets and the generated views read both.
-// Missing the baseline half was how the region could look unanimous while one
-// of the two reads pointed elsewhere.
 func TestLayoutBuckets(t *testing.T) {
 	in := views.Input{
 		ArchiveSources: []string{
@@ -24,9 +37,7 @@ func TestLayoutBuckets(t *testing.T) {
 			{Path: "/local/baselines/x.parquet"},
 		},
 	}
-	got := layoutBuckets(in)
-	want := []string{"archives", "baselines"}
-	if strings.Join(got, ",") != strings.Join(want, ",") {
+	if got, want := layoutBuckets(in), []string{"archives", "baselines"}; strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Fatalf("layoutBuckets = %v, want %v", got, want)
 	}
 	if b := layoutBuckets(views.Input{ArchiveSources: []string{"/only/local"}}); len(b) != 0 {
@@ -34,12 +45,16 @@ func TestLayoutBuckets(t *testing.T) {
 	}
 }
 
-// TestArchiveRegion_agreementDecidesWhetherAnythingIsPinned drives the decision
-// this feature turns on, with detection pre-seeded so the test needs no network
-// and no AWS. Pinning a region the layout does not unanimously live in is worse
-// than pinning none: the reader's own chain resolves one either way, and a
-// wrong pin sends EVERY bucket to the wrong place instead of just the odd one.
-func TestArchiveRegion_agreementDecidesWhetherAnythingIsPinned(t *testing.T) {
+// TestArchiveRegion_pinsOnlyWhatWasDetected is the regression guard for the
+// defect this resolver most easily reintroduces. s3:GetBucketLocation is
+// deliberately absent from bintrail's documented minimal IAM policy, so a
+// failed detection is the COMMON path, and it falls back to the daemon's own
+// ambient region — a plausible, confident, wrong value. Writing that into a
+// file that runs on someone else's machine OVERRIDES their correct
+// configuration; leaving it out lets their credential chain resolve the right
+// region on its own. Silence beats a guess here, which is the opposite of the
+// read path's trade-off.
+func TestArchiveRegion_pinsOnlyWhatWasDetected(t *testing.T) {
 	t.Setenv("AWS_REGION", "us-east-1")
 	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
 
@@ -49,14 +64,32 @@ func TestArchiveRegion_agreementDecidesWhetherAnythingIsPinned(t *testing.T) {
 	}
 	cases := []struct {
 		name          string
-		seed          map[string]string
+		seed          map[string]bucketRegionEntry
 		wantRegion    string
 		wantAmbiguous bool
 	}{
-		{"both buckets in one region", map[string]string{"archives": "eu-central-1", "baselines": "eu-central-1"}, "eu-central-1", false},
-		{"buckets disagree", map[string]string{"archives": "eu-central-1", "baselines": "us-west-2"}, "", true},
-		{"one bucket unresolvable, the other pins", map[string]string{"archives": "", "baselines": "us-west-2"}, "us-west-2", false},
-		{"nothing resolvable", map[string]string{"archives": "", "baselines": ""}, "", false},
+		{"both detected in one region",
+			map[string]bucketRegionEntry{"archives": detected("eu-central-1"), "baselines": detected("eu-central-1")},
+			"eu-central-1", false},
+		// Two DETECTIONS that differ: a fact, so the file may state it.
+		{"two detections disagree",
+			map[string]bucketRegionEntry{"archives": detected("eu-central-1"), "baselines": detected("us-west-2")},
+			"", true},
+		// The regression: one bucket detected, the other only guessed. Pinning
+		// the detection would export a value that is right for one bucket and
+		// unverified for the other.
+		{"one detected, one only guessed",
+			map[string]bucketRegionEntry{"archives": detected("eu-central-1"), "baselines": fellBack("us-east-1")},
+			"", false},
+		// And it must NOT be reported as a disagreement: the two values differ,
+		// but one of them is not evidence of anything. Claiming it sends the
+		// operator off to split a file that is fine.
+		{"a guess that differs is not a disagreement",
+			map[string]bucketRegionEntry{"archives": detected("eu-central-1"), "baselines": fellBack("ap-south-1")},
+			"", false},
+		{"nothing detected",
+			map[string]bucketRegionEntry{"archives": fellBack("us-east-1"), "baselines": fellBack("us-east-1")},
+			"", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -75,20 +108,44 @@ func TestArchiveRegion_agreementDecidesWhetherAnythingIsPinned(t *testing.T) {
 	}
 }
 
-// The cache is what keeps this off the SQL panel's hot path: buildViewsInput
-// runs per query, so a second call must not re-detect.
-func TestArchiveRegion_detectsEachBucketOnce(t *testing.T) {
+// A detection is a property of the bucket and never expires. A FAILURE is not:
+// its cheap causes are transient (a credential refresh, a blip, an operator
+// closing the download tab, which cancels the request context), and remembering
+// one forever leaves this daemon and the files it hands out disagreeing until
+// somebody restarts it.
+func TestCachedBucketRegion_failureExpiresButDetectionDoesNot(t *testing.T) {
 	t.Setenv("AWS_REGION", "us-east-1")
 	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
 
-	s := &Server{bucketRegions: map[string]string{"archives": "eu-central-1"}}
-	in := views.Input{ArchiveSources: []string{"s3://archives/events/bintrail_id=aaa"}}
-	for range 3 {
-		if r, _ := s.archiveRegion(context.Background(), in); r != "eu-central-1" {
-			t.Fatalf("region = %q; a re-detection would have overwritten the cached value", r)
-		}
+	// A cancelled context makes the re-attempt fail immediately, so this test
+	// needs no network: what it observes is WHETHER an attempt happened.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	stale := time.Now().Add(-negativeRegionTTL - time.Minute)
+	s := &Server{bucketRegions: map[string]bucketRegionEntry{
+		"fresh-miss": {region: "us-east-1", at: time.Now()},
+		"stale-miss": {region: "us-east-1", at: stale},
+		"hit":        {region: "eu-central-1", detected: true, at: stale},
+	}}
+	var cfg aws.Config
+	var loaded bool
+
+	if _, ok := s.cachedBucketRegion(ctx, &cfg, &loaded, "hit"); !ok {
+		t.Error("a detection older than the negative TTL was discarded; a bucket's region does not move")
 	}
-	if len(s.bucketRegions) != 1 {
-		t.Errorf("cache grew to %d entries for one bucket: %v", len(s.bucketRegions), s.bucketRegions)
+	if got := s.bucketRegions["hit"].at; !got.Equal(stale) {
+		t.Error("the detection was re-attempted despite being cached")
+	}
+
+	s.cachedBucketRegion(ctx, &cfg, &loaded, "fresh-miss")
+	if !s.bucketRegions["fresh-miss"].at.Equal(stale) && s.bucketRegions["fresh-miss"].at.Before(time.Now().Add(-time.Second)) {
+		t.Error("unexpected timestamp movement on a fresh miss")
+	}
+
+	before := s.bucketRegions["stale-miss"].at
+	s.cachedBucketRegion(ctx, &cfg, &loaded, "stale-miss")
+	if s.bucketRegions["stale-miss"].at.Equal(before) {
+		t.Error("a failed detection older than the TTL was never retried; a transient cause would stick forever")
 	}
 }

--- a/internal/console/bucketregion_test.go
+++ b/internal/console/bucketregion_test.go
@@ -138,9 +138,15 @@ func TestCachedBucketRegion_failureExpiresButDetectionDoesNot(t *testing.T) {
 		t.Error("the detection was re-attempted despite being cached")
 	}
 
+	// Compared against the value BEFORE the call. The first version of this
+	// asserted `!at.Equal(stale) && at.Before(now-1s)` on an entry seeded to
+	// time.Now(): the second half is false by construction, so the whole leg
+	// was unreachable and removing the negative memoization outright left it
+	// green.
+	freshBefore := s.bucketRegions["fresh-miss"].at
 	s.cachedBucketRegion(ctx, &cfg, &loaded, "fresh-miss")
-	if !s.bucketRegions["fresh-miss"].at.Equal(stale) && s.bucketRegions["fresh-miss"].at.Before(time.Now().Add(-time.Second)) {
-		t.Error("unexpected timestamp movement on a fresh miss")
+	if !s.bucketRegions["fresh-miss"].at.Equal(freshBefore) {
+		t.Error("a failure still inside the TTL was re-attempted; the memoization is what keeps this off the SQL panel's per-query path")
 	}
 
 	before := s.bucketRegions["stale-miss"].at

--- a/internal/console/bucketregion_test.go
+++ b/internal/console/bucketregion_test.go
@@ -1,0 +1,94 @@
+package console
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/views"
+)
+
+// TestLayoutBuckets: both halves of a layout count, because archives and
+// baselines can sit in different buckets and the generated views read both.
+// Missing the baseline half was how the region could look unanimous while one
+// of the two reads pointed elsewhere.
+func TestLayoutBuckets(t *testing.T) {
+	in := views.Input{
+		ArchiveSources: []string{
+			"s3://archives/events/bintrail_id=aaa",
+			"/local/archives/bintrail_id=bbb", // not S3: contributes no bucket
+			"s3://archives/events/bintrail_id=ccc",
+		},
+		Baselines: []views.BaselineTable{
+			{Path: "s3://baselines/2026-06-10T12-00-00Z/shop/orders.parquet"},
+			{Path: "/local/baselines/x.parquet"},
+		},
+	}
+	got := layoutBuckets(in)
+	want := []string{"archives", "baselines"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("layoutBuckets = %v, want %v", got, want)
+	}
+	if b := layoutBuckets(views.Input{ArchiveSources: []string{"/only/local"}}); len(b) != 0 {
+		t.Errorf("a local-only layout yielded buckets: %v", b)
+	}
+}
+
+// TestArchiveRegion_agreementDecidesWhetherAnythingIsPinned drives the decision
+// this feature turns on, with detection pre-seeded so the test needs no network
+// and no AWS. Pinning a region the layout does not unanimously live in is worse
+// than pinning none: the reader's own chain resolves one either way, and a
+// wrong pin sends EVERY bucket to the wrong place instead of just the odd one.
+func TestArchiveRegion_agreementDecidesWhetherAnythingIsPinned(t *testing.T) {
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+
+	layout := views.Input{
+		ArchiveSources: []string{"s3://archives/events/bintrail_id=aaa"},
+		Baselines:      []views.BaselineTable{{Path: "s3://baselines/x/shop/orders.parquet"}},
+	}
+	cases := []struct {
+		name          string
+		seed          map[string]string
+		wantRegion    string
+		wantAmbiguous bool
+	}{
+		{"both buckets in one region", map[string]string{"archives": "eu-central-1", "baselines": "eu-central-1"}, "eu-central-1", false},
+		{"buckets disagree", map[string]string{"archives": "eu-central-1", "baselines": "us-west-2"}, "", true},
+		{"one bucket unresolvable, the other pins", map[string]string{"archives": "", "baselines": "us-west-2"}, "us-west-2", false},
+		{"nothing resolvable", map[string]string{"archives": "", "baselines": ""}, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Server{bucketRegions: tc.seed}
+			region, ambiguous := s.archiveRegion(context.Background(), layout)
+			if region != tc.wantRegion || ambiguous != tc.wantAmbiguous {
+				t.Fatalf("got (%q, %v), want (%q, %v)", region, ambiguous, tc.wantRegion, tc.wantAmbiguous)
+			}
+		})
+	}
+
+	// A local-only layout asks nothing of AWS at all.
+	s := &Server{}
+	if r, amb := s.archiveRegion(context.Background(), views.Input{ArchiveSources: []string{"/local"}}); r != "" || amb {
+		t.Errorf("a local layout resolved a region: (%q, %v)", r, amb)
+	}
+}
+
+// The cache is what keeps this off the SQL panel's hot path: buildViewsInput
+// runs per query, so a second call must not re-detect.
+func TestArchiveRegion_detectsEachBucketOnce(t *testing.T) {
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+
+	s := &Server{bucketRegions: map[string]string{"archives": "eu-central-1"}}
+	in := views.Input{ArchiveSources: []string{"s3://archives/events/bintrail_id=aaa"}}
+	for range 3 {
+		if r, _ := s.archiveRegion(context.Background(), in); r != "eu-central-1" {
+			t.Fatalf("region = %q; a re-detection would have overwritten the cached value", r)
+		}
+	}
+	if len(s.bucketRegions) != 1 {
+		t.Errorf("cache grew to %d entries for one bucket: %v", len(s.bucketRegions), s.bucketRegions)
+	}
+}

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -18,6 +18,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -197,6 +198,13 @@ type RotationDefaults struct {
 // gates) lives in a connManager bundle resolved per request from the
 // X-Bintrail-Server header.
 type Server struct {
+	// bucketRegions memoizes DetectBucketRegion per bucket: buildViewsInput
+	// runs on every SQL panel query, and a bucket's region is fixed for its
+	// lifetime, so one lookup per bucket per process is both enough and the
+	// most this hot path should pay.
+	bucketRegionMu sync.Mutex
+	bucketRegions  map[string]string
+
 	listen     string
 	token      string
 	denyTables []query.SchemaTable

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -199,11 +199,13 @@ type RotationDefaults struct {
 // X-Bintrail-Server header.
 type Server struct {
 	// bucketRegions memoizes DetectBucketRegion per bucket: buildViewsInput
-	// runs on every SQL panel query, and a bucket's region is fixed for its
-	// lifetime, so one lookup per bucket per process is both enough and the
-	// most this hot path should pay.
+	// runs on every SQL panel query, so a network round trip does not belong
+	// on that path in the steady state. A DETECTED region never expires (it is
+	// fixed for the bucket's lifetime); a failed detection is not a property of
+	// the bucket and expires after negativeRegionTTL, so a blip does not poison
+	// every file this daemon hands out until someone restarts it.
 	bucketRegionMu sync.Mutex
-	bucketRegions  map[string]string
+	bucketRegions  map[string]bucketRegionEntry
 
 	listen     string
 	token      string

--- a/internal/console/sqlpanel.go
+++ b/internal/console/sqlpanel.go
@@ -76,7 +76,7 @@ const (
 var sqlPanelTimeout = 60 * time.Second
 
 // sqlPanelSetupTimeout bounds the pre-query setup — the S3 baseline LIST in
-// buildViewsInput is the one unbounded step that runs under the single-flight
+// buildViewsInput holds the unbounded steps that run under the single-flight
 // latch, so a hung listing must not pin the panel at 429 for every other user.
 // The query itself is bounded separately by sqlPanelTimeout.
 var sqlPanelSetupTimeout = 30 * time.Second
@@ -200,8 +200,8 @@ func (s *Server) handleSQLPanel(w http.ResponseWriter, r *http.Request) {
 	}
 	defer s.sqlPanelBusy.Store(false)
 
-	// Bound the setup: buildViewsInput's S3 baseline LIST is the one unbounded
-	// step under the latch. r.Context() still propagates (Cancel works); the
+	// Bound the setup: buildViewsInput's S3 baseline LIST, and the region
+	// lookup beside it, are the unbounded steps under the latch. r.Context() still propagates (Cancel works); the
 	// deadline is what stops a hung listing from wedging the single-flight.
 	setupCtx, setupCancel := context.WithTimeout(r.Context(), sqlPanelSetupTimeout)
 	in, err := s.buildViewsInput(setupCtx, b, false) // runs here: local-first routing

--- a/internal/console/views_api.go
+++ b/internal/console/views_api.go
@@ -81,9 +81,10 @@ func (s *Server) buildViewsInput(ctx context.Context, b *bundle, portable bool) 
 			return views.Input{}, fmt.Errorf("S3 endpoint configuration: %w", err)
 		}
 		in.S3Endpoint = ep
-		// The region this daemon's own archive reads would use (#1462). Left
-		// empty before, so a downloaded file described a different read than
-		// the one performed here.
+		// The region for this layout, when it was actually DETECTED (#1462).
+		// Not "the region our own reads use": those fall back to the ambient
+		// one and are right to, since they fail here and loudly. A file that
+		// leaves the host pins nothing rather than a guess.
 		in.ArchiveRegion, in.RegionAmbiguous = s.archiveRegion(ctx, in)
 	}
 	return in, nil

--- a/internal/console/views_api.go
+++ b/internal/console/views_api.go
@@ -81,6 +81,10 @@ func (s *Server) buildViewsInput(ctx context.Context, b *bundle, portable bool) 
 			return views.Input{}, fmt.Errorf("S3 endpoint configuration: %w", err)
 		}
 		in.S3Endpoint = ep
+		// The region this daemon's own archive reads would use (#1462). Left
+		// empty before, so a downloaded file described a different read than
+		// the one performed here.
+		in.ArchiveRegion, in.RegionAmbiguous = s.archiveRegion(ctx, in)
 	}
 	return in, nil
 }

--- a/internal/console/views_endpoint_test.go
+++ b/internal/console/views_endpoint_test.go
@@ -121,7 +121,7 @@ func TestViewsAPI_pinsTheDetectedRegion(t *testing.T) {
 	srv.cm.boot.db = db
 	// Pre-seeded so the test needs no network: what is under test is that the
 	// resolver's answer reaches the file, not how the answer is obtained.
-	srv.bucketRegions = map[string]string{"bkt": "eu-central-1"}
+	srv.bucketRegions = map[string]bucketRegionEntry{"bkt": detected("eu-central-1")}
 
 	rec, body := doServersReq(t, srv, "GET", "/api/views.sql", "")
 	if rec.Code != 200 {
@@ -129,6 +129,51 @@ func TestViewsAPI_pinsTheDetectedRegion(t *testing.T) {
 	}
 	if !strings.Contains(string(body), "REGION 'eu-central-1'") {
 		t.Errorf("the downloaded file pins no region, so the reader resolves their own:\n%s", body)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+// The other half of the same rule, at the endpoint: a bucket whose region was
+// only GUESSED (GetBucketLocation is outside bintrail's documented minimal IAM
+// policy, so this is the common case) must leave the file unpinned. Pinning the
+// daemon's ambient region would override the reader's own correct
+// configuration on a machine this process cannot see.
+func TestViewsAPI_pinsNothingForAGuessedRegion(t *testing.T) {
+	t.Setenv(storage.EnvS3PathStyle, "")
+	t.Setenv(storage.EnvS3Endpoint, "")
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	mock.ExpectQuery("FROM archive_state").WillReturnRows(
+		sqlmock.NewRows([]string{"bintrail_id", "sample_local", "sample_bucket", "sample_key"}).
+			AddRow("aaaa", nil, "bkt", "events/bintrail_id=aaaa/f.parquet"))
+
+	srv := newViewsServer(t, "", false)
+	srv.cm.boot.db = db
+	srv.bucketRegions = map[string]bucketRegionEntry{"bkt": fellBack("us-east-1")}
+
+	rec, body := doServersReq(t, srv, "GET", "/api/views.sql", "")
+	if rec.Code != 200 {
+		t.Fatalf("code = %d, body = %s", rec.Code, body)
+	}
+	for _, line := range strings.Split(string(body), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "--") {
+			continue
+		}
+		if strings.Contains(line, "REGION '") || strings.Contains(line, "s3_region") {
+			t.Errorf("an unverified region was pinned into a file that leaves this host: %s", line)
+		}
+	}
+	// And it must not claim the buckets disagree, which would be a stated fact.
+	if strings.Contains(string(body), "each detected in a DIFFERENT region") {
+		t.Errorf("a bucket that could not be asked was reported as a disagreement:\n%s", body)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Error(err)

--- a/internal/console/views_endpoint_test.go
+++ b/internal/console/views_endpoint_test.go
@@ -96,3 +96,41 @@ func TestViewsAPI_localOnlyLayoutIgnoresEndpointTypo(t *testing.T) {
 		t.Errorf("a layout treated as local reads S3 after all:\n%s", body)
 	}
 }
+
+// TestViewsAPI_pinsTheDetectedRegion is the WIRING guard for #1462: the
+// resolver is unit-tested on its own, which says nothing about whether
+// buildViewsInput calls it. Before this the console pinned no region at all
+// while the daemon's own reads pinned a detected one, so a downloaded file
+// described a different read than the one this process performs.
+func TestViewsAPI_pinsTheDetectedRegion(t *testing.T) {
+	t.Setenv(storage.EnvS3PathStyle, "")
+	t.Setenv(storage.EnvS3Endpoint, "")
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	mock.ExpectQuery("FROM archive_state").WillReturnRows(
+		sqlmock.NewRows([]string{"bintrail_id", "sample_local", "sample_bucket", "sample_key"}).
+			AddRow("aaaa", nil, "bkt", "events/bintrail_id=aaaa/f.parquet"))
+
+	srv := newViewsServer(t, "", false)
+	srv.cm.boot.db = db
+	// Pre-seeded so the test needs no network: what is under test is that the
+	// resolver's answer reaches the file, not how the answer is obtained.
+	srv.bucketRegions = map[string]string{"bkt": "eu-central-1"}
+
+	rec, body := doServersReq(t, srv, "GET", "/api/views.sql", "")
+	if rec.Code != 200 {
+		t.Fatalf("code = %d, body = %s", rec.Code, body)
+	}
+	if !strings.Contains(string(body), "REGION 'eu-central-1'") {
+		t.Errorf("the downloaded file pins no region, so the reader resolves their own:\n%s", body)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}

--- a/internal/parquetquery/parquetquery.go
+++ b/internal/parquetquery/parquetquery.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	smithy "github.com/aws/smithy-go"
 	_ "github.com/duckdb/duckdb-go/v2"
 	"golang.org/x/sync/errgroup"
 
@@ -316,36 +315,7 @@ func listS3ParquetScoped(ctx context.Context, source string, since, until *time.
 		return nil, 0, "", nil, err
 	}
 
-	// Detect the bucket's actual region via GetBucketLocation (must be called
-	// from us-east-1). This prevents 301 PermanentRedirect errors when the
-	// configured region doesn't match the bucket's location.
-	bucketRegion := cfg.Region
-	locClient := storage.NewS3ClientFromConfig(cfg, func(o *s3.Options) {
-		o.Region = "us-east-1"
-	})
-	loc, locErr := locClient.GetBucketLocation(ctx, &s3.GetBucketLocationInput{
-		Bucket: &bucket,
-	})
-	if locErr != nil {
-		if isBucketLocationAccessDenied(locErr) {
-			// Expected — see isBucketLocationAccessDenied. Still logs locErr so
-			// the rarer non-benign case sharing this same error code (an SCP or
-			// VPC-endpoint-policy deny, a cross-account restriction) stays
-			// diagnosable at --log-level debug.
-			slog.Debug("skipping S3 bucket region auto-detection: GetBucketLocation denied (expected under the minimal IAM policy); using resolved default region", "bucket", bucket, "region", cfg.Region, "error", locErr)
-		} else {
-			slog.Warn("could not detect S3 bucket region, using default", "bucket", bucket, "error", locErr)
-		}
-	} else {
-		r := string(loc.LocationConstraint)
-		if r == "" {
-			r = "us-east-1" // GetBucketLocation returns empty for us-east-1
-		}
-		if r != cfg.Region {
-			slog.Debug("S3 bucket in different region, switching", "bucket", bucket, "bucket_region", r, "default_region", cfg.Region)
-		}
-		bucketRegion = r
-	}
+	bucketRegion := storage.DetectBucketRegion(ctx, cfg, bucket)
 
 	client = storage.NewS3ClientFromConfig(cfg, func(o *s3.Options) {
 		o.Region = bucketRegion
@@ -397,21 +367,6 @@ func listS3ParquetScoped(ctx context.Context, source string, since, until *time.
 
 	slog.Debug("listed S3 archive files", "source", source, "count", len(files))
 	return files, maxSize, bucketRegion, client, nil
-}
-
-// isBucketLocationAccessDenied reports whether err is an AWS AccessDenied-class
-// error from GetBucketLocation. This is the expected outcome under bintrail's
-// documented minimal least-privilege S3 IAM policy (docs/upload.md), which
-// intentionally omits s3:GetBucketLocation — not a misconfiguration worth a
-// WARN. Any other error (network failure, NoSuchBucket, throttling) is
-// unexpected and still warrants one.
-func isBucketLocationAccessDenied(err error) bool {
-	var apiErr smithy.APIError
-	if !errors.As(err, &apiErr) {
-		return false
-	}
-	code := apiErr.ErrorCode()
-	return code == "AccessDenied" || code == "AccessDeniedException"
 }
 
 // sinceLowerBoundHint computes the coarse, deliberately over-inclusive

--- a/internal/parquetquery/parquetquery.go
+++ b/internal/parquetquery/parquetquery.go
@@ -315,7 +315,9 @@ func listS3ParquetScoped(ctx context.Context, source string, since, until *time.
 		return nil, 0, "", nil, err
 	}
 
-	bucketRegion := storage.DetectBucketRegion(ctx, cfg, bucket)
+	// The read path ignores the detected flag on purpose: it is about to read,
+	// so a wrong guess fails here and loudly.
+	bucketRegion, _ := storage.DetectBucketRegion(ctx, cfg, bucket)
 
 	client = storage.NewS3ClientFromConfig(cfg, func(o *s3.Options) {
 		o.Region = bucketRegion

--- a/internal/parquetquery/parquetquery_test.go
+++ b/internal/parquetquery/parquetquery_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	smithy "github.com/aws/smithy-go"
 
 	"github.com/dbtrail/dbtrail/internal/parser"
 	"github.com/dbtrail/dbtrail/internal/query"
@@ -89,30 +88,6 @@ func TestParseS3Source(t *testing.T) {
 		if prefix != tc.wantPrefix {
 			t.Errorf("parseS3Source(%q) prefix = %q, want %q", tc.source, prefix, tc.wantPrefix)
 		}
-	}
-}
-
-// ─── isBucketLocationAccessDenied ───────────────────────────────────────────
-
-func TestIsBucketLocationAccessDenied(t *testing.T) {
-	tests := []struct {
-		name string
-		err  error
-		want bool
-	}{
-		{"AccessDenied code", &smithy.GenericAPIError{Code: "AccessDenied", Message: "not authorized"}, true},
-		{"AccessDeniedException code", &smithy.GenericAPIError{Code: "AccessDeniedException", Message: "not authorized"}, true},
-		{"wrapped AccessDenied", fmt.Errorf("get bucket location: %w", &smithy.GenericAPIError{Code: "AccessDenied", Message: "denied"}), true},
-		{"NoSuchBucket code", &smithy.GenericAPIError{Code: "NoSuchBucket", Message: "not found"}, false},
-		{"non-API error", errors.New("connection reset"), false},
-		{"nil error", nil, false},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := isBucketLocationAccessDenied(tc.err); got != tc.want {
-				t.Errorf("isBucketLocationAccessDenied(%v) = %v, want %v", tc.err, got, tc.want)
-			}
-		})
 	}
 }
 

--- a/internal/storage/bucketregion.go
+++ b/internal/storage/bucketregion.go
@@ -10,20 +10,24 @@ import (
 	smithy "github.com/aws/smithy-go"
 )
 
-// DetectBucketRegion resolves a bucket's ACTUAL region, falling back to the
-// resolved default when it cannot. Best-effort by contract: it never returns an
-// error, because every caller has a usable answer without one and none of them
-// should fail a read over a region hint.
+// DetectBucketRegion resolves a bucket's ACTUAL region. The second return
+// says whether that is a DETECTION or the resolved default standing in for
+// one, and the two must not be conflated: s3:GetBucketLocation is deliberately
+// absent from bintrail's documented minimal IAM policy (docs/s3-iam-policy.md),
+// so a denial — and therefore the fallback — is the COMMON path, not an edge.
 //
 // Why it is not just cfg.Region: a bucket outside the configured region answers
 // 301 PermanentRedirect, and GetBucketLocation is the call that prevents it.
 // That call must itself be made from us-east-1.
 //
-// Lives here rather than beside its first caller because a second one now needs
-// the SAME answer for a different reason: the console names archive roots in a
-// downloadable views.sql, and a file whose region disagrees with the daemon's
-// own reads sends the recipient somewhere the daemon never went.
-func DetectBucketRegion(ctx context.Context, cfg aws.Config, bucket string) string {
+// It never returns an error, because a read has a usable answer without one and
+// must not fail over a region hint. Callers that PUBLISH the answer want the
+// bool: a read that guesses wrong fails here, loudly, against a store this
+// process can see, while a wrong region written into a downloadable file fails
+// on someone else's machine hours later with nothing pointing back here — and
+// where nothing is pinned, that reader's own credential chain resolves the
+// right region on its own. Guessing is strictly worse than silence there.
+func DetectBucketRegion(ctx context.Context, cfg aws.Config, bucket string) (string, bool) {
 	locClient := NewS3ClientFromConfig(cfg, func(o *s3.Options) {
 		o.Region = "us-east-1"
 	})
@@ -39,7 +43,7 @@ func DetectBucketRegion(ctx context.Context, cfg aws.Config, bucket string) stri
 		} else {
 			slog.Warn("could not detect S3 bucket region, using default", "bucket", bucket, "error", err)
 		}
-		return cfg.Region
+		return cfg.Region, false
 	}
 	r := string(loc.LocationConstraint)
 	if r == "" {
@@ -48,7 +52,7 @@ func DetectBucketRegion(ctx context.Context, cfg aws.Config, bucket string) stri
 	if r != cfg.Region {
 		slog.Debug("S3 bucket in different region, switching", "bucket", bucket, "bucket_region", r, "default_region", cfg.Region)
 	}
-	return r
+	return r, true
 }
 
 func isBucketLocationAccessDenied(err error) bool {

--- a/internal/storage/bucketregion.go
+++ b/internal/storage/bucketregion.go
@@ -1,0 +1,61 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	smithy "github.com/aws/smithy-go"
+)
+
+// DetectBucketRegion resolves a bucket's ACTUAL region, falling back to the
+// resolved default when it cannot. Best-effort by contract: it never returns an
+// error, because every caller has a usable answer without one and none of them
+// should fail a read over a region hint.
+//
+// Why it is not just cfg.Region: a bucket outside the configured region answers
+// 301 PermanentRedirect, and GetBucketLocation is the call that prevents it.
+// That call must itself be made from us-east-1.
+//
+// Lives here rather than beside its first caller because a second one now needs
+// the SAME answer for a different reason: the console names archive roots in a
+// downloadable views.sql, and a file whose region disagrees with the daemon's
+// own reads sends the recipient somewhere the daemon never went.
+func DetectBucketRegion(ctx context.Context, cfg aws.Config, bucket string) string {
+	locClient := NewS3ClientFromConfig(cfg, func(o *s3.Options) {
+		o.Region = "us-east-1"
+	})
+	loc, err := locClient.GetBucketLocation(ctx, &s3.GetBucketLocationInput{Bucket: &bucket})
+	if err != nil {
+		if isBucketLocationAccessDenied(err) {
+			// Expected: GetBucketLocation is outside the minimal IAM policy.
+			// Still logs err so the rarer non-benign case sharing this error
+			// code (an SCP or VPC-endpoint-policy deny, a cross-account
+			// restriction) stays diagnosable at --log-level debug.
+			slog.Debug("skipping S3 bucket region auto-detection: GetBucketLocation denied (expected under the minimal IAM policy); using resolved default region",
+				"bucket", bucket, "region", cfg.Region, "error", err)
+		} else {
+			slog.Warn("could not detect S3 bucket region, using default", "bucket", bucket, "error", err)
+		}
+		return cfg.Region
+	}
+	r := string(loc.LocationConstraint)
+	if r == "" {
+		r = "us-east-1" // GetBucketLocation returns empty for us-east-1
+	}
+	if r != cfg.Region {
+		slog.Debug("S3 bucket in different region, switching", "bucket", bucket, "bucket_region", r, "default_region", cfg.Region)
+	}
+	return r
+}
+
+func isBucketLocationAccessDenied(err error) bool {
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	code := apiErr.ErrorCode()
+	return code == "AccessDenied" || code == "AccessDeniedException"
+}

--- a/internal/storage/bucketregion_test.go
+++ b/internal/storage/bucketregion_test.go
@@ -45,7 +45,10 @@ func TestIsBucketLocationAccessDenied(t *testing.T) {
 // A cancelled context makes the call fail without a network or an AWS account,
 // so this is hermetic.
 func TestDetectBucketRegion_failureIsReportedAsSuch(t *testing.T) {
-	t.Setenv("AWS_REGION", "us-east-1")
+	// NOT us-east-1: that is what the SUCCESS path substitutes for an empty
+	// LocationConstraint, so an ambient us-east-1 would let a mutation that
+	// returns the literal survive this assertion.
+	t.Setenv("AWS_REGION", "eu-west-2")
 	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
 	t.Setenv("AWS_ACCESS_KEY_ID", "testdummykey")
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "testdummysecret")
@@ -63,7 +66,7 @@ func TestDetectBucketRegion_failureIsReportedAsSuch(t *testing.T) {
 	}
 	// The read path still needs a usable value, which is why the failure is not
 	// an error: it is about to read, and a wrong guess fails there, loudly.
-	if region != "us-east-1" {
+	if region != "eu-west-2" {
 		t.Errorf("region = %q, want the resolved default for the read path to fall back on", region)
 	}
 }

--- a/internal/storage/bucketregion_test.go
+++ b/internal/storage/bucketregion_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -32,5 +33,37 @@ func TestIsBucketLocationAccessDenied(t *testing.T) {
 				t.Errorf("isBucketLocationAccessDenied(%v) = %v, want %v", tc.err, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestDetectBucketRegion_failureIsReportedAsSuchExists because the fallback is
+// the COMMON path (s3:GetBucketLocation is outside bintrail's documented
+// minimal IAM policy) and it returns a plausible, confident, WRONG region. The
+// only thing separating it from a detection is the second return value, and a
+// caller that publishes the answer relies on it entirely.
+//
+// A cancelled context makes the call fail without a network or an AWS account,
+// so this is hermetic.
+func TestDetectBucketRegion_failureIsReportedAsSuch(t *testing.T) {
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+	t.Setenv("AWS_ACCESS_KEY_ID", "testdummykey")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "testdummysecret")
+
+	cfg, err := LoadAWSConfig(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	region, detected := DetectBucketRegion(ctx, cfg, "some-bucket")
+	if detected {
+		t.Error("a failed lookup reported itself as a detection; the console would pin this guess into a downloadable file")
+	}
+	// The read path still needs a usable value, which is why the failure is not
+	// an error: it is about to read, and a wrong guess fails there, loudly.
+	if region != "us-east-1" {
+		t.Errorf("region = %q, want the resolved default for the read path to fall back on", region)
 	}
 }

--- a/internal/storage/bucketregion_test.go
+++ b/internal/storage/bucketregion_test.go
@@ -1,0 +1,36 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	smithy "github.com/aws/smithy-go"
+)
+
+// GetBucketLocation sits outside bintrail's documented minimal IAM policy, so a
+// denial is the EXPECTED shape and must stay a debug line with a usable
+// fallback. Every other failure is worth a warning. Misclassifying either way
+// is a support cost: a warning on every read for a policy we ourselves
+// recommend, or a silenced SCP deny that looks like a benign one.
+func TestIsBucketLocationAccessDenied(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"AccessDenied code", &smithy.GenericAPIError{Code: "AccessDenied", Message: "not authorized"}, true},
+		{"AccessDeniedException code", &smithy.GenericAPIError{Code: "AccessDeniedException", Message: "not authorized"}, true},
+		{"wrapped AccessDenied", fmt.Errorf("get bucket location: %w", &smithy.GenericAPIError{Code: "AccessDenied", Message: "denied"}), true},
+		{"NoSuchBucket code", &smithy.GenericAPIError{Code: "NoSuchBucket", Message: "not found"}, false},
+		{"non-API error", errors.New("connection reset"), false},
+		{"nil error", nil, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isBucketLocationAccessDenied(tc.err); got != tc.want {
+				t.Errorf("isBucketLocationAccessDenied(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/views/views.go
+++ b/internal/views/views.go
@@ -65,11 +65,14 @@ type Input struct {
 	// default.
 	ArchiveRegion string
 
-	// RegionAmbiguous is set when the layout's buckets do not agree on one
-	// region, so ArchiveRegion was deliberately left empty rather than pinned
-	// to one of them. One secret and one s3_region cannot describe two
-	// regions. The file says so, because a reader who sees no REGION clause
-	// cannot otherwise tell "nothing to pin" from "we could not agree".
+	// RegionAmbiguous is set when two buckets were each DETECTED in a
+	// different region, so ArchiveRegion was left empty rather than pinned to
+	// one of them: one secret and one s3_region cannot describe two. The file
+	// states that as a fact, so the producer must not set it for a bucket that
+	// merely could not be asked — an undetectable bucket is not evidence that
+	// the regions differ, and claiming it would send the reader off to split a
+	// file that is fine. Same rule as ArchiveDiscoveryFailed above: never state
+	// a cause the caller does not know.
 	RegionAmbiguous bool
 	// S3Endpoint is the S3-compatible store the paths live in, when the
 	// generating process was configured with one (#1454). It is a location,
@@ -104,7 +107,15 @@ func Generate(in Input) string {
 	var b strings.Builder
 	writeHeader(&b, in)
 	if in.NeedsS3() {
-		writeS3Preamble(&b, in.ArchiveRegion, in.S3Endpoint, in.RegionAmbiguous)
+		region := in.ArchiveRegion
+		if in.RegionAmbiguous {
+			// Enforced here, not only trusted from the producer: the file
+			// STATES that no region is pinned, so emitting one anyway would
+			// make the artifact contradict itself in the one place a reader
+			// looks to understand why their read failed.
+			region = ""
+		}
+		writeS3Preamble(&b, region, in.S3Endpoint, in.RegionAmbiguous)
 	}
 	writeEventsView(&b, in)
 	writeStateViews(&b, in)
@@ -219,10 +230,10 @@ func writeS3Preamble(b *strings.Builder, region string, ep storage.S3Endpoint, a
 		fmt.Fprintf(b, "-- s3:// paths here live in an S3-compatible store at %s, not in AWS.\n", ep.URL)
 	}
 	if ambiguousRegion {
-		b.WriteString("-- No region is pinned below: the archives and baselines this file reads\n")
-		b.WriteString("-- are in buckets whose regions differ, and one secret cannot name two.\n")
-		b.WriteString("-- Your own AWS configuration resolves one; a bucket outside it answers\n")
-		b.WriteString("-- 301 PermanentRedirect. Split those reads into one file per region, or\n")
+		b.WriteString("-- No region is pinned below: two of the buckets this file reads were\n")
+		b.WriteString("-- each detected in a DIFFERENT region, and one secret cannot name two.\n")
+		b.WriteString("-- Your own AWS configuration resolves one of them; the other rejects a\n")
+		b.WriteString("-- request signed for it. Split those reads into one file per region, or\n")
 		b.WriteString("-- add a second scoped secret for the odd bucket out.\n")
 	}
 	b.WriteString("INSTALL httpfs; LOAD httpfs;\n")

--- a/internal/views/views.go
+++ b/internal/views/views.go
@@ -64,6 +64,13 @@ type Input struct {
 	// chain resolve it, which is what every other bintrail S3 read does by
 	// default.
 	ArchiveRegion string
+
+	// RegionAmbiguous is set when the layout's buckets do not agree on one
+	// region, so ArchiveRegion was deliberately left empty rather than pinned
+	// to one of them. One secret and one s3_region cannot describe two
+	// regions. The file says so, because a reader who sees no REGION clause
+	// cannot otherwise tell "nothing to pin" from "we could not agree".
+	RegionAmbiguous bool
 	// S3Endpoint is the S3-compatible store the paths live in, when the
 	// generating process was configured with one (#1454). It is a location,
 	// not a credential, and belongs in the file: a reader on another machine
@@ -97,7 +104,7 @@ func Generate(in Input) string {
 	var b strings.Builder
 	writeHeader(&b, in)
 	if in.NeedsS3() {
-		writeS3Preamble(&b, in.ArchiveRegion, in.S3Endpoint)
+		writeS3Preamble(&b, in.ArchiveRegion, in.S3Endpoint, in.RegionAmbiguous)
 	}
 	writeEventsView(&b, in)
 	writeStateViews(&b, in)
@@ -206,10 +213,17 @@ func orUnknown(s string) string {
 // paste into a notebook or share with a colleague: it resolves whatever the
 // environment already has (instance role, SSO profile, env vars) and puts NO key
 // material in the generated text.
-func writeS3Preamble(b *strings.Builder, region string, ep storage.S3Endpoint) {
+func writeS3Preamble(b *strings.Builder, region string, ep storage.S3Endpoint, ambiguousRegion bool) {
 	b.WriteString("-- S3 setup, mirroring what bintrail's own DuckDB sessions configure.\n")
 	if ep.Set() {
 		fmt.Fprintf(b, "-- s3:// paths here live in an S3-compatible store at %s, not in AWS.\n", ep.URL)
+	}
+	if ambiguousRegion {
+		b.WriteString("-- No region is pinned below: the archives and baselines this file reads\n")
+		b.WriteString("-- are in buckets whose regions differ, and one secret cannot name two.\n")
+		b.WriteString("-- Your own AWS configuration resolves one; a bucket outside it answers\n")
+		b.WriteString("-- 301 PermanentRedirect. Split those reads into one file per region, or\n")
+		b.WriteString("-- add a second scoped secret for the odd bucket out.\n")
 	}
 	b.WriteString("INSTALL httpfs; LOAD httpfs;\n")
 	b.WriteString("INSTALL aws; LOAD aws;\n")

--- a/internal/views/views_endpoint_test.go
+++ b/internal/views/views_endpoint_test.go
@@ -80,10 +80,12 @@ func TestGenerate_noEndpointIsAWS(t *testing.T) {
 // means one of their buckets will answer 301 and the file needs splitting.
 func TestGenerate_ambiguousRegionSaysSo(t *testing.T) {
 	in := goldenInput()
-	in.ArchiveRegion, in.RegionAmbiguous = "", true
+	// A NON-EMPTY region with the flag set: with "" the suppression assertion
+	// below passes whatever the flag does, which is a guard that cannot fail.
+	in.ArchiveRegion, in.RegionAmbiguous = "eu-central-1", true
 	out := Generate(in)
 
-	if !strings.Contains(out, "buckets whose regions differ") {
+	if !strings.Contains(out, "each detected in a DIFFERENT region") {
 		t.Errorf("an ambiguous region renders silently:\n%s", out)
 	}
 	// Executable lines only: the file's closing comment SHOWS a sample secret
@@ -98,7 +100,7 @@ func TestGenerate_ambiguousRegionSaysSo(t *testing.T) {
 	}
 	// The note is prose, so it must not be executable.
 	for _, line := range strings.Split(out, "\n") {
-		if strings.Contains(line, "buckets whose regions differ") && !strings.HasPrefix(strings.TrimSpace(line), "--") {
+		if strings.Contains(line, "each detected in a DIFFERENT region") && !strings.HasPrefix(strings.TrimSpace(line), "--") {
 			t.Errorf("the note is not a comment: %s", line)
 		}
 	}
@@ -109,7 +111,7 @@ func TestGenerate_unambiguousRegionCarriesNoNote(t *testing.T) {
 	in := goldenInput()
 	in.ArchiveRegion, in.RegionAmbiguous = "eu-central-1", false
 	out := Generate(in)
-	if strings.Contains(out, "buckets whose regions differ") {
+	if strings.Contains(out, "each detected in a DIFFERENT region") {
 		t.Errorf("a pinned region carries the ambiguity note:\n%s", out)
 	}
 	if !strings.Contains(out, "REGION 'eu-central-1'") {

--- a/internal/views/views_endpoint_test.go
+++ b/internal/views/views_endpoint_test.go
@@ -74,3 +74,45 @@ func TestGenerate_noEndpointIsAWS(t *testing.T) {
 		t.Errorf("an AWS layout mentions an endpoint or reroutes httpfs:\n%s", out)
 	}
 }
+
+// A reader who sees no REGION clause cannot tell "nothing to pin" from "we
+// could not agree", and the two need different action from them: the second
+// means one of their buckets will answer 301 and the file needs splitting.
+func TestGenerate_ambiguousRegionSaysSo(t *testing.T) {
+	in := goldenInput()
+	in.ArchiveRegion, in.RegionAmbiguous = "", true
+	out := Generate(in)
+
+	if !strings.Contains(out, "buckets whose regions differ") {
+		t.Errorf("an ambiguous region renders silently:\n%s", out)
+	}
+	// Executable lines only: the file's closing comment SHOWS a sample secret
+	// carrying REGION, so an unscoped scan matches prose and never fails.
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "--") {
+			continue
+		}
+		if strings.Contains(line, "REGION '") || strings.Contains(line, "s3_region") {
+			t.Errorf("a region was pinned despite the buckets disagreeing: %s", line)
+		}
+	}
+	// The note is prose, so it must not be executable.
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "buckets whose regions differ") && !strings.HasPrefix(strings.TrimSpace(line), "--") {
+			t.Errorf("the note is not a comment: %s", line)
+		}
+	}
+}
+
+// The ordinary case stays silent: a pinned region needs no explanation.
+func TestGenerate_unambiguousRegionCarriesNoNote(t *testing.T) {
+	in := goldenInput()
+	in.ArchiveRegion, in.RegionAmbiguous = "eu-central-1", false
+	out := Generate(in)
+	if strings.Contains(out, "buckets whose regions differ") {
+		t.Errorf("a pinned region carries the ambiguity note:\n%s", out)
+	}
+	if !strings.Contains(out, "REGION 'eu-central-1'") {
+		t.Errorf("the pinned region is missing from the secret:\n%s", out)
+	}
+}

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -1712,7 +1712,17 @@ try {
       return { total, arrived, firstSeen, maxGap: Math.max(0, ...gapAround) };
     });
   };
-  const rmTl = await staggerProbe("reduce");
+  // Retried on READINESS, like the no-preference arm below and for the same
+  // reason: a runner loaded enough to starve runState leaves the probe with
+  // zero nodes to look at, and `total: 0` was reported as a missing-stagger
+  // regression (#1463). Readiness only — not the assertion — so a real JS
+  // stagger under reduced motion satisfies rmRead on the first attempt and
+  // still fails the same-tick check below, every attempt.
+  const rmRead = (r) => r.total >= 2 && r.arrived === r.total;
+  let rmTl = await staggerProbe("reduce");
+  for (let attempt = 0; attempt < 2 && !rmRead(rmTl); attempt++) {
+    rmTl = await staggerProbe("reduce");
+  }
   // The no-preference arm reads an ORDER out of a 55ms step by polling every
   // 10ms, so a loaded runner can hide it: if the loop stalls longer than one
   // step, both nodes are first seen on the same poll and the arm reports a


### PR DESCRIPTION
closes #1462
closes #1463

## What was wrong

`views.Input.ArchiveRegion` had exactly one producer: `bintrail views --region`. The console filled it never. So every `views.sql` downloaded from the console pinned no S3 region, and neither did the SQL panel's own DuckDB session, while the daemon's archive reads pin a region **detected from the bucket** (#511). The file described a different read than the process that generated it performs, and a store that validates the signing region rejects what the recipient sends.

## Only a DETECTED region is pinned

This is the part worth reviewing, because the obvious version of this fix is a regression.

`s3:GetBucketLocation` is **deliberately outside** bintrail's documented minimal IAM policy (`docs/s3-iam-policy.md`), so a failed lookup is the **common** path, not an edge — and it falls back to the daemon's own ambient region: a plausible, confident, wrong value. Writing that into a file that runs on someone else's machine **overrides their correct configuration**, where pinning nothing lets their credential chain resolve the right region unaided. Silence beats a guess when the artifact leaves the host.

That is the opposite of the read path's trade-off, which is why `DetectBucketRegion` now returns `(region, detected)` and the read path keeps ignoring the second value: it is about to read, so a wrong guess fails there, loudly, against a store this process can see.

- Pins only when **every** bucket was detected and they agree. Partial knowledge is not a basis for pinning.
- Declares ambiguity only when **two detections** differ. A bucket that could not be asked is not evidence that the regions differ, and the file states that as a fact. Same rule `ArchiveDiscoveryFailed` already sets: never state a cause the caller does not know.
- `Generate` enforces the pairing rather than trusting the producer, so the artifact cannot contradict its own explanation.

## The rest

- The `GetBucketLocation` detection moves from `internal/parquetquery` to `storage.DetectBucketRegion` unchanged (branch for branch, same log levels and messages); its `isBucketLocationAccessDenied` test moves with it.
- **Failed detections expire** (`negativeRegionTTL`). A cancelled download (the endpoint has no request deadline) or a credential refresh is not a property of a bucket; remembering one forever left the daemon and the files it hands out disagreeing until a restart.
- **The mutex covers the map, never the RPC.** `sync.Mutex` is not context-aware, so a goroutine blocked acquiring it cannot be released by the SQL panel's setup deadline, and one hung lookup on the deadline-free download path would have stalled the panel into 429s for everyone.
- `LoadAWSConfig` is lazy and runs only when some bucket actually needs asking; its failure logs, because that is the one case the file itself cannot describe.
- The download and the panel resolve **separately**, not identically: the download names archives portably (S3 wherever registered), the panel local-first, so on a daemon with local copies the panel legitimately stays unpinned.

## #1463, folded in

The reduced-motion stagger probe retries its `reduce` arm on **readiness**, as its `no-preference` sibling already did. A runner loaded enough to starve `runState` left the probe with zero nodes and reported `total: 0` as a missing-stagger regression.

## Test plan

- [x] `go test ./... -count=1` green; `GOWORK=off go build ./...`; `go vet`; OSS firewall clean
- [x] Console e2e run locally against real headless Chrome: **320/320**
- [x] Mutation-checked, each applied and reverted, each turning exactly one guard red: a fallback treated as a detection; partial knowledge pinning anyway; a failed detection cached forever; ambiguity not suppressing the pin; `DetectBucketRegion` claiming every fallback as a detection.
- [x] For #1463 the mutation that matters for a retry is whether it disarmed the assertion: remove the reduced-motion gate in `app.js` so nodes genuinely stagger, and the scenario still **fails** — `{"total":2,"arrived":2,"firstSeen":[7,12]}` — a shape no retry absorbs, and nothing like the flake's `total: 0`.

## Notes

Two things review caught that are worth repeating, because both were guards that could not fail:

- The first version of the console test seeded `""` for an unresolvable bucket. Production cannot produce that: a failure returns `cfg.Region`. The test asserted the desired behavior for a case it never exercised.
- Nothing reached `DetectBucketRegion` at all — every console test pre-seeds the cache — so making it claim every fallback as a detection broke no test. The single bit this feature turns on had no guard.