### PR TITLE
docs/indexing: say that a PK lookup needs the index's leading columns

### DIFF
--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -112,9 +112,21 @@ Indexed events go into `binlog_events`, range-partitioned by hour on
 `event_timestamp`. PK lookups are fast because `pk_hash`
 (`SHA2(pk_values, 256)`) is a stored, indexed column; queries match on
 `pk_hash` **and** the exact `pk_values` (the second check guards against the
-astronomically rare hash collision). `pk_values` is the pipe-delimited PK in
-column ordinal order; a PK value whose raw bytes are not valid UTF-8 (e.g. a
-`BINARY(16)` UUID) is stored as `0x` + uppercase hex — see
+astronomically rare hash collision).
+
+Matching those two columns is what makes the answer *correct*; it is not what
+makes it *fast*. The index is `idx_pk_hash (schema_name, table_name, pk_hash,
+event_timestamp)`, so `schema_name` and `table_name` have to be in the
+predicate too or the index cannot be used at all. A lookup naming only
+`pk_hash` and `pk_values` falls back to a full table scan, which on a
+multi-million-row `binlog_events` is seconds per query rather than
+milliseconds. `EXPLAIN` shows the difference immediately: `type: ref` with
+`key: idx_pk_hash` when the leading columns are present, `type: ALL` when they
+are not.
+
+`pk_values` is the pipe-delimited PK in column ordinal order; a PK value
+whose raw bytes are not valid UTF-8 (e.g. a `BINARY(16)` UUID) is stored as
+`0x` + uppercase hex — see
 [Binary primary keys](query-and-recovery.md#binary-primary-keys-the-0x-hex-spelling)
 for how to spell it in `--pk` lookups. Partition lifecycle, retention, and
 archiving to Parquet are covered in [Rotation and status](rotation-and-status.md).

--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -110,19 +110,23 @@ can group indexed files by origin server — see
 
 Indexed events go into `binlog_events`, range-partitioned by hour on
 `event_timestamp`. PK lookups are fast because `pk_hash`
-(`SHA2(pk_values, 256)`) is a stored, indexed column; queries match on
-`pk_hash` **and** the exact `pk_values` (the second check guards against the
-astronomically rare hash collision).
+(`SHA2(pk_values, 256)`) is covered by `idx_pk_hash (schema_name, table_name,
+pk_hash, event_timestamp)`; queries match on `pk_hash` **and** the exact
+`pk_values` (the second check guards against the astronomically rare hash
+collision).
 
-Matching those two columns is what makes the answer *correct*; it is not what
-makes it *fast*. The index is `idx_pk_hash (schema_name, table_name, pk_hash,
-event_timestamp)`, so `schema_name` and `table_name` have to be in the
-predicate too or the index cannot be used at all. A lookup naming only
-`pk_hash` and `pk_values` falls back to a full table scan, which on a
-multi-million-row `binlog_events` is seconds per query rather than
-milliseconds. `EXPLAIN` shows the difference immediately: `type: ref` with
+Those are two separate rules, and it is worth keeping them apart. Matching
+`pk_values` is what makes the answer *correct*. Naming `schema_name` and
+`table_name` is what makes it *fast*: they lead the index, so a predicate
+without them leaves the optimizer nothing to seek on and it falls back to
+scanning the table. `EXPLAIN` tells you which one you got — `type: ref` with
 `key: idx_pk_hash` when the leading columns are present, `type: ALL` when they
 are not.
+
+This matters when you query `binlog_events` directly, in SQL you wrote. The
+shipped commands already require it: `query`, `recover`, the MCP tools and the
+console all refuse a PK filter that does not also name a schema and a table,
+precisely so the index is never scanned blindly.
 
 `pk_values` is the pipe-delimited PK in column ordinal order; a PK value
 whose raw bytes are not valid UTF-8 (e.g. a `BINARY(16)` UUID) is stored as

--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -17,7 +17,10 @@ Filters: `--schema`, `--table`, `--pk`, `--event-type`, `--gtid`,
 `--column-eq` (events where a column has a given value — see below), and
 `--flag` (tables/columns labeled via [RBAC flags](server-identity.md)). A
 `--pk` lookup is fast and collision-safe — it matches a hash of the PK values
-plus the exact values. Binary primary keys need a special spelling — see
+plus the exact values, and it requires `--schema` and `--table` alongside it.
+That is not a formality: those two columns lead the index, so a lookup without
+them would scan the table instead of seeking, and the command refuses rather
+than doing that quietly. Binary primary keys need a special spelling — see
 [the `0x` hex spelling](#binary-primary-keys-the-0x-hex-spelling) below.
 
 ### Binary primary keys: the `0x` hex spelling

--- a/internal/agent/handler.go
+++ b/internal/agent/handler.go
@@ -151,10 +151,14 @@ func (h *DefaultHandler) HandleResolvePK(ctx context.Context, req ResolvePKReque
 
 // resolvePKFromMySQL queries binlog_events for a single pk_hash.
 //
-// Note: the standard PK lookup pattern requires both pk_hash = SHA2(?, 256)
-// AND pk_values = ? as a collision guard. Here we only have the hash (that's
-// what we're resolving), so we query by pk_hash alone. SHA-256 collisions
-// are astronomically unlikely; callers should verify results when critical.
+// Note: the standard PK lookup pattern pairs pk_hash = SHA2(?, 256) with
+// pk_values = ? as a collision guard. Here pk_values is the ANSWER, not an
+// input, so the guard cannot be applied and the hash stands alone. SHA-256
+// collisions are astronomically unlikely; callers should verify results when
+// critical.
+//
+// schema_name and table_name are still passed, and are not optional: they
+// lead idx_pk_hash, so dropping them would turn this seek into a full scan.
 func (h *DefaultHandler) resolvePKFromMySQL(ctx context.Context, item PKItem) (string, error) {
 	var pkValues string
 	err := h.IndexDB.QueryRowContext(ctx,


### PR DESCRIPTION
closes #1488

## What was wrong

`docs/indexing.md` described PK lookups as fast because `pk_hash` is a stored,
indexed column, and said queries match on `pk_hash` and `pk_values`. Both
statements are true. Read together they imply that naming those two columns is
what gets you the index, and it is not.

The index is `idx_pk_hash (schema_name, table_name, pk_hash, event_timestamp)`.
Without `schema_name` and `table_name` in the predicate, the leading columns are
missing and MySQL cannot use it.

## Measured

On a 5.2M row `binlog_events`:

```
-- without the leading columns
type: ALL     rows: 5200893     key: NULL      -> 5.2 s per query

-- with them
type: ref     rows: 17          key: idx_pk_hash  -> 1.2 ms
```

## The change

One added paragraph, separating the two rules that were previously blended into
one sentence: matching `pk_values` is what makes the answer correct (collision
guard), and including the leading columns is what makes it fast. It names the
index, states the consequence, and points at `EXPLAIN` as the way to tell.

Docs only. No code change.
