### PR TITLE
telemetry: wait on the delivery in TestEndToEndDelivery, not on a 3s clock

### DIFF
--- a/internal/cli/telemetry_class_wiring_test.go
+++ b/internal/cli/telemetry_class_wiring_test.go
@@ -12,6 +12,10 @@ import (
 	"github.com/dbtrail/dbtrail/internal/telemetry/telemetrytest"
 )
 
+// deliveryCeiling bounds how long the wiring test waits for a background
+// delivery. Only a genuine hang trips it; a slow machine costs latency.
+const deliveryCeiling = 30 * time.Second
+
 // classedErr stands in for a producer's typed refusal.
 type classedErr struct{}
 
@@ -48,7 +52,13 @@ func TestTelemetryHookRecordsTheCommandsClass(t *testing.T) {
 		t.Fatal("Execute must return the command's error")
 	}
 
-	deadline := time.Now().Add(5 * time.Second)
+	// The poll returns the moment the body lands; the ceiling only bounds a
+	// genuine hang. It is generous on purpose: a daemon tick, a drain and a
+	// POST all run in the background, and a fixed few-second budget for them
+	// is what fails a loaded release runner (#1502). The collecting handler
+	// lives in the shared telemetrytest helper, which is why this waits on
+	// bodies() rather than on a channel of its own.
+	deadline := time.Now().Add(deliveryCeiling)
 	for time.Now().Before(deadline) {
 		for _, b := range bodies() {
 			if strings.Contains(b, `"error_class":"config_invalid"`) && strings.Contains(b, `"command":"stream"`) {
@@ -57,5 +67,5 @@ func TestTelemetryHookRecordsTheCommandsClass(t *testing.T) {
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
-	t.Fatalf("no delivered event carried error_class=config_invalid for stream; bodies: %v", bodies())
+	t.Fatalf("no delivered event carried error_class=config_invalid for stream within %v; bodies: %v", deliveryCeiling, bodies())
 }

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -933,16 +933,29 @@ func TestNilSafety(t *testing.T) {
 	s.Finish()
 }
 
+// deliveryCeiling bounds how long TestEndToEndDelivery waits for the background
+// drain to reach the endpoint. It is deliberately generous: the test waits on
+// the delivery itself, so on a loaded runner this costs latency, never a
+// failure, and only a genuine hang trips it (#1502). It is not a performance
+// assertion; the drain's own budget is drainDeadline, and a local round trip
+// that outruns THAT is what the failure message points at.
+const deliveryCeiling = 30 * time.Second
+
 // TestEndToEndDelivery exercises the whole path: a first run spools, a second
 // run drains and delivers over HTTP.
 func TestEndToEndDelivery(t *testing.T) {
 	clearEnv(t)
-	var mu sync.Mutex
-	var body []byte
+	// The handler hands the body over on a channel so the test blocks on the
+	// delivery rather than polling the clock. Buffered and non-blocking: claim-
+	// by-rename delivers each batch once, but the handler must never stall a
+	// drainer if a second POST ever arrives after the test has stopped reading.
+	delivered := make(chan []byte, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		mu.Lock()
-		defer mu.Unlock()
-		body, _ = readAll(r)
+		b, _ := readAll(r)
+		select {
+		case delivered <- b:
+		default:
+		}
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
@@ -955,20 +968,14 @@ func TestEndToEndDelivery(t *testing.T) {
 
 	// A later invocation drains what the first one spooled.
 	Init(cfg)
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		mu.Lock()
-		got := len(body)
-		mu.Unlock()
-		if got > 0 {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
+	var body []byte
+	select {
+	case body = <-delivered:
+	case <-time.After(deliveryCeiling):
+		t.Fatalf("nothing delivered to the endpoint within %v: the startup drain never reached it (a hang, or the POST outran drainDeadline=%v and was abandoned)", deliveryCeiling, drainDeadline)
 	}
-	mu.Lock()
-	defer mu.Unlock()
 	if len(body) == 0 {
-		t.Fatal("nothing delivered to the endpoint")
+		t.Fatal("endpoint received an empty body")
 	}
 	var e Event
 	if err := json.Unmarshal([]byte(strings.SplitN(strings.TrimSpace(string(body)), "\n", 2)[0]), &e); err != nil {

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -963,7 +963,12 @@ func TestEndToEndDelivery(t *testing.T) {
 	dir := t.TempDir()
 	cfg := Config{Dir: dir, Endpoint: srv.URL, Version: "0.40.0", Stderr: &bytes.Buffer{}, Interactive: boolPtr(false)}
 
-	c := Init(cfg)
+	// Drained before it spools: appendEvent creates the file and then writes
+	// it, and a bare Init's startup drain could scan in that gap, claim the
+	// still-empty file, read nothing and remove it, so the write would land on
+	// an unlinked inode and nothing would ever POST. With the first drain over
+	// before Finish appends, the second Init below is provably the deliverer.
+	c := initDrained(t, cfg)
 	c.RecordCommand("status").Finish()
 
 	// A later invocation drains what the first one spooled.


### PR DESCRIPTION
closes #1502

## Summary

- `TestEndToEndDelivery` no longer polls the clock. The httptest handler hands the request body over on a buffered channel and the test selects on it, so it waits on the delivery itself. A loaded runner now costs latency, not a failure.
- The ceiling is 30s (`deliveryCeiling`, a named test constant) and only a genuine hang trips it. The failure message says what it can: the drain never reached the endpoint, either because it hung or because the POST outran the product's own `drainDeadline` (2s) and was abandoned. That budget is production behaviour and is deliberately not changed here.
- The channel send is non-blocking on purpose: claim-by-rename delivers each batch once, but a handler that could block on a full channel would stall a drainer if a second POST ever arrived after the test stopped reading.
- Review follow-up 1: the first client is built with `initDrained` instead of a bare `Init`. `appendEvent` creates the spool file and then writes it, and the first Init's startup drain could scan in that gap, claim the still-empty file, read nothing and remove it, so the write would land on an unlinked inode and nothing would ever POST (forced with sleeps, it failed at the ceiling blaming a hang). With the first drain over before `Finish` appends, the second `Init` is provably the only deliverer.
- Review follow-up 2: `internal/cli/telemetry_class_wiring_test.go` (`TestTelemetryHookRecordsTheCommandsClass`, added for #1503) had the same defect class and the same release-job risk: a fixed 5s poll on a daemon tick, a drain and a POST, all in the background. The poll already returns the moment the body lands, so the change is the ceiling, now 30s (`deliveryCeiling`), and a failure message that names it. It keeps polling `bodies()` rather than waiting on a channel of its own because the collecting handler lives in the shared `telemetrytest.CollectingClient` helper used by eight tests; the assertions are unchanged.
- Test-only change: no CHANGELOG entry.

## Other fixed deadlines in the same file, left alone

None has the "assert on a background delivery within a short budget" shape:

- `telemetry_test.go` lines 441, 470, 651 (`time.Now().Add(-...)`): age spool files and claims by mtime. Fixture setup, not a wait.
- `telemetry_test.go` lines 700, 702 (`Sleep` in `TestConcurrentDrainSendsEachBatchOnce`): stagger the four drainers and hold a claim like a real POST. They shape the race; the `WaitGroup` bounds it, so contention only makes the stagger wider.

Sibling files were out of the issue's scope, listed for completeness. `daemon_test.go:122`/`:163` and `runtime_consent_test.go:88` poll a delivery counter with a 10s deadline, already the generous shape. `daemon_test.go:37` (2s) and `:200` (1s) `time.After` assert that `RunDaemon` returns after cancel or on a disabled client, not a background delivery. `daemon_test.go:97`/`:132` and `runtime_consent_test.go:81` are negative-space sleeps ("nothing may happen for N ms") where contention only makes them easier to pass. `gofmt -l` also flags `runtime_consent_test.go` on `main` already; not touched here.

## Test plan

- [x] `go test ./internal/telemetry/ -count=5 -race -run TestEndToEndDelivery -v`: 5/5 PASS, each 0.00s, package 1.3s.
- [x] `go test ./internal/telemetry/ -count=5 -race` idle: `ok 9.166s`.
- [x] Same under CPU load, 20 x `yes > /dev/null` on a 10-core machine (killed afterwards): `ok 9.487s`, `TestEndToEndDelivery` 0.00 to 0.01s per run.
- [x] Same while a cold `go build ./...` (fresh `GOCACHE`, CGO DuckDB) competed for CPU, load average 14 to 18.6 on 10 cores: `ok 9.421s`, `TestEndToEndDelivery` 0.00s per run.
- [x] Red proof that the ceiling still fails loudly: with `c.RecordCommand("status").Finish()` temporarily replaced by a no-op (nothing spooled, so nothing to deliver), the test fails after exactly 30.00s with `nothing delivered to the endpoint within 30s: the startup drain never reached it (a hang, or the POST outran drainDeadline=2s and was abandoned)`. Mutation reverted; the diff is only the intended change.
- [x] `go vet ./internal/telemetry/` clean; `gofmt -l` clean on the touched file.
- [x] After the review follow-ups: `go test ./internal/telemetry/ ./internal/cli/ -count=3 -race`: `ok internal/telemetry 6.005s`, `ok internal/cli 8.746s`; `go vet` on both packages and `gofmt -l` on both touched files clean.
- [ ] The unlinked-inode race in follow-up 1 was not re-forced here (it needs sleeps inside `spool.go`); the fix is the package's own `initDrained` helper, whose comment documents the same race for the spool-reading tests.
- [x] `go test ./... -count=1` from the worktree: every package ok, no FAIL lines, exit 0.
- [ ] Reproducing the original failure on this machine was not attempted: the 3s budget did not trip here even under load, and the issue's evidence (3.01s elapsed, the deadline itself, on a commit that had passed `unit`) is what the change answers.
