### PR TITLE
console: anchor the config-dir fallback absolutely when HOME is unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   since nothing creates the tree until something saves into it. Because that
   repeated failure was in practice the only signal anywhere that `HOME` was
   unset, fixing it would have removed the signal and left the cause, so a
-  homeless daemon now warns once at startup, naming the directory it anchored
-  to and the settings that override it. It is a warning and not a refusal:
+  daemon with no home that falls back to a default path now warns once, naming
+  the directory it anchored to and the settings that override it. It is a warning and not a refusal:
   losing run history must never stop a refresh, and the console is a recovery
   path that does not decline to boot over where its own state file landed. The
   same relative fallback was shared verbatim by `generate-key`'s default key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **The console daemon keeps its baseline run history, and says when it cannot
+  find a home directory** (#1487). A daemon started without `HOME`, which is
+  how a service manager starts one, resolved its server registry, auth file,
+  MCP token, verify history and baseline run history through a fallback
+  written as `filepath.Join(".", ".config", ...)`. That reads as though it
+  anchors to the current directory and does not: `Join` runs `Clean`, which
+  deletes the leading `"."`, so the result was a bare relative path resolved
+  against the process working directory at each IO. The path now names the
+  working directory outright. Nothing moves as a result, since no code path
+  changes directory between resolving a path and writing it; what changes is
+  that a failure names a directory an operator can go and look at, instead of
+  one that depended on when the syscall happened. Separately, and this is what
+  actually lost the history: `BaselineRunHistory.save` was the only one of five
+  sibling atomic savers that did not create its directory first, so every
+  refresh failed with `ENOENT` whenever `~/.config/bintrail` did not exist yet.
+  That is the normal state of a fresh install with a perfectly good `HOME`,
+  since nothing creates the tree until something saves into it. Because that
+  repeated failure was in practice the only signal anywhere that `HOME` was
+  unset, fixing it would have removed the signal and left the cause, so a
+  homeless daemon now warns once at startup, naming the directory it anchored
+  to and the settings that override it. It is a warning and not a refusal:
+  losing run history must never stop a refresh, and the console is a recovery
+  path that does not decline to boot over where its own state file landed. The
+  same relative fallback was shared verbatim by `generate-key`'s default key
+  path and is fixed there too.
 - **The console daemon's background folds are bounded, and their volume warning
   works** (#1477). `bintrail-console watch` rebuilds snapshots in the same
   process that captures binlogs, for the scheduled baseline refresh, the

--- a/cliapp/generate_key.go
+++ b/cliapp/generate_key.go
@@ -36,11 +36,18 @@ func init() {
 	rootCmd.AddCommand(generateKeyCmd)
 }
 
-// defaultKeyPath returns ~/.config/bintrail/dump.key.
+// defaultKeyPath returns ~/.config/bintrail/dump.key. With no home directory
+// the fallback anchors in the working directory EXPLICITLY: filepath.Join(".",
+// ...) Cleans the leading "." away and yields a RELATIVE path, which resolves
+// against wherever the process happens to be (#1487).
 func defaultKeyPath() string {
 	home, err := os.UserHomeDir()
-	if err != nil {
-		return filepath.Join(".", ".config", "bintrail", "dump.key")
+	if err != nil || home == "" {
+		wd, wdErr := os.Getwd()
+		if wdErr != nil {
+			return filepath.Join(".config", "bintrail", "dump.key")
+		}
+		home = wd
 	}
 	return filepath.Join(home, ".config", "bintrail", "dump.key")
 }

--- a/cliapp/generate_key_test.go
+++ b/cliapp/generate_key_test.go
@@ -137,3 +137,19 @@ func TestDefaultKeyPath(t *testing.T) {
 		t.Errorf("unexpected default key path: %s", p)
 	}
 }
+
+// TestDefaultKeyPathIsAbsoluteWithoutHome pins the same #1487 defect on the
+// CLI's key path: with no HOME the fallback must still be absolute, or
+// `bintrail generate-key` writes into (and later reads from) whatever working
+// directory it was launched in.
+//
+// Not parallel: t.Setenv.
+func TestDefaultKeyPathIsAbsoluteWithoutHome(t *testing.T) {
+	// os.UserHomeDir errors on an EMPTY value, not only on an unset one.
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "") // its source on Windows
+
+	if p := defaultKeyPath(); !filepath.IsAbs(p) {
+		t.Errorf("defaultKeyPath() = %q with no HOME; want an absolute path", p)
+	}
+}

--- a/consoleapp/user.go
+++ b/consoleapp/user.go
@@ -85,9 +85,9 @@ func init() {
 }
 
 // resolveAuthPath applies flag > env > default for the auth-file location.
-// Every error path downstream prints the RESOLVED path: in containers the
-// default falls back to an unwritable relative ./.config when the process
-// user has no home, and the path is the only way to see that.
+// Every error path downstream prints the RESOLVED path: with no home
+// directory the default anchors beside the working directory instead of a
+// config directory, and the path is the only way to see that.
 func resolveAuthPath(cmd *cobra.Command) string {
 	cli.LoadEnvFile()
 	if usrAuthFile != "" {

--- a/internal/console/authfile.go
+++ b/internal/console/authfile.go
@@ -69,13 +69,9 @@ type AuthFile struct {
 var authFileMu sync.Mutex
 
 // DefaultAuthPath returns ~/.config/bintrail/console-auth.yaml, with the same
-// relative fallback as DefaultRegistryPath for homeless environments.
+// homeless fallback as DefaultRegistryPath (see configPath).
 func DefaultAuthPath() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return filepath.Join(".", ".config", "bintrail", "console-auth.yaml")
-	}
-	return filepath.Join(home, ".config", "bintrail", "console-auth.yaml")
+	return configPath("console-auth.yaml")
 }
 
 // LoadAuthFile reads the credential file at path. A missing file returns
@@ -205,8 +201,8 @@ func verifyAndMaybeRehash(path string, a *AuthFile, username, password string) b
 // (same class as the server registry). Callers hold authFileMu.
 func saveAuthFile(path string, a *AuthFile) error {
 	// Every error wraps the resolved path: in a homeless container the default
-	// resolves to an unwritable relative ./.config/... and the path is the
-	// only clue (e.g. a full-disk write needs to say WHERE).
+	// resolves outside the operator's home and the path is the only clue
+	// (e.g. a full-disk write needs to say WHERE).
 	data, err := yaml.Marshal(a)
 	if err != nil {
 		return fmt.Errorf("marshal console auth file %s: %w", path, err)

--- a/internal/console/baseline_history.go
+++ b/internal/console/baseline_history.go
@@ -146,7 +146,17 @@ func (h *BaselineRunHistory) save() error {
 	if err != nil {
 		return err
 	}
-	tmp, err := os.CreateTemp(filepath.Dir(h.path), ".baseline-history-*")
+	// Create the tree first, exactly as the sibling savers do (Registry.save,
+	// saveAuthFile, saveMCPTokenFile, VerifyHistory.save — this is
+	// VerifyHistory.save's shape, the closest relative). Nothing else creates
+	// ~/.config/bintrail on a fresh install, so without this the first refresh
+	// on a brand-new host loses its history to ENOENT (#1487). 0700 because
+	// the directory also holds the registry's DSN passwords.
+	dir := filepath.Dir(h.path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".baseline-history-*")
 	if err != nil {
 		return err
 	}

--- a/internal/console/baseline_history.go
+++ b/internal/console/baseline_history.go
@@ -144,7 +144,10 @@ func (h *BaselineRunHistory) List(serverID string) []BaselineRunRecord {
 func (h *BaselineRunHistory) save() error {
 	b, err := json.Marshal(baselineHistoryFile{Version: baselineHistoryVersion, Servers: h.servers})
 	if err != nil {
-		return err
+		// The only step here whose failure names nothing on its own: every
+		// other one returns an *os.PathError/*os.LinkError already carrying
+		// the path, which is why they keep VerifyHistory.save's raw returns.
+		return fmt.Errorf("marshal baseline history %s: %w", h.path, err)
 	}
 	// Create the tree first, exactly as the sibling savers do (Registry.save,
 	// saveAuthFile, saveMCPTokenFile, VerifyHistory.save — this is

--- a/internal/console/baseline_history_test.go
+++ b/internal/console/baseline_history_test.go
@@ -1,0 +1,63 @@
+package console
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestBaselineHistoryAppendCreatesMissingConfigDir pins the second half of
+// #1487. Making the config path absolute stops the history landing in an
+// arbitrary working directory, but it does not by itself make the write
+// succeed: BaselineRunHistory.save was the only one of five sibling atomic
+// savers (Registry.save, saveAuthFile, saveMCPTokenFile, VerifyHistory.save)
+// that did not create its directory first.
+//
+// That reproduces the reported symptom — the run history lost on every
+// refresh — on a fresh install with a perfectly good HOME. Nothing creates
+// ~/.config/bintrail on its own: LoadRegistry treats a missing file as an
+// empty registry, and Registry.save only runs on a mutation, so the first
+// baseline refresh can genuinely be the tree's first writer.
+//
+// Deliberately independent of the absolute-path fix: the path here is
+// explicit, so this test stays red whenever the MkdirAll is missing, and the
+// absolute-path test stays red whenever the fallback is relative. Neither fix
+// alone turns both green.
+func TestBaselineHistoryAppendCreatesMissingConfigDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), ".config", "bintrail")
+	path := filepath.Join(dir, "console-baseline-history.json")
+
+	h, err := OpenBaselineHistory(path)
+	if err != nil {
+		t.Fatalf("OpenBaselineHistory under a not-yet-created tree: %v", err)
+	}
+	rec := BaselineRunRecord{
+		ServerID:     "s1",
+		Kind:         BaselineRunRefresh,
+		SnapshotTime: "2026-08-27T10:00:00Z",
+		StartedAt:    "2026-08-27T09:59:00Z",
+	}
+	if err := h.Append(rec); err != nil {
+		t.Fatalf("Append into a not-yet-created config directory: %v", err)
+	}
+
+	// Durability, not just a nil error: a save that wrote nothing would pass
+	// an error check on its own.
+	reloaded, err := OpenBaselineHistory(path)
+	if err != nil {
+		t.Fatalf("reopen history: %v", err)
+	}
+	if got := reloaded.FindBySnapshot(rec.ServerID, rec.SnapshotTime); got == nil {
+		t.Fatalf("record did not survive the write to %s", path)
+	}
+
+	// 0700 like every sibling saver: this directory holds the registry's DSN
+	// passwords and the console credential file.
+	st, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat the created config directory: %v", err)
+	}
+	if perm := st.Mode().Perm(); perm != 0o700 {
+		t.Errorf("created config directory mode = %04o, want 0700 (matching Registry.save and VerifyHistory.save)", perm)
+	}
+}

--- a/internal/console/configpath.go
+++ b/internal/console/configpath.go
@@ -1,9 +1,16 @@
 package console
 
 import (
+	"log/slog"
 	"os"
 	"path/filepath"
+	"sync"
 )
+
+// configPathWarnOnce keeps the homeless warning to one line per process. Every
+// Default*Path() runs inside a run function, several of them per boot and some
+// per cycle, so warning on each call would bury the log it belongs in.
+var configPathWarnOnce sync.Once
 
 // configPath returns ~/.config/bintrail/<name> — the console's on-disk state
 // directory, shared by the server registry, the credential file, the managed
@@ -28,7 +35,31 @@ func configPath(name string) string {
 			// one so the caller's error at least names the file.
 			return filepath.Join(".config", "bintrail", name)
 		}
+		warnHomelessConfigDir(filepath.Join(wd, ".config", "bintrail"))
 		home = wd
 	}
 	return filepath.Join(home, ".config", "bintrail", name)
+}
+
+// warnHomelessConfigDir reports, once, that console state is anchored beside
+// the working directory instead of a config directory.
+//
+// This is not decoration. Every reader on this path is quiet by design: a
+// missing registry loads as an EMPTY registry with no error, a missing auth
+// file lands in the first-run password setup, a missing managed MCP token just
+// 401s its clients. So a homeless daemon comes up with no servers and an offer
+// to create a password, which looks like a console nobody configured yet
+// rather than one detached from its state. Under systemd's default
+// WorkingDirectory=/ (and in a container, whose default cwd is also /) that
+// state sits in /.config/bintrail: it persists under systemd, but in a
+// container it lives in the writable layer and dies with the container.
+//
+// Warning, never fatal. The console is a recovery path; it does not refuse to
+// boot over where its own state file landed.
+func warnHomelessConfigDir(dir string) {
+	configPathWarnOnce.Do(func() {
+		slog.Warn("no home directory could be resolved, so console state is anchored beside the working directory instead of a config directory. An existing registry elsewhere will not be found and the console will come up with no servers, as if it had never been configured",
+			"dir", dir,
+			"fix", "set HOME for the service, or pass explicit paths (CLI: --servers-file on serve, --console-servers-file on watch, or BINTRAIL_CONSOLE_SERVERS; --auth-file or BINTRAIL_CONSOLE_AUTH)")
+	})
 }

--- a/internal/console/configpath.go
+++ b/internal/console/configpath.go
@@ -1,0 +1,34 @@
+package console
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// configPath returns ~/.config/bintrail/<name> — the console's on-disk state
+// directory, shared by the server registry, the credential file, the managed
+// MCP token, and (as siblings derived from the registry path) the verify and
+// baseline run histories.
+//
+// With no home directory — a daemon started by a process manager that passes
+// no HOME, systemd DynamicUser, a scrubbed container — the fallback anchors in
+// the working directory EXPLICITLY. The obvious spelling,
+// filepath.Join(".", ".config", ...), does NOT do that: Join Cleans the
+// leading "." away and yields a RELATIVE path. That path then resolves against
+// wherever the process happens to be at write time, and its failures name a
+// directory no operator can find (#1487: every baseline refresh logged
+// `open .config/bintrail/.baseline-history-…: no such file or directory`).
+func configPath(name string) string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		wd, wdErr := os.Getwd()
+		if wdErr != nil {
+			// Neither a home nor a working directory: there is nothing left to
+			// anchor to. Return the bare relative path rather than an empty
+			// one so the caller's error at least names the file.
+			return filepath.Join(".config", "bintrail", name)
+		}
+		home = wd
+	}
+	return filepath.Join(home, ".config", "bintrail", name)
+}

