### PR TITLE
watch: restart the main source on an index write deadline instead of exiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **A slow index no longer ends capture** (#1482). `bintrail-console watch`
+  supervised the sources added from its console, restarting them with backoff,
+  but ran its own `--source-dsn` source as a single call: a batch INSERT that
+  ran past `--write-timeout` returned an error the daemon exited on, and
+  nothing restarted it. Read pressure on the index was enough to trigger it,
+  and capture then stayed down until an operator noticed, with the exposure
+  bounded only by how long the source keeps its binlogs. That exit also ran the
+  supervisor's shutdown, so the main source's failure stopped every supervised
+  source alongside it, and those recorded `stopped` rather than `failed`,
+  leaving nothing to show they had died of another source's error. The write
+  deadline is now its own failure class and the main source restarts on it,
+  under the policy the supervised sources already used: 15s doubling to a 5m
+  cap, reset by a run that streamed for more than 10 minutes, and a permanent
+  stop after 6h of continuous crash-looping that returns the original error
+  with its original advice. Every other error still ends the run on the first
+  failure, unchanged. This restarts the stream and deliberately does NOT retry
+  the INSERT in place, a distinction that must survive any later
+  simplification: the deadline is enforced by the client, which cancels by
+  closing the socket without a `KILL QUERY`, so a batch that was merely slow
+  usually goes on to commit on the server after the client stopped waiting, and
+  re-running that statement would write every row a second time, permanently,
+  into a table with no natural key to deduplicate on. A restart instead replays
+  from the last checkpoint through the dedup-on-resume step, which exists to
+  drop exactly those rows. Know three limits. The breaker bounds a fast crash
+  loop, not a slow flap: a source that fails only after runs longer than the
+  healthy-reset window restarts indefinitely, which is long-standing behaviour
+  and is what you want, since capture is up for all but the backoff of such a
+  cycle. The new failure class covers the batch INSERT only, so a deadline on
+  the checkpoint or the gap record still ends the daemon as before. And the
+  daemon no longer exiting means its Prometheus target no longer disappears, so
+  an `up == 0` alert will not fire and the stream gauges freeze at their last
+  healthy value rather than rising: alert on staleness of
+  `bintrail_stream_last_flush_timestamp_seconds` instead of on a lag gauge, and
+  note that `watch` exposes no metrics at all unless `--metrics-addr` is set.
+- **A connection attempt can no longer block forever** (#1482). `Connect` and
+  `ConnectWithTLS` verified a new connection with an unbounded ping, and the
+  `timeout=` DSN parameter is the dial timeout only, with no read or write
+  timeout set anywhere. A server that accepted the TCP connection and then
+  never completed the MySQL handshake, which is what a frozen VM or an
+  idle-dropped load balancer looks like, left the caller blocked with no way
+  out. Both paths now spend the DSN's own connect budget on the handshake as
+  well, so such a peer surfaces as a ping error. The bound covers the connect
+  phase only and never becomes a read deadline on an established connection, so
+  long-running statements are unaffected; raise `timeout=` in the DSN if a
+  server legitimately needs longer to complete a handshake.
+- **A supervised source no longer gives up after one failure that follows a
+  long healthy run** (#1482). The crash-loop circuit breaker measured the
+  failed run's own uptime instead of how long the source had been failing, so a
+  source that had streamed for longer than the 6h give-up threshold, which is
+  the normal state of a healthy daemon, was marked permanently `failed` on its
+  first failure without a single retry, reporting a crash loop that had never
+  happened. It now measures from the first failure. The retry delay also
+  overflowed after 30 consecutive failures and became no delay at all, hammering
+  a failing source roughly 2h13m into what should have been a 6h budget; it now
+  stops growing once it reaches the 5m cap.
 - **The console daemon's background folds are bounded, and their volume warning
   works** (#1477). `bintrail-console watch` rebuilds snapshots in the same
   process that captures binlogs, for the scheduled baseline refresh, the

--- a/consoleapp/crashloop.go
+++ b/consoleapp/crashloop.go
@@ -1,0 +1,60 @@
+package consoleapp
+
+import "time"
+
+// crashLoopPolicy is the restart policy shared by the supervised registry
+// sources (monitorSupervisor.run) and the daemon's main source
+// (runMainStreamWithWriteDeadlineRetry): exponential backoff plus a circuit
+// breaker, in ONE implementation so the two cannot drift apart. It holds no
+// clock of its own — callers pass the run's start and the current time — so the
+// arithmetic is testable at real constants without sleeping through them.
+type crashLoopPolicy struct {
+	attempt int
+	// since is the first FAILURE of the current loop; zero means not looping.
+	since time.Time
+}
+
+// failed records one failed run and returns how long to wait before restarting,
+// how long the current loop has been going, and whether to stop retrying.
+func (p *crashLoopPolicy) failed(started, now time.Time) (delay, looping time.Duration, giveUp bool) {
+	// A run that streamed for longer than monitorHealthyReset was not part of a
+	// crash loop, so it clears both the backoff and the breaker clock.
+	//
+	// A source that flaps SLOWLY therefore restarts indefinitely. That is
+	// deliberate, not an oversight, and TestMonitorRun_healthyRunResetsBreaker
+	// pins it: across such a cycle capture is up for all but the backoff, and
+	// stopping capture outright would be worse than the flap. The breaker exists
+	// for a FAST crash loop, where restarting achieves nothing.
+	if now.Sub(started) > monitorHealthyReset {
+		p.attempt = 0
+		p.since = time.Time{}
+	}
+	if p.since.IsZero() {
+		// The FAILURE time, never the run's start.
+		//
+		// Charging a healthy run's uptime to the breaker made it trip on failure
+		// number ONE of any daemon that had been up longer than
+		// monitorGiveUpAfter, which is the normal state of a capture daemon: a
+		// process up 35 hours reported "gave up after 35h of crash-looping" on its
+		// first stall, having restarted nothing. The restart policy therefore did
+		// not engage at all in the incident it exists to handle (#1482), and a
+		// registry source hit the same wall as a permanent `failed` (#1031).
+		p.since = now
+	}
+	looping = now.Sub(p.since)
+	// >= so that a zero threshold still means "trip on the first failure", which
+	// is how the breaker's own tests express "immediately".
+	if looping >= monitorGiveUpAfter {
+		return 0, looping, true
+	}
+	// Advance the backoff only while it is still growing. Past the cap another
+	// shift changes nothing, and left unbounded it overflows int64 (at attempt 30
+	// for a 15s base) where min() would pick the NEGATIVE value and the backoff
+	// would silently become no delay at all.
+	shifted := monitorBackoffBase << p.attempt
+	if shifted <= 0 || shifted >= monitorBackoffCap {
+		return monitorBackoffCap, looping, false
+	}
+	p.attempt++
+	return shifted, looping, false
+}

--- a/consoleapp/crashloop_test.go
+++ b/consoleapp/crashloop_test.go
@@ -1,0 +1,86 @@
+package consoleapp
+
+import (
+	"testing"
+	"time"
+)
+
+// The breaker must measure CRASH-LOOPING, not uptime.
+//
+// Assigning the breaker clock the start of the run that just failed charges a
+// daemon's entire healthy lifetime to it. Any daemon up longer than
+// monitorGiveUpAfter, which is the normal state of a capture daemon, then gives
+// up on failure number ONE having restarted nothing, and logs a crash loop that
+// never happened. That defeats the restart policy in exactly the incident it
+// exists to handle (#1482) and marks a registry source permanently failed after
+// one blip (#1031).
+//
+// Real constants, fake clock: no sleeping through six hours.
+func TestCrashLoopPolicy_longHealthyRunDoesNotTripTheBreaker(t *testing.T) {
+	var p crashLoopPolicy
+	start := time.Now()
+
+	// A daemon that streamed for 35 hours, then failed once.
+	delay, looping, giveUp := p.failed(start, start.Add(35*time.Hour))
+
+	if giveUp {
+		t.Fatalf("gave up on the first failure of a 35h-healthy daemon (looping reported as %s); "+
+			"the breaker is measuring uptime, not crash-looping", looping)
+	}
+	if looping != 0 {
+		t.Errorf("looping = %s on the first failure; want 0, the loop has just begun", looping)
+	}
+	if delay != monitorBackoffBase {
+		t.Errorf("delay = %s, want the base %s on the first restart", delay, monitorBackoffBase)
+	}
+}
+
+// The breaker must still fire on a genuine fast crash loop, or the change above
+// would trade one broken direction for another.
+func TestCrashLoopPolicy_fastCrashLoopStillGivesUp(t *testing.T) {
+	var p crashLoopPolicy
+	now := time.Now()
+
+	// Runs that fail after a second each, well under monitorHealthyReset, so
+	// nothing resets. Walk a fake clock until the breaker trips.
+	for i := 0; i < 100000; i++ {
+		started := now
+		now = now.Add(time.Second) // the run
+		delay, looping, giveUp := p.failed(started, now)
+		if giveUp {
+			if looping < monitorGiveUpAfter {
+				t.Fatalf("gave up after only %s of looping, before the %s threshold", looping, monitorGiveUpAfter)
+			}
+			return
+		}
+		now = now.Add(delay) // the backoff
+	}
+	t.Fatalf("a fast crash loop never tripped the %s breaker", monitorGiveUpAfter)
+}
+
+// The backoff must never hand back a non-positive delay. Left unbounded the
+// shift overflows int64 (attempt 30 at a 15s base), min() picks the NEGATIVE
+// value, and the "backoff" becomes an unthrottled hammer against the resource
+// that is already failing.
+func TestCrashLoopPolicy_backoffNeverGoesNonPositive(t *testing.T) {
+	var p crashLoopPolicy
+	now := time.Now()
+
+	for i := 0; i < 200; i++ {
+		started := now
+		now = now.Add(time.Millisecond)
+		delay, _, giveUp := p.failed(started, now)
+		if giveUp {
+			// Re-arm: this test is about the delay, not the breaker.
+			p = crashLoopPolicy{}
+			continue
+		}
+		if delay <= 0 {
+			t.Fatalf("iteration %d: delay = %s; a non-positive backoff is an unthrottled retry loop", i, delay)
+		}
+		if delay > monitorBackoffCap {
+			t.Fatalf("iteration %d: delay = %s exceeds the %s cap", i, delay, monitorBackoffCap)
+		}
+		now = now.Add(delay)
+	}
+}

--- a/consoleapp/mainstream.go
+++ b/consoleapp/mainstream.go
@@ -1,0 +1,91 @@
+package consoleapp
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/streamrun"
+)
+
+// mainStreamFn runs the daemon's main source stream to completion.
+// streamrun.One in production; a seam so the restart policy below is testable
+// without a live source (the supervised registry sources have the same seam,
+// monitorSupervisor.streamFn).
+var mainStreamFn = streamrun.One
+
+// runMainStreamWithWriteDeadlineRetry runs `watch --source-dsn`'s stream and,
+// on an index write-deadline failure ONLY, restarts it instead of ending the
+// daemon (#1482).
+//
+// The hole this closes: `watch` supervises the registry sources it streams
+// (monitorSupervisor.run — crash-loop backoff, circuit breaker) but ran its MAIN
+// source as a bare, one-shot call. One slow batch INSERT therefore terminated
+// the process, and nothing restarted it; observed in #1482 as 41 minutes of no
+// capture after a heavy analytical read starved the index, ended by hand. Worse,
+// that exit runs supervisor.Shutdown(), so the main source's failure also tore
+// down every supervised source whose own backoff loop would have ridden it out.
+// This is the same policy those sources already get, narrowed to the one error
+// class where retrying is sound.
+//
+// Why a RESTART and not a retry of the batch INSERT. The deadline is
+// client-side: go-sql-driver cancels by closing the socket (mysqlConn.cancel →
+// cleanup, no KILL QUERY), so an INSERT that was merely slow generally runs to
+// completion and COMMITS on the server after the client has stopped waiting.
+// Re-executing it in place would duplicate every row of that batch, in a
+// forensics index, with nothing to clean up after — binlog_events has no natural
+// key to dedup on. Re-entering streamrun.One replays from the last durable
+// checkpoint and passes through dedup-on-resume
+// (deleteEventsSinceCheckpoint / …GTID), which exists precisely to drop rows a
+// timed-out write may have left behind. So the restart is not just the cheaper
+// fix, it is the only duplicate-safe one. Caveat inherited, not introduced: in
+// GTID mode after a gap auto-advance that dedup is deliberately skipped, and the
+// documented accepted-duplicate window (#500) applies to a restart here exactly
+// as it does to a restart by hand.
+//
+// Only indexer.ErrWriteDeadline re-arms the loop; every other error returns
+// unchanged, exactly as before. That is not a shortcut, it is the point: an
+// un-indexable event must still abort loudly rather than spin (#652), and an
+// index that is genuinely gone fails One() at connect with a different error, so
+// this loop cannot sit on a dead link.
+func runMainStreamWithWriteDeadlineRetry(ctx context.Context, cfg streamrun.Config) error {
+	attempt := 0
+	var crashLoopSince time.Time // first failure of the current loop; zero = healthy
+	for {
+		started := time.Now()
+		err := mainStreamFn(ctx, cfg)
+		// ctx.Err() first: on shutdown One's final checkpoint flush can hit the
+		// same deadline, and that is a stopping daemon, not a stall to ride out.
+		if err == nil || ctx.Err() != nil || !errors.Is(err, indexer.ErrWriteDeadline) {
+			return err
+		}
+		if time.Since(started) > monitorHealthyReset {
+			attempt = 0
+			crashLoopSince = time.Time{}
+		}
+		if crashLoopSince.IsZero() {
+			crashLoopSince = started
+		}
+		// Circuit breaker. The give-up path is the OLD behaviour, unchanged and
+		// undiluted: the same error, with the same three remedies, ends the
+		// daemon. Retrying only moves when that happens, never whether.
+		if looping := time.Since(crashLoopSince); looping > monitorGiveUpAfter {
+			slog.Error("main source stream kept exhausting the index write deadline; giving up and stopping capture",
+				"looping_for", looping.Round(time.Minute), "attempts", attempt+1, "error", err)
+			return err
+		}
+		delay := min(monitorBackoffBase<<attempt, monitorBackoffCap)
+		attempt++
+		slog.Warn("main source stream hit the index write deadline; restarting capture from its last checkpoint",
+			"attempt", attempt, "delay", delay, "error", err)
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			// Stopped mid-backoff. Surface the failure that put us here rather
+			// than exiting 0 on a daemon that was not capturing.
+			return err
+		}
+	}
+}

--- a/consoleapp/mainstream.go
+++ b/consoleapp/mainstream.go
@@ -51,8 +51,7 @@ var mainStreamFn = streamrun.One
 // index that is genuinely gone fails One() at connect with a different error, so
 // this loop cannot sit on a dead link.
 func runMainStreamWithWriteDeadlineRetry(ctx context.Context, cfg streamrun.Config) error {
-	attempt := 0
-	var crashLoopSince time.Time // first failure of the current loop; zero = healthy
+	var policy crashLoopPolicy
 	for {
 		started := time.Now()
 		err := mainStreamFn(ctx, cfg)
@@ -61,25 +60,17 @@ func runMainStreamWithWriteDeadlineRetry(ctx context.Context, cfg streamrun.Conf
 		if err == nil || ctx.Err() != nil || !errors.Is(err, indexer.ErrWriteDeadline) {
 			return err
 		}
-		if time.Since(started) > monitorHealthyReset {
-			attempt = 0
-			crashLoopSince = time.Time{}
-		}
-		if crashLoopSince.IsZero() {
-			crashLoopSince = started
-		}
 		// Circuit breaker. The give-up path is the OLD behaviour, unchanged and
 		// undiluted: the same error, with the same three remedies, ends the
 		// daemon. Retrying only moves when that happens, never whether.
-		if looping := time.Since(crashLoopSince); looping > monitorGiveUpAfter {
+		delay, looping, giveUp := policy.failed(started, time.Now())
+		if giveUp {
 			slog.Error("main source stream kept exhausting the index write deadline; giving up and stopping capture",
-				"looping_for", looping.Round(time.Minute), "attempts", attempt+1, "error", err)
+				"looping_for", looping.Round(time.Minute), "error", err)
 			return err
 		}
-		delay := min(monitorBackoffBase<<attempt, monitorBackoffCap)
-		attempt++
 		slog.Warn("main source stream hit the index write deadline; restarting capture from its last checkpoint",
-			"attempt", attempt, "delay", delay, "error", err)
+			"delay", delay, "error", err)
 		select {
 		case <-time.After(delay):
 		case <-ctx.Done():

--- a/consoleapp/mainstream_test.go
+++ b/consoleapp/mainstream_test.go
@@ -1,0 +1,216 @@
+package consoleapp
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/streamrun"
+)
+
+// realWriteDeadlineError produces the ACTUAL error `watch` died on in #1482, by
+// driving indexer.InsertBatch against a TCP listener that accepts and then never
+// speaks MySQL, with WriteTimeout shrunk. Hand-building an error here would test
+// this file's idea of what the indexer returns; a restart policy keyed on the
+// wrong shape is exactly the bug, so the fixture has to come from the real path.
+//
+// Mutates the shared indexer.WriteTimeout global, so callers must not
+// t.Parallel().
+func realWriteDeadlineError(t *testing.T) error {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	go func() {
+		var held []net.Conn
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				for _, h := range held {
+					h.Close()
+				}
+				return
+			}
+			held = append(held, c) // hold open, never respond
+		}
+	}()
+
+	prev := indexer.WriteTimeout
+	indexer.WriteTimeout = 250 * time.Millisecond
+	t.Cleanup(func() { indexer.WriteTimeout = prev })
+
+	db, err := sql.Open("mysql", "root:x@tcp("+ln.Addr().String()+")/db?timeout=30s")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	_, err = indexer.New(db, 1).InsertBatch(nil)
+	if err == nil {
+		t.Fatal("setup: expected the stalled write to fail")
+	}
+	if !errors.Is(err, indexer.ErrWriteDeadline) {
+		t.Fatalf("setup: expected a write-deadline error from the real path, got: %v", err)
+	}
+	return err
+}
+
+// shrinkMonitorBackoff makes the restart policy run in milliseconds.
+func shrinkMonitorBackoff(t *testing.T) {
+	t.Helper()
+	giveUp, base, cap_, healthy := monitorGiveUpAfter, monitorBackoffBase, monitorBackoffCap, monitorHealthyReset
+	t.Cleanup(func() {
+		monitorGiveUpAfter, monitorBackoffBase, monitorBackoffCap, monitorHealthyReset = giveUp, base, cap_, healthy
+	})
+	monitorGiveUpAfter = time.Hour
+	monitorBackoffBase = time.Millisecond
+	monitorBackoffCap = 2 * time.Millisecond
+	monitorHealthyReset = time.Hour // no run in this test is "healthy"
+}
+
+// Every behavioural test below drives the policy through the mainStreamFn seam,
+// which proves the policy works and says NOTHING about whether the daemon uses
+// it. The regression that reopens #1482 is one line: watch.go going back to
+// calling streamrun.One directly. All four tests stay green through that, so
+// pin the call site.
+//
+// What this guard CANNOT see, on purpose: whether the wrapper's policy is
+// correct (the tests below), or a caller added somewhere other than watch.go.
+// It sees exactly one thing — that watch's main source goes through the
+// wrapper and not around it.
+func TestWatch_mainSourceGoesThroughTheRestartPolicy(t *testing.T) {
+	src, err := os.ReadFile("watch.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(src, []byte("runMainStreamWithWriteDeadlineRetry(ctx, streamCfg)")) {
+		t.Error("watch.go must run its main source through runMainStreamWithWriteDeadlineRetry; " +
+			"without it a slow index write ends the daemon again (#1482)")
+	}
+	if bytes.Contains(src, []byte("streamrun.One(")) {
+		t.Error("watch.go calls streamrun.One directly again; the main source must go through " +
+			"runMainStreamWithWriteDeadlineRetry (#1482)")
+	}
+}
+
+// #1482: a single index write-deadline failure must not end capture. Before the
+// restart policy, `watch`'s main source was a bare one-shot streamrun.One call,
+// so this returned the error on the first attempt and the daemon exited — the
+// 41-minute outage in the issue. The assertion is that CAPTURE SURVIVED (nil
+// error, stream re-entered), not that some counter reached a number.
+//
+// Must not t.Parallel(): mutates indexer.WriteTimeout and the monitor policy
+// globals.
+func TestRunMainStream_restartsOnWriteDeadline(t *testing.T) {
+	shrinkMonitorBackoff(t)
+	deadlineErr := realWriteDeadlineError(t)
+
+	prev := mainStreamFn
+	t.Cleanup(func() { mainStreamFn = prev })
+
+	calls := 0
+	mainStreamFn = func(ctx context.Context, cfg streamrun.Config) error {
+		calls++
+		if calls == 1 {
+			return deadlineErr // the index was starved; the link is fine
+		}
+		return nil // restarted, resumed from the checkpoint, ran to a clean stop
+	}
+
+	if err := runMainStreamWithWriteDeadlineRetry(context.Background(), streamrun.Config{}); err != nil {
+		t.Fatalf("a write-deadline failure ended capture instead of restarting it: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("stream ran %d time(s); want the failed run plus exactly one restart", calls)
+	}
+}
+
+// The narrowing is load-bearing, not incidental: an un-indexable event must
+// still abort loudly rather than spin (#652), so anything that is not a write
+// deadline has to return on the first failure, untouched.
+func TestRunMainStream_doesNotRetryOtherErrors(t *testing.T) {
+	shrinkMonitorBackoff(t)
+
+	prev := mainStreamFn
+	t.Cleanup(func() { mainStreamFn = prev })
+
+	want := errors.New("batch INSERT of 1000 events failed: Error 1406: Data too long")
+	calls := 0
+	mainStreamFn = func(ctx context.Context, cfg streamrun.Config) error {
+		calls++
+		return want
+	}
+
+	if err := runMainStreamWithWriteDeadlineRetry(context.Background(), streamrun.Config{}); !errors.Is(err, want) {
+		t.Fatalf("a non-deadline error must surface unchanged, got: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("stream ran %d times; a non-deadline error must not be retried", calls)
+	}
+}
+
+// A daemon that is shutting down must not be dragged through the backoff loop:
+// One's final checkpoint flush can hit the very same deadline, and that is a
+// stopping daemon, not a stall to ride out. The error still surfaces — a daemon
+// that stopped without capturing does not exit 0.
+func TestRunMainStream_cancelledContextDoesNotRetry(t *testing.T) {
+	shrinkMonitorBackoff(t)
+	deadlineErr := realWriteDeadlineError(t)
+
+	prev := mainStreamFn
+	t.Cleanup(func() { mainStreamFn = prev })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	mainStreamFn = func(ctx context.Context, cfg streamrun.Config) error {
+		calls++
+		cancel()
+		return deadlineErr
+	}
+
+	if err := runMainStreamWithWriteDeadlineRetry(ctx, streamrun.Config{}); !errors.Is(err, indexer.ErrWriteDeadline) {
+		t.Fatalf("the failure that stopped a shutting-down daemon must still surface, got: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("stream ran %d times; a cancelled daemon must not restart capture", calls)
+	}
+}
+
+// Exhausting the budget must be no quieter than exiting on the first failure
+// was: the SAME error, with its three remedies intact, ends the daemon.
+// Must not t.Parallel().
+func TestRunMainStream_givesUpWithTheOriginalError(t *testing.T) {
+	shrinkMonitorBackoff(t)
+	monitorGiveUpAfter = 0 // any continuous crash-looping trips it immediately
+	deadlineErr := realWriteDeadlineError(t)
+
+	prev := mainStreamFn
+	t.Cleanup(func() { mainStreamFn = prev })
+
+	calls := 0
+	mainStreamFn = func(ctx context.Context, cfg streamrun.Config) error {
+		calls++
+		return deadlineErr
+	}
+
+	err := runMainStreamWithWriteDeadlineRetry(context.Background(), streamrun.Config{})
+	if err == nil {
+		t.Fatal("a permanently stalled index must still stop the daemon")
+	}
+	if err.Error() != deadlineErr.Error() {
+		t.Fatalf("the give-up path must return the original message verbatim (it names --write-timeout,\n"+
+			"--batch-size and max_allowed_packet); got:\n%v", err)
+	}
+	if calls < 1 {
+		t.Fatal("the stream never ran")
+	}
+}

--- a/consoleapp/mainstream_test.go
+++ b/consoleapp/mainstream_test.go
@@ -134,6 +134,46 @@ func TestRunMainStream_restartsOnWriteDeadline(t *testing.T) {
 	}
 }
 
+// The incident's own shape: a daemon that had been capturing happily for a long
+// time, then hit ONE write deadline. It must restart.
+//
+// This exercises the healthy-reset branch and the breaker clock TOGETHER, which
+// is the combination the other tests here deliberately avoid (they pin
+// monitorHealthyReset above every run, or monitorGiveUpAfter at zero). With the
+// breaker clock seeded from the failed run's START, the run's own 60ms of uptime
+// is charged to it, exceeds the 20ms give-up threshold, and capture stops on
+// failure number one having restarted nothing. Scaled constants, same ordering
+// as 35 hours of uptime against a 6h breaker.
+//
+// Must not t.Parallel(): mutates indexer.WriteTimeout and the policy globals.
+func TestRunMainStream_longHealthyRunThenOneDeadlineStillRestarts(t *testing.T) {
+	shrinkMonitorBackoff(t)
+	monitorHealthyReset = 10 * time.Millisecond // the first run outlives this
+	monitorGiveUpAfter = 20 * time.Millisecond  // ...and outlives this too
+	deadlineErr := realWriteDeadlineError(t)
+
+	prev := mainStreamFn
+	t.Cleanup(func() { mainStreamFn = prev })
+
+	calls := 0
+	mainStreamFn = func(ctx context.Context, cfg streamrun.Config) error {
+		calls++
+		if calls == 1 {
+			time.Sleep(60 * time.Millisecond) // a long, healthy run
+			return deadlineErr
+		}
+		return nil
+	}
+
+	if err := runMainStreamWithWriteDeadlineRetry(context.Background(), streamrun.Config{}); err != nil {
+		t.Fatalf("a healthy daemon's first write deadline ended capture instead of restarting it: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("stream ran %d time(s); want the failed run plus one restart. The breaker charged the "+
+			"daemon's uptime to a crash loop that had not started yet (#1482)", calls)
+	}
+}
+
 // The narrowing is load-bearing, not incidental: an un-indexable event must
 // still abort loudly rather than spin (#652), so anything that is not a write
 // deadline has to return on the first failure, untouched.

--- a/consoleapp/monitor.go
+++ b/consoleapp/monitor.go
@@ -576,8 +576,7 @@ func (m *monitorSupervisor) run(ctx context.Context, job *monitorJob, e console.
 	// for-loop below, so this never fires mid-retry.
 	defer job.cancel()
 
-	attempt := 0
-	var crashLoopSince time.Time // first failure of the current loop; zero = healthy
+	var policy crashLoopPolicy
 	for {
 		job.set("pending", "")
 		started := time.Now()
@@ -586,23 +585,15 @@ func (m *monitorSupervisor) run(ctx context.Context, job *monitorJob, e console.
 			job.set("stopped", "")
 			return
 		}
-		if time.Since(started) > monitorHealthyReset {
-			attempt = 0
-			crashLoopSince = time.Time{}
-		}
-		if crashLoopSince.IsZero() {
-			crashLoopSince = started
-		}
 		scrubbed := config.ScrubDSNError(err, e.SourceDSN, e.DSN)
-		if looping := time.Since(crashLoopSince); looping > monitorGiveUpAfter {
+		delay, looping, giveUp := policy.failed(started, time.Now())
+		if giveUp {
 			slog.Error("monitored stream crash-looped past the give-up threshold; not retrying",
 				"server", e.Name, "entry", e.ID, "looping_for", looping.Round(time.Minute), "error", scrubbed)
 			job.set("failed", fmt.Sprintf("%s (gave up after %s of crash-looping; fix the issue, then press Start to retry)",
 				scrubbed, looping.Round(time.Minute)))
 			return
 		}
-		delay := min(monitorBackoffBase<<attempt, monitorBackoffCap)
-		attempt++
 		slog.Warn("monitored stream failed; retrying with backoff",
 			"server", e.Name, "entry", e.ID, "delay", delay, "error", scrubbed)
 		job.set("failed", scrubbed+" (retrying)")

--- a/consoleapp/watch.go
+++ b/consoleapp/watch.go
@@ -777,7 +777,7 @@ func runUpStreamWithConsole(cmd *cobra.Command, args []string) error {
 	streamCfg := watchStreamConfig(serverID)
 	ext.RunSourceJobs(ctx, mainSourceJobInfo(upSourceDSN, upIndexDSN, streamCfg.Flavor))
 
-	streamErr := streamrun.One(ctx, streamCfg)
+	streamErr := runMainStreamWithWriteDeadlineRetry(ctx, streamCfg)
 	stop()                // drain the console even if the stream returned without a signal
 	<-consoleDone         // order the console goroutine's exit before the deferred db.Close()
 	stopFlashback()       // drain the flashback port before the deferred db.Close()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"crypto/tls"
 	"database/sql"
 	"errors"
@@ -159,19 +160,46 @@ const defaultTimeout = 10 * time.Second
 // A 10-second TCP connect timeout is applied when the DSN does not specify one.
 // The caller is responsible for closing the returned *sql.DB.
 func Connect(dsn string) (*sql.DB, error) {
-	normalized, err := buildDSN(dsn)
+	cfg, err := normalizeDSN(dsn)
 	if err != nil {
 		return nil, err
 	}
-	db, err := sql.Open("mysql", normalized)
+	db, err := sql.Open("mysql", cfg.FormatDSN())
 	if err != nil {
 		return nil, fmt.Errorf("failed to open MySQL connection: %w", err)
 	}
-	if err := db.Ping(); err != nil {
+	if err := pingBounded(db, cfg.Timeout); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("failed to ping MySQL: %w", err)
 	}
 	return db, nil
+}
+
+// pingBounded verifies a freshly opened connection within the DSN's own connect
+// budget (cfg.Timeout, defaultTimeout when the DSN sets none).
+//
+// A bare db.Ping() is UNBOUNDED, and cfg.Timeout is the DIAL timeout only —
+// normalizeDSN sets no ReadTimeout or WriteTimeout anywhere. So against a peer
+// that completes the TCP handshake and then never speaks MySQL (a frozen VM, an
+// idle-dropped NLB) the dial succeeds and the driver then blocks in
+// readHandshakePacket forever. That made opening a connection the one step of a
+// stream restart that could never return, so a supervisor could neither count
+// the attempt nor give up: the daemon stayed alive with capture dead and
+// /api/healthz green (#1482). The driver installs its context watcher BEFORE the
+// handshake read (connector.Connect), so a deadline here really does cut it.
+//
+// Scoped to the connect phase deliberately. It never becomes a read deadline on
+// a pooled connection, so a legitimately long query — a partition scan, a schema
+// migration — is untouched, which is why this is not a DSN-level ReadTimeout.
+// Operators who need a longer handshake budget already have the knob: timeout=
+// in the DSN.
+func pingBounded(db *sql.DB, timeout time.Duration) error {
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return db.PingContext(ctx)
 }
 
 // driverDefaultMaxAllowedPacket is the client-side max_allowed_packet the
@@ -265,7 +293,7 @@ func ConnectWithTLS(dsn string, tlsCfg *tls.Config) (*sql.DB, error) {
 		return nil, fmt.Errorf("failed to create MySQL connector: %w", err)
 	}
 	db := sql.OpenDB(connector)
-	if err := db.Ping(); err != nil {
+	if err := pingBounded(db, cfg.Timeout); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("failed to ping MySQL: %w", err)
 	}

--- a/internal/config/connect_timeout_test.go
+++ b/internal/config/connect_timeout_test.go
@@ -1,0 +1,87 @@
+package config
+
+import (
+	"crypto/tls"
+	"database/sql"
+	"net"
+	"testing"
+	"time"
+)
+
+// silentPeer is a TCP listener that ACCEPTS and then never speaks MySQL. It is
+// the frozen-VM / idle-dropped-NLB shape: the dial succeeds, so cfg.Timeout
+// (the DIAL timeout, and the only timeout normalizeDSN sets) is already spent,
+// and the driver then blocks in readHandshakePacket with no read deadline
+// anywhere.
+func silentPeer(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	go func() {
+		var held []net.Conn
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				for _, h := range held {
+					h.Close()
+				}
+				return
+			}
+			held = append(held, c) // hold open, never respond
+		}
+	}()
+	return ln.Addr().String()
+}
+
+// Opening a connection must not be able to block forever (#1482).
+//
+// This is not a tidiness issue. The write-deadline restart policy in
+// consoleapp counts attempts and gives up after a bounded number of them, and
+// an attempt re-enters through this function. A connect that never returns
+// makes that bound unenforceable: the daemon stays alive, /api/healthz stays
+// green, and capture is dead with one log line to show for it. Before the
+// bounded ping this test does not fail fast, it HANGS, which is why the guard
+// is a wall-clock ceiling rather than an error assertion alone.
+//
+// Both entry points are covered because they do NOT share a body: Connect
+// builds its own DSN string, ConnectWithTLS keeps the *mysql.Config. Bounding
+// only one leaves the other able to hang.
+func TestConnect_boundedAgainstASilentPeer(t *testing.T) {
+	addr := silentPeer(t)
+	// timeout=1s is the DSN's own connect budget, shrunk so the test is quick.
+	dsn := "root:x@tcp(" + addr + ")/db?timeout=1s"
+
+	for _, tc := range []struct {
+		name string
+		open func() (*sql.DB, error)
+	}{
+		{"Connect", func() (*sql.DB, error) { return Connect(dsn) }},
+		{"ConnectWithTLS", func() (*sql.DB, error) { return ConnectWithTLS(dsn, (*tls.Config)(nil)) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			done := make(chan error, 1)
+			go func() {
+				db, err := tc.open()
+				if db != nil {
+					db.Close()
+				}
+				done <- err
+			}()
+
+			select {
+			case err := <-done:
+				if err == nil {
+					t.Fatal("a peer that never speaks MySQL must not yield a usable connection")
+				}
+			case <-time.After(15 * time.Second):
+				// The goroutine is parked in the driver's handshake read and will
+				// stay there; the test process exiting is what releases it.
+				t.Fatalf("%s blocked past its own connect budget — the ping is unbounded, "+
+					"so a stream restart can hang here forever and no supervisor can count the attempt (#1482)", tc.name)
+			}
+		})
+	}
+}

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -38,6 +38,36 @@ const DefaultWriteTimeout = 3 * time.Minute
 // a shared global).
 var WriteTimeout = DefaultWriteTimeout
 
+// ErrWriteDeadline tags an index write that ran out of WriteTimeout, as opposed
+// to one the server refused. It exists because nothing else distinguished the
+// two: every flush failure reached the caller as an opaque error, so an index
+// that was merely SLOW (a heavy analytical read starving it) ended capture just
+// as surely as an un-indexable event did — the daemon exited and nothing brought
+// it back (#1482).
+//
+// A deadline is the only failure class where "the same write, later" is a
+// reasonable thing to attempt: the write never got a verdict, so the server
+// neither accepted nor rejected it. Match with errors.Is; never on message text.
+//
+// Deliberately NOT a licence to re-execute the INSERT in place. The deadline
+// fires client-side, and the driver reacts by closing the socket without a KILL
+// QUERY, so a slow batch usually goes on to COMMIT on the server after the
+// client has given up. Re-running that statement would duplicate every row it
+// wrote, permanently. The only duplicate-safe way to act on this tag is to
+// restart the stream, which replays from the checkpoint through
+// streamrun's dedup-on-resume — the step that exists to drop exactly those rows.
+var ErrWriteDeadline = errors.New("index write deadline exceeded")
+
+// writeDeadlineError carries ErrWriteDeadline alongside the original error
+// without changing the message operators read: Error() delegates verbatim, and
+// the multi-error Unwrap keeps BOTH the wrapped cause (context.DeadlineExceeded,
+// still matched by errors.Is, as write_timeout_test.go pins) and the sentinel
+// reachable in the chain.
+type writeDeadlineError struct{ err error }
+
+func (e *writeDeadlineError) Error() string   { return e.err.Error() }
+func (e *writeDeadlineError) Unwrap() []error { return []error{e.err, ErrWriteDeadline} }
+
 // insertColumnsSQL is the column list of insertBatch's multi-row INSERT.
 // insertColumnCount must equal its column count — pinned by a unit test.
 const insertColumnsSQL = `binlog_file, start_pos, end_pos, event_timestamp, gtid, connection_id, ` +
@@ -264,9 +294,13 @@ func (idx *Indexer) insertBatch(batch []event.Event) (int64, error) {
 			// Distinguish a slow-but-working link (a batch too large to transmit
 			// within WriteTimeout) from a genuine stall, so the operator knows the
 			// knob rather than chasing a phantom network fault (#959).
-			return 0, fmt.Errorf("batch INSERT of %d events exceeded the %s write deadline "+
+			//
+			// Tagged with ErrWriteDeadline (#1482) so a supervisor can tell this
+			// apart from every other flush failure WITHOUT matching on message
+			// text. The message itself is unchanged.
+			return 0, &writeDeadlineError{fmt.Errorf("batch INSERT of %d events exceeded the %s write deadline "+
 				"(a network stall, or a batch too large for the link — raise --write-timeout, "+
-				"or lower --batch-size / the server max_allowed_packet): %w", len(batch), WriteTimeout, err)
+				"or lower --batch-size / the server max_allowed_packet): %w", len(batch), WriteTimeout, err)}
 		}
 		return 0, fmt.Errorf("batch INSERT of %d events failed: %w", len(batch), err)
 	}

--- a/internal/indexer/write_timeout_test.go
+++ b/internal/indexer/write_timeout_test.go
@@ -77,6 +77,14 @@ func TestInsertBatch_boundedByWriteTimeout(t *testing.T) {
 	if !strings.Contains(err.Error(), "write deadline") || !strings.Contains(err.Error(), "--write-timeout") {
 		t.Fatalf("DeadlineExceeded error must carry the operator hint (write deadline / --write-timeout), got: %v", err)
 	}
+	// #1482: the same error must ALSO be machine-classifiable. A supervisor that
+	// restarts capture on a stalled index (consoleapp.runMainStreamWithWriteDeadlineRetry)
+	// keys on this sentinel; drop it and the daemon silently goes back to exiting
+	// on the first slow batch, with every message assertion above still green.
+	// Asserted on the REAL error from the REAL write path, not a hand-built one.
+	if !errors.Is(err, ErrWriteDeadline) {
+		t.Fatalf("the write-deadline error must be classifiable as ErrWriteDeadline, got: %v", err)
+	}
 }
 
 // digestStatements runs BEFORE the batch INSERT inside insertBatch, so an


### PR DESCRIPTION
## What this changes

`bintrail-console watch` no longer ends capture on a single index write-deadline
failure. The main source stream restarts from its last checkpoint, with backoff,
and only for that one error class.

## The hole

`watch` supervises two kinds of stream and gave them opposite failure policies:

| path | on error |
|---|---|
| registry sources (console "+ Add server"), `monitorSupervisor.run` | crash-loop backoff, 15s doubling to a 5m cap, circuit breaker at 6h |
| main source (`--source-dsn`), `consoleapp/watch.go:780` | bare one-shot call, error returned, process exits 1 |

The reported run used the second one. A batch INSERT exceeded
`indexer.WriteTimeout`, `streamrun.One` returned, and `runWatch` propagated the
error straight to `os.Exit(1)`. Nothing restarted it, so capture stayed down for
41 minutes until somebody noticed.

The blast radius is wider than the issue reports: that exit path also calls
`supervisor.Shutdown()`, so the main source's failure tore down every supervised
registry source too, including ones whose own backoff loop would have ridden the
same index stall out. They record `stopped`, not `failed`, so nothing in the
state machine shows they died of someone else's error.

## What distinguished recoverable from unrecoverable before this

Nothing. That is the crux of the issue. Every flush failure reached the caller as
an opaque error, so an index that was merely slow ended capture exactly as
surely as an event that can never be inserted (#652). The classification is what
this PR adds; the restart is what it does with it.

`indexer.ErrWriteDeadline` now tags the batch-INSERT deadline error. The message
is byte-identical (a multi-error `Unwrap` keeps both the sentinel and the
original `context.DeadlineExceeded` reachable), so `errors.Is` works and nothing
matches on message text.

## Why a restart and not a retry of the INSERT

This is the part worth reviewing carefully. The obvious minimal fix, retrying the
batch INSERT in place, is not safe, and the repo already contains the evidence:

* The deadline fires on the client. go-sql-driver v1.9.3 reacts by closing the
  socket (`mysqlConn.cancel` -> `cleanup`, connection.go:478). It does not send
  `KILL QUERY`. A batch that was merely slow therefore usually runs to
  completion and COMMITS on the server after the client has stopped waiting.
* `binlog_events` has no natural key. Re-executing that statement duplicates
  every row it wrote, permanently, in a forensics index.
* `streamrun.One` already has the machinery for exactly this hazard:
  `deleteEventsSinceCheckpoint` / `deleteEventsSinceCheckpointGTID` run on
  resume specifically to drop rows a timed-out write may have left behind. That
  is why a manual restart was safe and an in-place retry would not be.
* `pgstreamrun.go:413` states the same constraint from the other side: "If a
  future change ever retries or continues past a flush error, this clear must
  move into the success branch or those rows are lost." Retrying inside
  `indexer.insertBatch` leaves that invariant untouched by construction, but it
  is the duplicate hazard above that rules it out.

So the restart is not the cheaper fix, it is the only duplicate-safe one. It also
reuses shipped behaviour instead of inventing a second one.

Caveat inherited, not introduced: in GTID mode after a gap auto-advance, that
dedup is deliberately skipped and the documented accepted-duplicate window (#500)
applies. A restart here inherits it exactly as a restart by hand does.

## The retry policy, and what the bound actually bounds

Backoff of 15s doubling to a 5m cap, reset by a run that streamed longer than
10 minutes, circuit breaker after 6h of continuous crash-looping. Same policy
the supervised sources already ran under, and now literally the same code: both
call sites were the same twenty lines, so review pressure turned them into one
`crashLoopPolicy` instead of a second copy free to drift.

Two defects in that arithmetic were found in review and are fixed here. Both
predate this PR, in `monitor.go`, traceable to #1031.

**The breaker measured uptime, not crash-looping.** `crashLoopSince` was
assigned the START of the run that had just failed, so a daemon's entire
healthy lifetime was charged to a loop that had not begun. A daemon up 35 hours
that hit one write deadline computed `looping = 35h`, tripped the 6h breaker on
failure number one, restarted nothing, and logged a 35-hour crash loop that
never happened. Since a capture daemon is normally up longer than 6h, **the
restart policy would not have engaged in the incident it was written for.** It
now records the FAILURE time. A registry source hit the same wall, going
permanently `failed` after a single blip following a long healthy run; that is
fixed with it.

**The backoff shift overflowed int64.** `monitorBackoffBase << attempt`
overflows at attempt 30 for a 15s base, `min` then selects the NEGATIVE value
and `time.After` returns immediately, turning the backoff into an unthrottled
hammer roughly 2h13m into a supposed 6h budget. Reachable today on the shipped
supervised path with a fast-failing source. The counter now stops advancing
once the delay reaches the cap, where further shifts change nothing. This was
offered as a separate issue; consolidating the two call sites made it a
one-line change inside code this PR was already rewriting, and shipping a known
negative-delay loop in freshly written shared code seemed worse than filing it.

### What the bound does and does not cover

Stated precisely, because the earlier draft of this section overclaimed.

* The breaker bounds a FAST crash loop. A source that flaps SLOWLY, failing
  after runs longer than the 10-minute healthy-reset window, resets the clock
  each time and restarts indefinitely. That is deliberate and predates this PR:
  `TestMonitorRun_healthyRunResetsBreaker` pins it, commenting that the breaker
  "must keep resetting and never trip, no matter how long the flapping goes on
  in total". Across such a cycle capture is up for all but the backoff, and
  stopping it outright would be worse than the flap. Unchanged here.
* The breaker bounds the NUMBER of attempts, not wall-clock time, because an
  attempt is only as bounded as the operations inside it. Connect is now
  bounded (below). `indexer.EnsureSchema`, the resolver's snapshot lookup,
  `loadStreamState` and the dedup DELETE still run with no deadline, so a
  severely starved index can still park a restart inside one of them. Those are
  pre-existing and run on every start, not only on a restart.

## Opening a connection could never return, which made the bound unenforceable

Found by review, verified in source, fixed here. `config.Connect` and
`ConnectWithTLS` both called a bare `db.Ping()`, and `normalizeDSN` sets only
`cfg.Timeout`, which in go-sql-driver is the DIAL timeout. There is no
`ReadTimeout` or `WriteTimeout` set anywhere. Against a peer that completes the
TCP handshake and then never speaks MySQL, the dial succeeds and the driver
blocks in `readHandshakePacket` forever.

That is not a hypothetical shape. It is a frozen VM or an idle-dropped NLB, the
exact case this PR claimed the breaker covered, and it is what this PR's own
test fixture builds. Without this fix the change would have converted "exit
after one stall, which the shipped compose file restarts" into "stay alive
forever after one stall, with one warning line and a green `/api/healthz`",
which is strictly worse than before on that class.

Both paths now use a `pingBounded` helper that spends the DSN's own connect
budget (`timeout=`, default 10s). The driver installs its context watcher
BEFORE the handshake read (`connector.Connect`), so a deadline there genuinely
cuts it; that was read in the driver source, not assumed. Scoped to the connect
phase on purpose: it never becomes a read deadline on a pooled connection, so a
long partition scan or schema migration is untouched. A restart against a
silent index now ends the daemon on the next attempt with a ping error, which
is a non-deadline error and so returns immediately, exactly as today.

## The dedup DELETE is unbounded, and this PR does not bound it

`deleteEventsSinceCheckpoint` runs on a bare `db.Exec`. Its predicate wraps
`binlog_file` in `CHAR_LENGTH()`, `binlog_events` carries no index on that
column (the PK is `(event_id, event_timestamp)`; the secondary indexes are on
schema/table, pk_hash and gtid), and it never mentions `event_timestamp`, so
partition pruning cannot apply either. It is a full scan of every partition, on
every resume, against the index whose contention caused the restart.

Deliberately left alone. Timing it out and continuing would skip the step that
makes a restart duplicate-safe, reintroducing exactly the rows this design
exists to avoid. Timing it out and failing the attempt only reproduces today's
exit while adding a threshold nobody can size correctly, since the scan cost
scales with the operator's index. It is pre-existing on every start. Naming it
here is more honest than a bound chosen by guessing.

## Observability, corrected

The earlier draft said "nothing but the log says so". That was wrong in both
directions.

**It is not only the log.** Two alerts documented in `docs/observability.md`
fire after about five minutes of a restart loop, because during one no batch
flushes and no events are indexed:
`time() - bintrail_stream_last_flush_timestamp_seconds > 300` and
`rate(bintrail_stream_events_indexed_total[5m]) == 0`.

**But there is less signal than before, in three ways an operator has to know.**

* `bintrail-console watch` defaults `--metrics-addr` to empty, so in the
  incident's own deployment shape there is no `/metrics` endpoint at all and
  none of those alerts exist.
* The process no longer exits, so the scrape target no longer vanishes and
  `up == 0` no longer fires. What this change removes is precisely the exit
  that the shipped compose file's `restart: unless-stopped` reacted to.
* Every stream gauge is written from inside `streamLoop`. With `streamLoop` not
  running they do not rise, they FREEZE at their last healthy value, so a
  `bintrail_stream_replication_lag_seconds > N` alert silently never fires
  during the outage. A staleness expression over
  `bintrail_stream_last_event_timestamp_seconds`, or the flush-timestamp one
  above, is the shape that still works, and nothing tells an operator they now
  need it.

`status --fail-on-gap` does NOT cover this, despite the name suggesting it
might: it keys on a stamped continuity `gap_lost`, and a restart resumes from
an intact checkpoint, so no gap is stamped.

Per-failure loudness is otherwise unchanged. Each restart logs `slog.Warn` with
the delay and the full error, where today there is no line at all; the
`batch_flush` error counter still fires; and the give-up path returns the
ORIGINAL error verbatim, so the daemon exits with the same message naming the
same three remedies. A test pins that string equality. Non-timeout errors
return on the first failure, unchanged.

## Scope held deliberately narrow

**By command.** Only `watch`'s main source restarts. `bintrail stream` and
`bintrail up` reach `streamrun.One` from a foreground CLI invocation with an
operator present, which is not the unattended-daemon failure this issue is
about. (The connect bound and the crash-loop fixes are shared, so they reach
every caller.)

**By site.** Only the batch-INSERT deadline carries `ErrWriteDeadline`.
`WriteTimeout` also bounds `saveCheckpoint` (already warn-only) and the
gap-loss record write. A deadline at one of those still returns an untagged
error and still ends the daemon, exactly as today. The batch INSERT is the site
the issue reports and the only one on the per-batch hot path; widening the tag
without evidence would be guessing at which of those are safe to re-enter.

## Known and deliberate

* A slow flap restarts forever, as described above. Ratified behaviour, pinned
  by an existing test, unchanged here.
* The main source publishes no per-server job state, so the console cannot
  render "restarting" for it the way it does for a supervised source. Adding
  one is a larger change than this fix.

## Tests

* `TestRunMainStream_restartsOnWriteDeadline` asserts capture SURVIVED (the call
  returns nil and the stream was re-entered), not that a counter hit a number.
* `TestRunMainStream_doesNotRetryOtherErrors` pins the narrowing.
* `TestRunMainStream_cancelledContextDoesNotRetry` covers the shutdown case,
  where `One`'s final checkpoint flush can hit the same deadline.
* `TestRunMainStream_givesUpWithTheOriginalError` pins the message verbatim on
  the give-up path.
* `TestInsertBatch_boundedByWriteTimeout` gains one assertion, so the
  classification and the operator message are pinned by the same test and cannot
  drift apart.
* `TestWatch_mainSourceGoesThroughTheRestartPolicy` pins the CALL SITE. The four
  behavioural tests all drive the policy through the `mainStreamFn` seam, so they
  prove the policy works and say nothing about whether the daemon uses it; the
  regression that reopens this issue is one line in watch.go, and all four stay
  green through it.

New in the review round:

* `TestConnect_boundedAgainstASilentPeer` covers BOTH connect entry points
  (they do not share a body) against an accept-then-silent listener. It went
  red with no mutation at all, because it compiles against the unfixed code:
  both calls blocked past their own connect budget and the 15s ceiling fired.
* `TestRunMainStream_longHealthyRunThenOneDeadlineStillRestarts` is the
  incident's own shape, a long healthy run then one deadline, and it is the
  test that exercises the healthy-reset branch and the breaker clock TOGETHER.
  The four earlier behavioural tests deliberately cannot: they park
  `monitorHealthyReset` above every run or pin `monitorGiveUpAfter` at zero,
  which are exactly the two settings under which those branches never interact.
* `TestCrashLoopPolicy_*` drive the extracted policy on a fake clock at REAL
  constants, so the 6h breaker is tested without sleeping through it.

Red-first, honestly: the connect test went red against unmodified code. For the
rest, a full `git stash` yields a compile error, not a behavioural red, because
the fix introduces the function under test. The meaningful red came from
mutations, each run and each restored:

| mutation | result |
|---|---|
| the loop reduced to a one-shot call (exact pre-fix behaviour) | `TestRunMainStream_restartsOnWriteDeadline` FAILS with the issue's own error string |
| the `ErrWriteDeadline` tag not attached to the deadline error | `TestInsertBatch_boundedByWriteTimeout` FAILS, every message assertion still green |
| watch.go reverted to calling `streamrun.One` directly | `TestWatch_mainSourceGoesThroughTheRestartPolicy` FAILS |
| breaker clock seeded from the run's start (the pre-fix arithmetic) | policy test FAILS reporting `looping` as `35h0m0s`, and the behavioural test FAILS with capture ended instead of restarted |
| the overflow guard removed | `TestCrashLoopPolicy_backoffNeverGoesNonPositive` FAILS at iteration 30 with `delay = -650171h18m33s` |
| (no mutation needed) the unfixed bare `db.Ping()` | `TestConnect_boundedAgainstASilentPeer` FAILS for both `Connect` and `ConnectWithTLS` |

The other three behavioural tests correctly stay GREEN under the one-shot mutant:
they pin the narrowing, the shutdown case and the give-up message, all of which
the old behaviour also satisfied.

The fixture error is not hand-built. Each test drives the real
`indexer.InsertBatch` against a TCP listener that accepts and never speaks MySQL,
with `WriteTimeout` shrunk, so the policy is keyed on the error the real write
path actually produces.

closes #1482
