### PR TITLE
console: show the exact telemetry sample event on the Usage telemetry card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **The console's telemetry card shows the exact sample event** (#1447). The
+  Usage telemetry card (Settings > Storage) gains a folded "Show a sample
+  event" section with the JSON one event would carry, byte for byte as
+  `bintrail telemetry show` prints it. Both surfaces render it through one
+  function (`telemetry.SampleEventJSON`), pinned by a test that compares the
+  console payload with the command's output, so the card can never drift into
+  a hand-maintained copy. Read-only; opening it sends nothing.
 - **`bintrail export iceberg`** (#1466). Writes each table's current state as
   an Apache Iceberg table under `--warehouse`, incrementally: the first run
   loads the newest baseline snapshot, every run after that folds the events

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -25,6 +25,10 @@ bintrail telemetry show
 bintrail telemetry status   # is it on, and what decided that
 ```
 
+The web console shows the same event: on **Storage → Usage telemetry**, open
+**Show a sample event**. The daemon renders it through the same function the
+command uses, so the two cannot differ, and opening it sends nothing.
+
 ## Why this document is longer than you expect
 
 bintrail reads your binary logs. It sees your schemas, your table names, your

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -27,7 +27,9 @@ bintrail telemetry status   # is it on, and what decided that
 
 The web console shows the same event: on **Storage → Usage telemetry**, open
 **Show a sample event**. The daemon renders it through the same function the
-command uses, so the two cannot differ, and opening it sends nothing.
+command uses, so the fields and their form are the same; the values are the
+daemon's own (each render draws a fresh `run_id`), and opening it sends
+nothing.
 
 ## Why this document is longer than you expect
 

--- a/docs/console.md
+++ b/docs/console.md
@@ -478,7 +478,9 @@ compact baseline summary card and links onward:
   beacons immediately (no restart) and records the machine-wide choice, exactly
   like `bintrail telemetry off`. When an environment variable (`DO_NOT_TRACK`,
   `BINTRAIL_TELEMETRY`) or the `--telemetry` flag already controls it, the card
-  says so and defers to that. See [TELEMETRY.md](./TELEMETRY.md).
+  says so and defers to that. Open **Show a sample event** to see the exact
+  JSON one event would carry, the same bytes `bintrail telemetry show` prints;
+  opening it sends nothing. See [TELEMETRY.md](./TELEMETRY.md).
 
 ### The SQL panel (opt-in)
 

--- a/internal/cli/telemetry.go
+++ b/internal/cli/telemetry.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -230,7 +229,7 @@ This command performs no network access. It exists so the payload can be
 inspected without trusting the documentation: what you see here is the
 complete set of fields the wire format permits.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		out, err := json.MarshalIndent(telemetry.SampleEvent(), "", "  ")
+		out, err := telemetry.SampleEventJSON()
 		if err != nil {
 			return fmt.Errorf("render sample event: %w", err)
 		}

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -3988,6 +3988,7 @@ function telemetryCard(t) {
   }
   if (!t.endpoint_set) {
     card.append(el("p", { class: "stg-hint", text: "This build sends no telemetry; no endpoint is compiled in." }));
+    card.append(telemetrySampleSection(t));
     return card;
   }
   card.append(el("p", { class: "stg-hint", text: t.reporting
@@ -3999,13 +4000,35 @@ function telemetryCard(t) {
       : t.decided_by === "BINTRAIL_TELEMETRY" ? "the BINTRAIL_TELEMETRY environment variable"
       : "the --telemetry flag";
     card.append(el("p", { class: "form-hint", text: "Set by " + by + " on the daemon, which overrides this toggle. Change it there." }));
+    card.append(telemetrySampleSection(t));
     return card;
   }
+  card.append(telemetrySampleSection(t));
   card.append(el("div", { class: "stg-cardfoot" },
     el("button", { class: "btn btn-sm", type: "button",
       text: t.consent ? "Turn telemetry off" : "Turn telemetry on",
       onclick: () => setTelemetry(!t.consent) })));
   return card;
+}
+
+// telemetrySampleSection folds the exact JSON one event would carry (#1447).
+// The text comes from the daemon verbatim (`sample_event`, rendered by the same
+// function the CLI's `telemetry show` prints through), so the card never
+// re-draws or re-orders it: it is a read-only <pre>, and JSON.stringify would
+// be a second renderer that could drift from the CLI. Opening it sends nothing.
+function telemetrySampleSection(t) {
+  const d = el("details", { class: "form-advanced tel-sample" },
+    el("summary", { class: "form-adv-summary", text: "Show a sample event" }));
+  if (!t.sample_event) {
+    d.append(el("p", { class: "form-hint", text:
+      "The daemon could not render the sample event. The command line prints the same event (CLI: bintrail telemetry show)." }));
+    return d;
+  }
+  d.append(el("p", { class: "form-hint", text:
+    "The exact event this machine would send, byte for byte, built by the same code the command line prints " +
+    "(CLI: bintrail telemetry show). Opening this sends nothing." }));
+  d.append(el("pre", { class: "stg-code tel-sample-pre", text: t.sample_event }));
+  return d;
 }
 
 async function setTelemetry(enabled) {

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -2088,6 +2088,10 @@ button { font-family: inherit; }
 .cn-snippet { display: block; margin: 8px 0 10px; white-space: pre; }
 .cn-other .form-hint { margin-top: 8px; }
 
+/* Telemetry sample event (#1447): the daemon's bytes, shown as they are. */
+.tel-sample { margin-top: 12px; }
+.tel-sample-pre { display: block; margin: 8px 0 0; white-space: pre; }
+
 /* ============================================================
    date/time picker (Since/Until/At filters)
    ============================================================ */

--- a/internal/console/telemetry_api.go
+++ b/internal/console/telemetry_api.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 
 	"github.com/dbtrail/dbtrail/internal/telemetry"
@@ -91,6 +92,12 @@ type telemetryStateDTO struct {
 	// the config file from here would not change what happens. The UI disables
 	// the toggle and explains which control is in charge.
 	Overridden bool `json:"overridden"`
+	// SampleEvent is the exact JSON one event would carry, pretty-printed, as
+	// `bintrail telemetry show` prints it (#1447). Both surfaces render it
+	// through telemetry.SampleEventJSON, so the card can never drift from the
+	// CLI into a hand-maintained illustration. Empty only if rendering failed,
+	// which the UI reports instead of showing a blank block.
+	SampleEvent string `json:"sample_event"`
 }
 
 func (s *Server) telemetryState() telemetryStateDTO {
@@ -112,6 +119,14 @@ func (s *Server) telemetryState() telemetryStateDTO {
 		dec = telemetry.Resolve("", "")
 	}
 
+	// The event struct holds only ints, bools and strings, so this cannot
+	// fail in practice; the branch exists because the encoder's contract has
+	// an error and swallowing one here would blank the section silently.
+	sample, err := telemetry.SampleEventJSON()
+	if err != nil {
+		slog.Warn("console: could not render the telemetry sample event", "error", err)
+	}
+
 	return telemetryStateDTO{
 		Reporting:   reporting,
 		Consent:     dec.Enabled,
@@ -121,6 +136,7 @@ func (s *Server) telemetryState() telemetryStateDTO {
 		Overridden: dec.Source == telemetry.SourceDoNotTrack ||
 			dec.Source == telemetry.SourceEnv ||
 			dec.Source == telemetry.SourceFlag,
+		SampleEvent: string(sample),
 	}
 }
 

--- a/internal/console/telemetry_api_test.go
+++ b/internal/console/telemetry_api_test.go
@@ -1,15 +1,20 @@
 package console
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
+
+	"github.com/dbtrail/dbtrail/internal/cli"
 	"github.com/dbtrail/dbtrail/internal/telemetry"
 )
 
@@ -350,5 +355,68 @@ func TestRecordActionStatusClassification(t *testing.T) {
 				t.Errorf("console event carries run_id: %+v", e)
 			}
 		})
+	}
+}
+
+// runIDLine matches the one field that legitimately differs between two
+// renderings of the sample event: every call draws a fresh run_id, exactly as
+// every `telemetry show` run does.
+var runIDLine = regexp.MustCompile(`"run_id": "[0-9a-f-]{36}"`)
+
+// TestHandleTelemetryGetSampleEventMatchesCLI pins the #1447 promise: the
+// console card's sample event is the SAME bytes `bintrail telemetry show`
+// prints, produced by the same function, never a hand-maintained copy. It
+// drives the real CLI command (through the cobra tree AddTelemetryCommand
+// registers) and the real GET handler, then compares the two renderings with
+// only the per-call run_id normalised, and checks that the normalisation
+// replaced exactly one line on each side so a sample that silently lost its
+// run_id could not pass by matching an empty replacement.
+func TestHandleTelemetryGetSampleEventMatchesCLI(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	root := &cobra.Command{Use: "bintrail"}
+	cli.AddTelemetryCommand(root)
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{"telemetry", "show"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("telemetry show: %v", err)
+	}
+	// The command prints the event, then a blank line and the field list.
+	cliJSON, _, found := strings.Cut(out.String(), "\n\n")
+	if !found {
+		t.Fatalf("telemetry show output has no blank line after the event:\n%s", out.String())
+	}
+
+	s := &Server{}
+	rec := httptest.NewRecorder()
+	s.handleTelemetryGet(rec, httptest.NewRequest("GET", "/api/telemetry", nil))
+	dto := decodeTelemetry(t, rec)
+
+	if n := len(runIDLine.FindAllString(dto.SampleEvent, -1)); n != 1 {
+		t.Fatalf("console sample carries %d run_id lines, want exactly 1:\n%s", n, dto.SampleEvent)
+	}
+	if n := len(runIDLine.FindAllString(cliJSON, -1)); n != 1 {
+		t.Fatalf("CLI sample carries %d run_id lines, want exactly 1:\n%s", n, cliJSON)
+	}
+	got := runIDLine.ReplaceAllString(dto.SampleEvent, `"run_id": "<run_id>"`)
+	want := runIDLine.ReplaceAllString(cliJSON, `"run_id": "<run_id>"`)
+	if got != want {
+		t.Errorf("console sample_event differs from `telemetry show`:\n--- console ---\n%s\n--- cli ---\n%s", got, want)
+	}
+
+	// The card renders the string verbatim, so it must already be the
+	// pretty-printed form: a parseable event, indented, with no trailing newline
+	// for the <pre> to turn into a blank last line.
+	var ev telemetry.Event
+	if err := json.Unmarshal([]byte(dto.SampleEvent), &ev); err != nil {
+		t.Fatalf("sample_event is not a JSON event: %v", err)
+	}
+	if ev.EventType != telemetry.EventCommandRun || ev.SchemaVersion != telemetry.SchemaVersion {
+		t.Errorf("sample_event is not the representative command_run event: %+v", ev)
+	}
+	if !strings.HasPrefix(dto.SampleEvent, "{\n  \"") || strings.HasSuffix(dto.SampleEvent, "\n") {
+		t.Errorf("sample_event is not the two-space pretty-printed form:\n%q", dto.SampleEvent)
 	}
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -460,8 +460,10 @@ func SampleEvent() Event {
 // SampleEventJSON renders SampleEvent the way `bintrail telemetry show` prints
 // it: two-space indented, no trailing newline. It is the ONE renderer behind
 // every "inspect the payload" surface (the CLI command and the console's
-// telemetry card), so the bytes an operator sees cannot depend on which one
-// they opened. Each call draws a fresh run_id, exactly as each `show` run does.
+// telemetry card), so the fields and their form cannot differ between them.
+// The VALUES are the rendering process's own: each call draws a fresh run_id,
+// and a daemon's version, is_release or is_interactive can legitimately differ
+// from the operator's local CLI.
 func SampleEventJSON() ([]byte, error) {
 	return json.MarshalIndent(SampleEvent(), "", "  ")
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -2,6 +2,7 @@ package telemetry
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"log/slog"
 	"net/http"
@@ -454,6 +455,15 @@ func SampleEvent() Event {
 		IsInteractive:  isInteractive(os.Stderr),
 		RunID:          uuid.NewString(),
 	}
+}
+
+// SampleEventJSON renders SampleEvent the way `bintrail telemetry show` prints
+// it: two-space indented, no trailing newline. It is the ONE renderer behind
+// every "inspect the payload" surface (the CLI command and the console's
+// telemetry card), so the bytes an operator sees cannot depend on which one
+// they opened. Each call draws a fresh run_id, exactly as each `show` run does.
+func SampleEventJSON() ([]byte, error) {
+	return json.MarshalIndent(SampleEvent(), "", "  ")
 }
 
 // Span measures one command invocation. A nil *Span is safe and inert.

--- a/test/console-e2e/README.md
+++ b/test/console-e2e/README.md
@@ -51,6 +51,7 @@ down.
 | timetravel (×6) | the reconstruct gate + baseline+deltas over a real fixture baseline (#970): event fold, baseline-only row, deleted row |
 | overview: window honesty (×2) | `buildOverview` window line uses the fetched window's own bounds, never `status.coverage` (#679/#686) |
 | storage: Create-baseline gates (×5) | the button's double-gate (#686): live enabled arm, destination-missing arm, capability-off arm; the fixture snapshot listed |
+| telemetry: sample event (×3) | the Storage card's "Show a sample event" fold (#1447): closed by default, opens to a read-only `<pre>` carrying the daemon's `sample_event` string verbatim (never re-serialized in the frontend) |
 | no uncaught JS errors | any thrown error over the whole drive |
 
 Adding a scenario: append an `ok(...)`/`bad(...)` block in `console_e2e.mjs`.

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -3608,6 +3608,56 @@ try {
     ? ok("tropical: config cards rotate through the home's tint palette")
     : bad("tropical: config cards rotate through the home's tint palette", JSON.stringify(tints));
 
+  // ── Scenario 17h — the telemetry card shows the exact sample event (#1447) ──
+  // Still on /storage. The "Show a sample event" fold must be closed by
+  // default, open on click, and carry the daemon's `sample_event` string
+  // VERBATIM in a read-only <pre>: the daemon renders it through the same
+  // function `bintrail telemetry show` prints through, and a JSON.stringify
+  // in the frontend would be a second renderer free to drift. Each fetch
+  // draws a fresh run_id (as each `show` run does), so that one line is
+  // normalised before the bytes are compared, and its presence is asserted so
+  // an empty normalisation cannot pass. run.sh builds without -ldflags, so
+  // this photographs the no-endpoint arm, where the fold still renders.
+  const telSample = await page.evaluate(async () => {
+    const card = Array.from(document.querySelectorAll(".cards .card"))
+      .find((c) => (c.querySelector(".card-title") || {}).textContent === "Usage telemetry");
+    if (!card) return { found: false };
+    const d = card.querySelector("details.tel-sample");
+    if (!d) return { found: true, details: false };
+    const closedBefore = !d.open;
+    // checkVisibility, not a rect: Chromium folds a closed <details> with
+    // content-visibility rather than display:none, so the <pre> keeps its
+    // box (15px measured while folded) and only checkVisibility sees the fold.
+    const preBefore = d.querySelector("pre");
+    const hiddenBefore = preBefore ? !preBefore.checkVisibility() : false;
+    d.querySelector("summary").click();
+    const pre = d.querySelector("pre");
+    const shown = pre ? pre.textContent : "";
+    const state = await api("/api/telemetry");
+    let parsed = null;
+    try { parsed = JSON.parse(shown); } catch (_) {}
+    return {
+      found: true, details: true, closedBefore, hiddenBefore, openAfter: d.open,
+      visible: pre ? pre.checkVisibility() : false,
+      shown, fromApi: state.sample_event || "",
+      parsedType: parsed && parsed.event_type,
+      readOnly: pre ? !pre.isContentEditable && pre.querySelectorAll("input,textarea").length === 0 : false,
+    };
+  });
+  const runIDLine = /"run_id": "[0-9a-f-]{36}"/g;
+  const normRunID = (s) => s.replace(runIDLine, '"run_id": "<run_id>"');
+  (telSample.found && telSample.details && telSample.closedBefore && telSample.hiddenBefore)
+    ? ok("telemetry: the sample event is folded by default")
+    : bad("telemetry: the sample event is folded by default", JSON.stringify(telSample));
+  (telSample.openAfter && telSample.visible && telSample.readOnly && telSample.parsedType === "command_run")
+    ? ok("telemetry: opening the fold shows the daemon's event as read-only JSON")
+    : bad("telemetry: opening the fold shows the daemon's event as read-only JSON", JSON.stringify(telSample));
+  (telSample.shown && (telSample.shown.match(runIDLine) || []).length === 1
+    && (telSample.fromApi.match(runIDLine) || []).length === 1
+    && normRunID(telSample.shown) === normRunID(telSample.fromApi))
+    ? ok("telemetry: the shown bytes are the daemon's sample_event verbatim")
+    : bad("telemetry: the shown bytes are the daemon's sample_event verbatim", JSON.stringify({ shown: telSample.shown, fromApi: telSample.fromApi }));
+
   // ── Scenario 17g — Connect AI is three short steps with a drawn dialog ──
   // The audience is Claude users, mostly non-technical. The first rewrite
   // (#1430) made the steps explicit but drowned them in prose; the verdict on


### PR DESCRIPTION
closes #1447

## Summary

- The Usage telemetry card (Settings > Storage) gains a folded **Show a sample event** section: a read-only, pretty-printed `<pre>` with the exact JSON one event would carry, byte for byte as `bintrail telemetry show` prints it. Folded by default; opening it sends nothing.
- One renderer, not two: the CLI built the text inline with `json.MarshalIndent(telemetry.SampleEvent(), ...)`. That call moves into `telemetry.SampleEventJSON()`, and both the CLI command and the console's `GET /api/telemetry` (new `sample_event` string field on the existing DTO, so no new route and no RBAC table change) call it.
- The frontend prints the daemon's string verbatim. A `JSON.stringify` of a parsed object in the browser would be a second serializer free to drift from the CLI (key order, escaping, indent), which is the exact failure the issue rules out.
- The fold also renders on a build with no endpoint compiled in, matching the CLI, which prints the sample there too. That arm is what the Playwright scenario photographs, since `run.sh` builds without `-ldflags`.
- Docs: `docs/TELEMETRY.md` and `docs/console.md` mention the card; e2e README row; CHANGELOG under Added.

## Test plan

- [x] `go test ./internal/console/ -run TestHandleTelemetry -count=1` green. The new `TestHandleTelemetryGetSampleEventMatchesCLI` drives the real cobra `telemetry show` command and the real GET handler and compares the two renderings with only the per-call `run_id` normalised, asserting exactly one `run_id` line was replaced on each side (so an event that silently lost its `run_id` cannot pass on an empty replacement).
- [x] Red-then-green (Go): with the console wiring removed (`SampleEvent: ""` in `telemetryState`) the test fails with `console sample carries 0 run_id lines, want exactly 1`; restored, it passes.
- [x] `go test ./... -count=1` (full unit suite): 54 packages ok, exit 0.
- [x] `go vet ./...` clean; `gofmt -l` clean on every touched Go file.
- [x] Playwright `test/console-e2e/run.sh`: 323/323, including the new scenario 17h (three assertions: folded by default, opens to read-only JSON, shown bytes equal the daemon's `sample_event` modulo `run_id`).
- [x] Red-then-green (Playwright): with the three `card.append(telemetrySampleSection(t))` lines removed from app.js the run reports 320/323 with exactly those three assertions failing (`details: false`); app.js restored byte-identical and the suite is 323/323 again.
- Note on the probe: a first draft asserted "folded" via `getBoundingClientRect().height === 0` and failed on real Chromium, which folds a closed `<details>` with `content-visibility` (the `<pre>` keeps a 15px box while hidden). The scenario uses `checkVisibility()`, verified against a standalone page: false while folded, true once open.