--- a/internal/console/configpath.go
+++ b/internal/console/configpath.go
@@ -21,10 +21,14 @@ var configPathWarnOnce sync.Once
 // no HOME, systemd DynamicUser, a scrubbed container — the fallback anchors in
 // the working directory EXPLICITLY. The obvious spelling,
 // filepath.Join(".", ".config", ...), does NOT do that: Join Cleans the
-// leading "." away and yields a RELATIVE path. That path then resolves against
-// wherever the process happens to be at write time, and its failures name a
-// directory no operator can find (#1487: every baseline refresh logged
-// `open .config/bintrail/.baseline-history-…: no such file or directory`).
+// leading "." away and yields a RELATIVE path. That designates the SAME
+// directory this does, since resolution happens against the working directory
+// either way and nothing outside tests calls os.Chdir — so this moved no data
+// and there is nothing to migrate. What it buys is a path that can be READ: a
+// failure now names a directory the operator can go and look at, and the
+// anchor is stated rather than left to whenever the syscall runs (#1487: every
+// baseline refresh logged `open .config/bintrail/.baseline-history-…: no such
+// file or directory`, which names nothing findable).
 func configPath(name string) string {
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {

--- a/internal/console/configpath_test.go
+++ b/internal/console/configpath_test.go
@@ -1,7 +1,11 @@
 package console
 
 import (
+	"bytes"
+	"log/slog"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 )
 
@@ -38,5 +42,62 @@ func TestDefaultConfigPathsAreAbsoluteWithoutHome(t *testing.T) {
 		if !filepath.IsAbs(p) {
 			t.Errorf("%s = %q with no HOME; want an absolute path (a relative one resolves against the daemon's working directory, and its write errors name a directory the operator cannot find)", name, p)
 		}
+	}
+}
+
+// TestConfigPathWarnsWhenHomeIsMissing pins the signal that the MkdirAll fix
+// would otherwise delete.
+//
+// Before this PR, a homeless daemon's registry, auth file and MCP token were
+// written successfully (their savers all MkdirAll) while the baseline history
+// write failed every cycle. That repeated ENOENT was, by accident, the ONLY
+// indication anywhere that HOME was unset. Making the history write succeed
+// removes it, and every reader on this path is quiet by design: a missing
+// registry is an empty registry with no error, a missing auth file lands in
+// the first-run setup flow, a missing MCP token just 401s. The composite is a
+// console that comes up with no servers and offers to create a password,
+// looking merely unconfigured rather than detached from its state.
+//
+// So the fallback has to say so itself. Warning, never fatal: the console is a
+// recovery path and must still boot.
+//
+// Not parallel: t.Setenv and it swaps the default logger.
+func TestConfigPathWarnsWhenHomeIsMissing(t *testing.T) {
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+
+	// The warning is once-per-process so a per-cycle caller cannot spam the
+	// log; reset it so this test does not depend on which test ran first.
+	configPathWarnOnce = sync.Once{}
+	t.Cleanup(func() { configPathWarnOnce = sync.Once{} })
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	defer slog.SetDefault(prev)
+
+	got := configPath("console-servers.yaml")
+	logged := buf.String()
+
+	if logged == "" {
+		t.Fatal("no warning logged when the home directory could not be resolved; a homeless daemon would silently anchor all console state at its working directory")
+	}
+	// It must name the directory it actually anchored to, so the operator can
+	// go and look at it.
+	if dir := filepath.Dir(got); !strings.Contains(logged, dir) {
+		t.Errorf("warning does not name the directory it anchored to (%s): %s", dir, logged)
+	}
+	// ...and the levers that fix it.
+	for _, want := range []string{"HOME", "servers-file", "auth-file"} {
+		if !strings.Contains(logged, want) {
+			t.Errorf("warning does not mention %q, so it names no way out: %s", want, logged)
+		}
+	}
+
+	// Once per process: a second call must stay silent.
+	buf.Reset()
+	configPath("console-auth.yaml")
+	if second := buf.String(); second != "" {
+		t.Errorf("warning repeated on a later call; it must fire once per process, got: %s", second)
 	}
 }

--- a/internal/console/configpath_test.go
+++ b/internal/console/configpath_test.go
@@ -1,0 +1,42 @@
+package console
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestDefaultConfigPathsAreAbsoluteWithoutHome pins #1487. A daemon started by
+// a process manager with no HOME (systemd without an explicit Environment=HOME,
+// DynamicUser, a scrubbed container) must still name an absolute path for its
+// state files. The old fallback built filepath.Join(".", ".config", …), and
+// Join CLEANS the leading "." away — so it returned a RELATIVE path that
+// resolved against whatever working directory the process happened to have.
+// The reported symptom was the baseline-run history: every refresh logged
+// `open .config/bintrail/.baseline-history-…: no such file or directory`, an
+// error naming a directory no operator could locate.
+//
+// Not parallel: t.Setenv.
+func TestDefaultConfigPathsAreAbsoluteWithoutHome(t *testing.T) {
+	// os.UserHomeDir errors on an EMPTY value, not only on an unset one, so
+	// this reproduces the homeless daemon. USERPROFILE is its source on
+	// Windows (see TestMain, which sets both).
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+
+	registry := DefaultRegistryPath()
+	paths := map[string]string{
+		"DefaultRegistryPath":  registry,
+		"DefaultAuthPath":      DefaultAuthPath(),
+		"DefaultMCPTokenPath":  DefaultMCPTokenPath(),
+		"DefaultVerifyHistory": DefaultVerifyHistoryPath(registry),
+		// The baseline-run history is a sibling of the registry file, so it
+		// inherits both the defect and the fix — this is the write #1487
+		// reported losing on all seven refreshes of a benchmark run.
+		"DefaultBaselineHistoryPath": DefaultBaselineHistoryPath(registry),
+	}
+	for name, p := range paths {
+		if !filepath.IsAbs(p) {
+			t.Errorf("%s = %q with no HOME; want an absolute path (a relative one resolves against the daemon's working directory, and its write errors name a directory the operator cannot find)", name, p)
+		}
+	}
+}

--- a/internal/console/mcptoken.go
+++ b/internal/console/mcptoken.go
@@ -74,13 +74,9 @@ type MCPTokenFile struct {
 var mcpTokenFileMu sync.Mutex
 
 // DefaultMCPTokenPath returns ~/.config/bintrail/console-mcp-token.yaml, with
-// the same relative fallback as DefaultAuthPath for homeless environments.
+// the same homeless fallback as DefaultAuthPath (see configPath).
 func DefaultMCPTokenPath() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return filepath.Join(".", ".config", "bintrail", "console-mcp-token.yaml")
-	}
-	return filepath.Join(home, ".config", "bintrail", "console-mcp-token.yaml")
+	return configPath("console-mcp-token.yaml")
 }
 
 // LoadMCPTokenFile reads the managed-token file at path. A missing file

