### PR TITLE
docs: link the Iceberg export from the console Storage section and the guide

### DIFF
--- a/docs/console.md
+++ b/docs/console.md
@@ -426,6 +426,11 @@ compact baseline summary card and links onward:
   archives disabled, for one with nothing archived and
   no baseline yet, and while an access-control profile is active — the file
   maps straight onto the unredacted Parquet a profile exists to withhold.
+  For an engine that wants a table rather than files (Spark, Trino, Athena, or
+  DuckDB without the merge step), `bintrail export iceberg` writes an Apache
+  Iceberg copy of each table from the same baseline and archives, kept current
+  run after run; it is a scheduler command, not a console feature, and it
+  never runs inside `watch`. See [Iceberg export](iceberg-export.md).
 - **Usage telemetry** — the current state of dbtrail's metadata-only usage
   telemetry and a one-click opt-out. Turning it off stops this `watch` daemon's
   beacons immediately (no restart) and records the machine-wide choice, exactly

--- a/docs/console.md
+++ b/docs/console.md
@@ -428,8 +428,8 @@ compact baseline summary card and links onward:
   maps straight onto the unredacted Parquet a profile exists to withhold.
   For an engine that wants a table rather than files (Spark, Trino, Athena, or
   DuckDB without the merge step), `bintrail export iceberg` writes an Apache
-  Iceberg copy of each table from the same baseline and archives, kept current
-  run after run; it is a scheduler command, not a console feature, and it
+  Iceberg copy of each table from the same baseline plus the change history
+  (archives and live index), kept current run after run; it is a scheduler command, not a console feature, and it
   never runs inside `watch`. See [Iceberg export](iceberg-export.md).
 - **Usage telemetry** — the current state of dbtrail's metadata-only usage
   telemetry and a one-click opt-out. Turning it off stops this `watch` daemon's

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -540,7 +540,8 @@ appending only what changed since its last run, under a local warehouse:
 bintrail export iceberg --index-dsn "$IDX" --baseline-dir /data/baselines --warehouse /data/iceberg
 ```
 
-Run it from cron; every run is one Iceberg snapshot per table, and any
+Run it from cron; every run that found changes is one Iceberg snapshot per
+table, and any
 Iceberg reader (`iceberg_scan('/data/iceberg/shop/orders')` in DuckDB) sees the
 table as of the last run. It refuses a table rather than publishing a wrong one
 (a capture gap, a TRUNCATE, a changed shape), with the same vocabulary as

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -512,6 +512,42 @@ See [Verify recoveries](verify.md) for both modes and the exit-code semantics,
 and [Rotation & Status](rotation-and-status.md#stream-continuity-no-data-lost)
 for the continuity signal.
 
+### Scenario O: Feed a reporting engine without touching production
+
+Reporting queries against the source hurt the source. dbtrail already keeps
+two things as plain Parquet, on disk or in S3: the archived change history
+(every hour that aged past retention) and the baseline snapshots. Both are
+readable by any DuckDB, Spark, Trino or Athena with no dbtrail involved.
+
+**Files, queried by name.** `bintrail views` writes a DuckDB schema over them:
+one `events` view across every archive and one `state_<schema>_<table>` view
+per table in the newest baseline (the console's **Storage → Query in DuckDB**
+card downloads the same file).
+
+```sh
+bintrail views --index-dsn "$IDX" --baseline-dir /data/baselines --out views.sql
+duckdb -init views.sql lake.db
+```
+
+The `state_*` views are the baseline, not the table right now; changes after
+it are in `events`, and joining the two is your query's job.
+
+**A table that stays current.** `bintrail export iceberg` does that join once
+per run and writes the result as an Apache Iceberg table per source table,
+appending only what changed since its last run, under a local warehouse:
+
+```sh
+bintrail export iceberg --index-dsn "$IDX" --baseline-dir /data/baselines --warehouse /data/iceberg
+```
+
+Run it from cron; every run is one Iceberg snapshot per table, and any
+Iceberg reader (`iceberg_scan('/data/iceberg/shop/orders')` in DuckDB) sees the
+table as of the last run. It refuses a table rather than publishing a wrong one
+(a capture gap, a TRUNCATE, a changed shape), with the same vocabulary as
+`baseline refresh`, and it never runs inside `watch`. Full flags, the type
+mapping and the refusals: [Iceberg export](iceberg-export.md); why the storage
+itself stays plain Parquet: [Parquet reference](parquet-debugging.md#the-archives-are-plain-parquet-on-purpose).
+
 ---
 
 ## 4. Keeping dbtrail Running (Day-to-Day)


### PR DESCRIPTION
Docs only. `bintrail export iceberg` (#1507) had its own page and the README row, but the two places an operator lands when they want reporting did not mention it:

- `docs/console.md`, Storage: the **Query in DuckDB** bullet now says what the export is for (an engine that wants a table rather than files), that it is a scheduler command and never runs inside `watch`, and links `iceberg-export.md`.
- `docs/guide.md`: a new **Scenario O, Feed a reporting engine without touching production**, which puts `bintrail views` (files, queried by name) and `bintrail export iceberg` (a table that stays current) side by side, with the `state_*`-is-the-baseline caveat that separates them, and links the plain-Parquet decision note.

No code, no claims beyond what `docs/iceberg-export.md` already documents.