--- a/internal/console/registry.go
+++ b/internal/console/registry.go
@@ -187,14 +187,12 @@ type Registry struct {
 	readOnly bool
 }
 
-// DefaultRegistryPath returns ~/.config/bintrail/console-servers.yaml,
-// mirroring generate-key's defaultKeyPath fallback behavior.
+// DefaultRegistryPath returns ~/.config/bintrail/console-servers.yaml, with
+// configPath's working-directory fallback for homeless environments. The
+// verify and baseline run histories are named as siblings of this path, so
+// they inherit whatever it resolves to.
 func DefaultRegistryPath() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return filepath.Join(".", ".config", "bintrail", "console-servers.yaml")
-	}
-	return filepath.Join(home, ".config", "bintrail", "console-servers.yaml")
+	return configPath("console-servers.yaml")
 }
 
 // LoadRegistry reads the registry file at path. A missing or empty file is an


### PR DESCRIPTION
Three commits. Only the second one changes what the daemon does with data; the other two are about being able to see what it did.

| Commit | Kind | Effect |
|---|---|---|
| `fe0048e` | diagnostics | the config-path fallback names an absolute directory. **Moves no data.** |
| `e9792d4` | behavioural | `MkdirAll` before the history write. **This is what was losing the history.** |
| `53c771d` | diagnostics | warn once when no home can be resolved, replacing the signal the fix above removes |

## Commit 1: the path was relative, and read as though it wasn't

`os.UserHomeDir()` **does** return an error when `HOME` is unset, and the error was not ignored. It was answered with a bad value:

```go
if err != nil {
    return filepath.Join(".", ".config", "bintrail", "console-servers.yaml")
}
```

`filepath.Join` calls `Clean`, which removes the leading `"."`. The fallback returned `.config/bintrail/console-servers.yaml`, a **relative** path. It is invisible on inspection: the code reads as if it anchors to the current directory and it does not. Every console state file derived from it inherited that, including the baseline run history, named as a sibling of the registry path.

### What this does and does not buy

Worth stating outright, because the commit subject ("anchor the config-dir fallback absolutely") could be read as though data moved. It did not.

There is **no `os.Chdir` anywhere outside `_test.go`** in this repo, and every `Default*Path()` call runs inside a run function after process start, never at package level. So `filepath.Join(os.Getwd(), ...)` designates **the same directory** the relative path resolved to. Nothing migrates and no deployment loses state.

What changes is legibility and determinism: the error now names a directory the operator can `ls`, and the path no longer depends on when the syscall happens rather than when it was resolved. What it explicitly does **not** buy is a better location. A homeless daemon still writes its state beside its working directory, DSN passwords in the registry included. That is the direction the issue asked for, so it is the right call here, but it is a floor and not a fix for where the data lives.

Follow-up worth its own issue: on unix `os.UserConfigDir()` honours `XDG_CONFIG_HOME`, which is the one anchor strictly better than cwd and would not relocate macOS users, since it is normally unset there. (Using `UserConfigDir` *unconditionally* is the wrong turn: on macOS it returns `~/Library/Application Support`, silently relocating every existing user.)

### Sites

Four had the construction verbatim, all fixed since it is one root cause:

| Site | Note |
|---|---|
| `console.DefaultRegistryPath` | the one in the report |
| `console.DefaultAuthPath` | its comment read "the same relative fallback as DefaultRegistryPath" |
| `console.DefaultMCPTokenPath` | same, chained off `DefaultAuthPath` |
| `cliapp.defaultKeyPath` | `bintrail generate-key` / `--encrypt-key` default |

The three in `internal/console` share one unexported `configPath` so the fix cannot drift. `DefaultVerifyHistoryPath` and `DefaultBaselineHistoryPath` take the registry path as an argument and inherit it.

Checked and **not** affected: `internal/cli/env.go`, `internal/duckdbutil`, `internal/console/storage_api.go` (all guard `if err == nil` and skip), `internal/telemetry.ConfigDir` and `cliapp`'s `config init` (both propagate the error instead of substituting a path).

### Two scope boundaries, both by design

- **The default path only.** `DefaultBaselineHistoryPath`/`DefaultVerifyHistoryPath` derive from `filepath.Dir(serversPath)`, so an operator passing a bare relative `--servers-file` / `--console-servers-file` still gets relative siblings, with `HOME` set perfectly. The test covers the defaults, so "always absolute" is **not** established as an invariant. `filepath.Abs` at the flag boundary would close it; the shipped compose passes absolute paths, so it is not live there. Follow-up, not this PR.
- **The guard is probabilistic, not structural.** `configpath.go` still returns the relative value if `os.Getwd()` *also* fails. Unreachable in practice and documented in place, but it is a fallback within a fallback rather than an impossibility.

## Commit 2: the directory was never created

`BaselineRunHistory.save` was the only one of five sibling atomic savers without `os.MkdirAll`. `Registry.save`, `saveAuthFile`, `saveMCPTokenFile` and `VerifyHistory.save` all have it.

This is **not** limited to the homeless case. Nothing creates `~/.config/bintrail` on its own: `LoadRegistry` treats a missing file as an empty registry, and `Registry.save` only runs on a mutation, so the first baseline refresh can be the tree's first writer, and the history is lost on a fresh install with a perfectly good `HOME`. Same reported symptom, different cause, which is why both ship together: fixing only commit 1 would have closed the issue while leaving its symptom fully reachable on the most common first-run path.

Copied from **`VerifyHistory.save`**, the closest relative (same package, same JSON history shape): hoist `dir` out of the `CreateTemp` call, `MkdirAll` `0700` ahead of it. `0700` matches all four siblings; the directory also holds the registry's DSN passwords. Ordering otherwise unchanged: create, temp file, chmod `0600`, write, fsync, close, rename.

On error wrapping: three siblings wrap with operation and path, `VerifyHistory.save` returns raw, and this copied the latter. Every step here except one fails with an `*os.PathError`/`*os.LinkError` that already carries the path, so raw returns preserve exactly the property this PR is about. The exception, `json.Marshal`, would name nothing at all, so that one branch now wraps with the path.

## Commit 3: the fix deletes a signal, so it puts one back

The asymmetry above is why the homeless daemon in the report had a **working registry** while the history write failed every cycle. That repeated `ENOENT` was, by accident, the operator's only indication anywhere that `HOME` was unset. Commit 2 makes the write succeed, which removes the symptom and leaves the cause.

Nothing else on this path speaks up. A missing registry loads as an empty registry with no error and no log; a missing auth file lands in the first-run password setup; a missing managed MCP token just 401s its clients. The composite is a console that comes up with no servers and an offer to create a password: it looks like one nobody configured yet, not one detached from its state. Under systemd's default `WorkingDirectory=/`, and in a container whose default cwd is also `/`, that state sits in `/.config/bintrail` — persistent under systemd, but in the container's writable layer, destroyed whenever the container is recreated.

So `configPath` now warns once per process when the home lookup fails, naming the directory it anchored to and the settings that override it. Once per process because several `Default*Path()` calls run per boot and some run per cycle. **Warning, not fatal**, which the issue was explicit about and is still right: losing run history must never stop a refresh, and the console is a recovery path that does not decline to boot over where its state file landed.

Also here: `consoleapp/user.go`'s `resolveAuthPath` comment still described the fallback as "an unwritable relative `./.config`". This PR falsified it. Its twin in `internal/console/authfile.go` was updated in commit 1 and this one was missed; a sweep confirms no other stale mention remains.

`CHANGELOG.md` gets an entry under `Unreleased`/`Fixed`, with no migration note, for the reason given above.

## Tests: three guards, each red first, none redundant

Written before their fixes and run red, never reverted with `git checkout`. Reverting each fix in isolation confirms **no single fix turns the others green**.

`TestDefaultConfigPathsAreAbsoluteWithoutHome` blanks `HOME`/`USERPROFILE` (`os.UserHomeDir` errors on an empty value, not only an unset one) and asserts `filepath.IsAbs` per site, so a partial fix stays red:

```
--- FAIL: TestDefaultConfigPathsAreAbsoluteWithoutHome
    DefaultRegistryPath = ".config/bintrail/console-servers.yaml" with no HOME; want an absolute path
    DefaultAuthPath = ".config/bintrail/console-auth.yaml" ...
    DefaultMCPTokenPath = ".config/bintrail/console-mcp-token.yaml" ...
    DefaultVerifyHistory = ".config/bintrail/console-verify-history.json" ...
    DefaultBaselineHistoryPath = ".config/bintrail/console-baseline-history.json" ...
```

`TestBaselineHistoryAppendCreatesMissingConfigDir` appends under a `.config/bintrail` that does not exist, reopens the file to prove the record is durable rather than merely in memory, and checks the created directory is `0700`. It reproduces the issue's error exactly, down to the temp-name shape:

```
--- FAIL: TestBaselineHistoryAppendCreatesMissingConfigDir
    Append into a not-yet-created config directory: open /.../.config/bintrail/.baseline-history-151778302: no such file or directory
```

`TestConfigPathWarnsWhenHomeIsMissing` captures the default logger and asserts the warning names the anchored directory and the levers out (`HOME`, `--servers-file`, `--auth-file`), then that a second call stays silent. Red on its assertion, not on a compile error — the `sync.Once` was added first so the test could actually run:

```
--- FAIL: TestConfigPathWarnsWhenHomeIsMissing
    no warning logged when the home directory could not be resolved; a homeless daemon would silently anchor all console state at its working directory
```

`go test ./... -count=1` exits 0 (53 packages). `go vet -tags integration ./...` exits 0. Green under `-race`; neither package contains a `t.Parallel()` call, so the `t.Setenv` and the logger swap are safe.

closes #1487
