### PR TITLE
console: show the time-travel SQL port on the Connect page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   package is guarded the day it appears; the console, MCP and pg binaries are
   pinned free of both. Records the #1467 decision mechanically: Iceberg is an
   output, not the storage layer.
+- **The Connect page shows the time-travel SQL port** (#1446). Settings →
+  Connect AI gains a "Connect a SQL client" panel for the embedded
+  MySQL-protocol port (`bintrail-console watch --flashback-listen`). With the
+  port open it shows the listen address, the user rule (the server picked in
+  the sidebar, by its registry name or id), the password rule (the console
+  token, never displayed) and a ready-to-copy `mysql` line for that server.
+  With the port off it says so and names the flag and environment variable
+  that open it, as daemon configuration; the standalone `serve` console says
+  the port belongs to `watch`. Backed by a new read-only `GET /api/flashback`
+  (`{enabled, listen, host, port}`, `settings:read`; `host` is empty on a
+  wildcard bind, so the page fills in the name it was opened with). Display
+  only: the console never opens or closes the port.
 
 ### Changed
 - **Usage telemetry classifies first-run failures** (#1503). A fresh install

--- a/consoleapp/watch.go
+++ b/consoleapp/watch.go
@@ -1408,7 +1408,8 @@ type consoleOpts struct {
 	// FlashbackListen is the --flashback-listen address, reported to the
 	// console so the Connect page can show the port (#1446). Empty = off.
 	// startFlashbackPort binds it after console.New and aborts the daemon on
-	// failure, so a value the console reports is one the port is serving.
+	// a bind failure, so a value the console reports was bound at startup;
+	// a mid-run serve failure is logged and swallowed, not reflected here.
 	FlashbackListen string
 }
 

--- a/consoleapp/watch.go
+++ b/consoleapp/watch.go
@@ -1405,21 +1405,27 @@ type consoleOpts struct {
 	TLSKey       string
 	AllowedHosts []string
 	AllowSetup   bool
+	// FlashbackListen is the --flashback-listen address, reported to the
+	// console so the Connect page can show the port (#1446). Empty = off.
+	// startFlashbackPort binds it after console.New and aborts the daemon on
+	// failure, so a value the console reports is one the port is serving.
+	FlashbackListen string
 }
 
 // upConsoleOpts snapshots the resolved upConsole* globals.
 func upConsoleOpts() consoleOpts {
 	return consoleOpts{
-		Listen:       upConsoleListen,
-		Token:        upConsoleToken,
-		BaselineDir:  upConsoleBaselineDir,
-		BaselineS3:   upConsoleBaselineS3,
-		AuthFile:     upConsoleAuthFile,
-		MCPTokenFile: upConsoleMCPTokenFile,
-		TLSCert:      upConsoleTLSCert,
-		TLSKey:       upConsoleTLSKey,
-		AllowedHosts: upConsoleAllowedHost,
-		AllowSetup:   upConsoleAllowSetup,
+		Listen:          upConsoleListen,
+		Token:           upConsoleToken,
+		BaselineDir:     upConsoleBaselineDir,
+		BaselineS3:      upConsoleBaselineS3,
+		AuthFile:        upConsoleAuthFile,
+		MCPTokenFile:    upConsoleMCPTokenFile,
+		TLSCert:         upConsoleTLSCert,
+		TLSKey:          upConsoleTLSKey,
+		AllowedHosts:    upConsoleAllowedHost,
+		AllowSetup:      upConsoleAllowSetup,
+		FlashbackListen: upConsoleFlashbackListen,
 	}
 }
 
@@ -1439,19 +1445,20 @@ func upConsoleConfig(db *sql.DB, indexDSN string, opts consoleOpts) (console.Con
 		return console.Config{}, fmt.Errorf("--index-dsn must include a database name (e.g. user:pass@tcp(host:3306)/binlog_index)")
 	}
 	return console.Config{
-		DB:           db,
-		DBName:       cfg.DBName,
-		BootDSN:      indexDSN,
-		Listen:       opts.Listen,
-		Token:        opts.Token,
-		SQLPanel:     sqlPanelEnabled(),
-		BaselineDir:  opts.BaselineDir,
-		BaselineS3:   opts.BaselineS3,
-		AuthPath:     opts.AuthFile,
-		MCPTokenPath: opts.MCPTokenFile,
-		TLSCert:      opts.TLSCert,
-		TLSKey:       opts.TLSKey,
-		AllowedHosts: opts.AllowedHosts,
+		DB:              db,
+		DBName:          cfg.DBName,
+		BootDSN:         indexDSN,
+		Listen:          opts.Listen,
+		Token:           opts.Token,
+		SQLPanel:        sqlPanelEnabled(),
+		BaselineDir:     opts.BaselineDir,
+		BaselineS3:      opts.BaselineS3,
+		AuthPath:        opts.AuthFile,
+		MCPTokenPath:    opts.MCPTokenFile,
+		TLSCert:         opts.TLSCert,
+		TLSKey:          opts.TLSKey,
+		AllowedHosts:    opts.AllowedHosts,
+		FlashbackListen: opts.FlashbackListen,
 		// The daemon's --rotate-* defaults, so GET /api/rotation can report the
 		// effective policy (and the console panel prefill it) before the
 		// operator saves an override.

--- a/consoleapp/watch_test.go
+++ b/consoleapp/watch_test.go
@@ -28,10 +28,22 @@ func assertStr(t *testing.T, name, got, want string) {
 }
 
 func TestUpConsoleConfig(t *testing.T) {
-	cfg, err := upConsoleConfig(nil, "user:pass@tcp(127.0.0.1:3306)/binlog_index", consoleOpts{Listen: "127.0.0.1:8090", Token: "tok", BaselineDir: "/baselines", BaselineS3: "s3://bucket/prefix/", AuthFile: "/auth.yaml", TLSCert: "/c.pem", TLSKey: "/k.pem", AllowedHosts: []string{"console.internal"}})
+	cfg, err := upConsoleConfig(nil, "user:pass@tcp(127.0.0.1:3306)/binlog_index", consoleOpts{Listen: "127.0.0.1:8090", Token: "tok", BaselineDir: "/baselines", BaselineS3: "s3://bucket/prefix/", AuthFile: "/auth.yaml", TLSCert: "/c.pem", TLSKey: "/k.pem", AllowedHosts: []string{"console.internal"}, FlashbackListen: "127.0.0.1:3308"})
 	if err != nil {
 		t.Fatalf("upConsoleConfig: %v", err)
 	}
+	// The time-travel port's address reaches the console verbatim (#1446), so
+	// GET /api/flashback reports the bind the daemon is serving; and the
+	// resolved flag global is what upConsoleOpts snapshots into it.
+	if cfg.FlashbackListen != "127.0.0.1:3308" {
+		t.Errorf("FlashbackListen=%q, want verbatim pass-through", cfg.FlashbackListen)
+	}
+	prevFB := upConsoleFlashbackListen
+	upConsoleFlashbackListen = "[::]:13308"
+	if got := upConsoleOpts().FlashbackListen; got != "[::]:13308" {
+		t.Errorf("upConsoleOpts().FlashbackListen=%q, want the --flashback-listen value", got)
+	}
+	upConsoleFlashbackListen = prevFB
 	if cfg.DBName != "binlog_index" {
 		t.Errorf("DBName = %q, want binlog_index", cfg.DBName)
 	}

--- a/docs/console.md
+++ b/docs/console.md
@@ -1188,7 +1188,9 @@ running version, and the raw-config fallback above. Its **Access token** card
 generates, replaces (**New token**), and deletes the managed MCP token; the plaintext is
 displayed exactly once, at generation, and never stored. For the
 start-to-finish walkthrough (bundle install included), see
-[Connect an AI assistant](connect-ai.md).
+[Connect an AI assistant](connect-ai.md). Below the three steps, the
+**Connect a SQL client** panel does the same for the embedded time-travel SQL
+port: see [Time-travel over the MySQL protocol](#time-travel-over-the-mysql-protocol-flashback-port).
 
 ## API
 
@@ -1227,12 +1229,14 @@ All endpoints return JSON except `GET /api/views.sql`, which serves a SQL file. 
 | `GET /api/views.sql` | **Not JSON** — a `text/plain` DuckDB schema over the selected server's Parquet (the same output as `bintrail views`), served as a `views.sql` attachment. Nothing is executed here; the file runs in your own DuckDB. 404 when archives are disabled or nothing is archived yet, 403 while an access-control profile is active. |
 | `POST /api/sql` | Runs a read-only `SELECT` over the selected server's Parquet **inside the daemon**, in a locked-down DuckDB sandbox, returning `{columns, rows, row_count, truncated, elapsed_ms}` plus an optional `warnings` list (present when the session is missing the `events` view because `archive_state` could not be read; a failed statement carries the same note after the engine message). Opt-in (`BINTRAIL_CONSOLE_SQL_PANEL=1`) — `403` otherwise. `403` while a profile is active; `404` when archives are disabled or there is nothing to query; `422` for a non-`SELECT`, a statement error, or the timeout; `429` when another query is already running. Cancellation is by aborting the request. See [The SQL panel](#the-sql-panel-opt-in). |
 | `GET /api/storage` | Process-global storage context: `{aws: {access_key_env, profile, region_env, shared_config, container_creds, web_identity}}` — presence booleans and non-secret names only, never credential values. |
+| `GET /api/flashback` | Process-global: the embedded time-travel SQL port (`watch --flashback-listen`): `{enabled, listen, host, port}`. `enabled: false` alone on the standalone console and on a daemon that did not open the port; `host` is empty on a wildcard bind (the UI then uses the name it was opened with). Never the console token that authenticates the port. Backs the **Connect a SQL client** panel on Settings → Connect AI. |
 | `GET /api/profiles` | RBAC data-profile **names** defined on the selected server's index: `{"profiles": ["..."]}`, sorted; empty on a legacy index without the table. Vocabulary for administration panels (e.g. a settings-surface profile picker) — never the rules or flagged tables/columns behind a name. |
 
 Every data endpoint (`status`, `schemas`, `events`, `recover`,
 `recover-cascade`, `capabilities`, `reconstruct`, `baselines`) targets the
 server named by the `X-Bintrail-Server` request header; without the header they
-target the default entry (`storage` is the one process-global exception).
+target the default entry (`storage` and `flashback` are the process-global
+exceptions).
 Selection is stateless — concurrent clients can each target a different server.
 
 ### Cascade recovery
@@ -1335,6 +1339,16 @@ and baseline, so one port covers them all. A token is required (`--console-token
 / `BINTRAIL_CONSOLE_TOKEN`) because MySQL-protocol auth cannot use the console's
 password store. Full setup, routing, and the `_snapshot` baseline-parity edge:
 [docs/time-travel-sql.md → the embedded port](time-travel-sql.md#the-embedded-port-multi-source).
+
+The console shows the port on **Settings → Connect AI**, in the **Connect a
+SQL client** panel (#1446): when `watch` opened it, the listen address, the
+user rule (the server picked in the sidebar: its registry name or id, `default`
+for the command-line entry), the password rule (the console token, never
+displayed) and a ready-to-copy `mysql -h <host> -P <port> -u <server> -p` line
+for that server. When the port is off, the panel says so and names
+`--flashback-listen` / `BINTRAIL_CONSOLE_FLASHBACK_LISTEN` as daemon
+configuration; on the standalone `serve` console it says the port belongs to
+`watch`. Display only: the console never opens or closes the port.
 
 ### Coverage gaps and incomplete data
 

--- a/docs/time-travel-sql.md
+++ b/docs/time-travel-sql.md
@@ -80,6 +80,13 @@ console's password store — so set `--console-token` / `BINTRAIL_CONSOLE_TOKEN`
 `watch` refuses to open the port otherwise. The default `127.0.0.1` bind keeps
 it host-local; do not expose it to untrusted networks.
 
+The console shows all of this on **Settings → Connect AI**, in the **Connect a
+SQL client** panel: whether the port is on, its address, the user and password
+rules, and a ready-to-copy `mysql` line for the server picked in the sidebar
+(the token itself is never displayed). When the port is off, the panel names
+`--flashback-listen` / `BINTRAIL_CONSOLE_FLASHBACK_LISTEN` as the daemon
+setting that opens it.
+
 `_snapshot.*` parity: each server reads the baseline configured on its registry
 entry (or the daemon's `--baseline-dir` / `--baseline-s3`), exactly as the
 console's Time-travel tab does — with one edge: a server configured with *both*

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -6056,7 +6056,10 @@ function shellWord(s) {
 // daemon named one; on a wildcard bind (host empty) the name this page was
 // opened on, which is the one name known to reach the daemon's machine.
 function flashbackHost(fb) {
-  return fb.host || location.hostname || "127.0.0.1";
+  // location.hostname keeps the brackets of an IPv6 literal ("[::1]"), while
+  // a named bind comes through Go's SplitHostPort bare ("::1"); strip them so
+  // both shapes print the same way.
+  return fb.host || (location.hostname || "").replace(/^\[|\]$/g, "") || "127.0.0.1";
 }
 
 // sqlClientPanel renders the port's state in one of four shapes: could not
@@ -6079,7 +6082,10 @@ function sqlClientPanel(servers, fb) {
       // serve: there is no daemon here to carry the port, so naming the
       // watch flag as "how to turn it on" would send the reader to a flag
       // this process does not have.
-      body.append(el("p", { class: "cn-sql-row", text: "Not available from this read-only console. The time-travel port is part of the watch daemon (CLI: bintrail-console watch --flashback-listen)." }));
+      body.append(el("p", { class: "cn-sql-row" },
+        "Not available from this read-only console. The time-travel port is part of the watch daemon (CLI: ",
+        el("code", { text: "bintrail-console watch --flashback-listen" }),
+        "). Run that daemon and your usual MySQL client can read any table as it was at a chosen moment."));
       return panel;
     }
     body.append(el("p", { class: "cn-sql-row", text: "Off. The port is set when the daemon starts, not from this page." }));
@@ -6116,7 +6122,7 @@ function sqlClientPanel(servers, fb) {
       " Use _snapshot for the whole table (needs a backup) and _diff for what changed between two moments. The user picks the server, so each server has its own line; pick another in the sidebar and copy again."),
     el("p", { class: "form-hint", text: fb.host
       ? "The port answers on that address only. Run mysql where it can reach it (on the daemon's machine when it is 127.0.0.1), or open a tunnel to it."
-      : "The port answers on every network address of the daemon's machine; the command uses the name this page was opened with." })));
+      : "The port answers on every network address of the daemon's machine; the command uses the name this page was opened with. If that name is a reverse proxy in front of the console, it does not pass this port through, so use the daemon machine's own name or address instead." })));
   return panel;
 }
 

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -5733,6 +5733,10 @@ async function renderConnect() {
   // failure — the card degrades to a reload hint instead of blanking the page.
   let tokStatus = null;
   try { tokStatus = await api("/api/mcp-token"); } catch (_) {}
+  // Time-travel port status (#1446): on/off plus its address, never the token.
+  // null on failure — the SQL client panel says it could not check.
+  let fbStatus = null;
+  try { fbStatus = await api("/api/flashback"); } catch (_) {}
   if (gen !== serverGen) {
     // The consumed plaintext cannot be re-shown; say so instead of losing it
     // silently (the user must rotate to get a usable value).
@@ -5740,7 +5744,7 @@ async function renderConnect() {
     return;
   }
   try {
-    buildConnect(servers, tokStatus, minted);
+    buildConnect(servers, tokStatus, minted, fbStatus);
   } catch (err) {
     if (minted) toastError("Token display interrupted; the plain token is gone. Click New token to get a fresh one");
     const v = VIEW(); clear(v); v.append(pageHead("Connect AI", null)); renderError(v, err);
@@ -5774,7 +5778,7 @@ function copyText(text, what) {
   navigator.clipboard.writeText(text).then(() => toast(what + " copied to clipboard"), () => toastError("Copy failed."));
 }
 
-function buildConnect(servers, tokStatus, minted) {
+function buildConnect(servers, tokStatus, minted, fbStatus) {
   const v = VIEW(); clear(v);
   const sub = el("p", { class: "page-sub" },
     "Three steps and Claude can answer questions about your database history. It can only read; it can never change anything.");
@@ -5786,6 +5790,7 @@ function buildConnect(servers, tokStatus, minted) {
   cards.append(bundleCard());
   v.append(cards);
   if (capsCache.mcp) v.append(otherClientsPanel(servers));
+  v.append(sqlClientPanel(servers, fbStatus));
   viewEnter();
 }
 
@@ -6026,6 +6031,92 @@ function otherClientsPanel(servers) {
   adv.append(el("p", { class: "form-hint", text:
     "If this console is reachable over public HTTPS, the same URL also works directly as a claude.ai custom connector; no bridge needed." }));
   panel.append(adv);
+  return panel;
+}
+
+// ── Connect a SQL client (#1446) ─────────────────────────────────────────────
+//
+// The embedded time-travel port (`watch --flashback-listen`, #996) serves the
+// _flashback / _snapshot / _diff schemas for every monitored server over the
+// MySQL protocol, routed by the connection USERNAME (the server's registry
+// name or id, "default" for the boot entry: the same selector /mcp uses, so
+// mcpSelector is reused) and authenticated with the console token. Display
+// only: the port is daemon configuration, so this panel can say where it is,
+// or that it is off and what turns it on, and never toggle it. Status comes
+// from GET /api/flashback; a null status means the call failed, and the panel
+// says so instead of guessing an address.
+
+// shellWord quotes a value for the copy-paste mysql line when it carries
+// anything a shell would split or expand (a display name with a space).
+function shellWord(s) {
+  return /^[A-Za-z0-9_.:@-]+$/.test(s) ? s : "'" + String(s).replace(/'/g, "'\\''") + "'";
+}
+
+// flashbackHost picks the host for the mysql line: the bind host when the
+// daemon named one; on a wildcard bind (host empty) the name this page was
+// opened on, which is the one name known to reach the daemon's machine.
+function flashbackHost(fb) {
+  return fb.host || location.hostname || "127.0.0.1";
+}
+
+// sqlClientPanel renders the port's state in one of four shapes: could not
+// check, off on a read-only console (the port belongs to watch), off on a
+// watch daemon (name the flag and env var, as daemon configuration), or on
+// (address, user rule, password rule, and the ready-to-copy mysql line for
+// the server picked in the sidebar). Not a .cn-card: the three numbered cards
+// are the Connect AI how-to, and this is a different client.
+function sqlClientPanel(servers, fb) {
+  const panel = el("section", { class: "ov-panel cn-sql", style: "margin-top:18px" });
+  panel.append(el("div", { class: "ov-panel-head" }, el("h2", { class: "ov-panel-title", text: "Connect a SQL client" })));
+  const body = el("div", { class: "cn-sql-body" });
+  panel.append(body);
+  if (!fb) {
+    body.append(el("p", { class: "cn-sql-row", text: "We could not check whether the time-travel port is on. Reload the page to try again." }));
+    return panel;
+  }
+  if (!fb.enabled) {
+    if (!capsCache.monitor) {
+      // serve: there is no daemon here to carry the port, so naming the
+      // watch flag as "how to turn it on" would send the reader to a flag
+      // this process does not have.
+      body.append(el("p", { class: "cn-sql-row", text: "Not available from this read-only console. The time-travel port is part of the watch daemon (CLI: bintrail-console watch --flashback-listen)." }));
+      return panel;
+    }
+    body.append(el("p", { class: "cn-sql-row", text: "Off. The port is set when the daemon starts, not from this page." }));
+    body.append(cnFine("How to turn it on",
+      el("p", { class: "form-hint" },
+        "Start the daemon with a port address (CLI: ", el("code", { text: "--flashback-listen 127.0.0.1:3308" }),
+        ", or the environment variable ", el("code", { text: "BINTRAIL_CONSOLE_FLASHBACK_LISTEN" }),
+        ") and a console token (CLI: ", el("code", { text: "--console-token" }), " or ", el("code", { text: "BINTRAIL_CONSOLE_TOKEN" }),
+        "). This panel then shows the address and a ready to copy mysql line, and your usual MySQL client can read any table as it was at a chosen moment.")));
+    return panel;
+  }
+  const cur = (servers || []).find((s) => s.id === (currentServer || defaultServerId));
+  const user = mcpSelector(cur);
+  // A wildcard bind (":3308") reads as a typo to a non-technical reader; say
+  // what it means and let the mysql line carry the name this page uses.
+  body.append(el("p", { class: "cn-sql-row" }, "Address ",
+    el("code", { text: fb.host ? fb.listen : "port " + (fb.port || fb.listen) }),
+    fb.host ? "" : " on every network address of the daemon's machine"));
+  body.append(el("p", { class: "cn-sql-row" }, "User ",
+    user ? el("code", { text: user }) : el("code", { text: "<server name>" }),
+    user ? ", the server picked in the left sidebar" : ", the name of a server in the left sidebar (none yet)"));
+  body.append(el("p", { class: "cn-sql-row" },
+    "Password: the console token (CLI: ", el("code", { text: "--console-token" }), " or ", el("code", { text: "BINTRAIL_CONSOLE_TOKEN" }), "), never shown here"));
+  if (fb.port) {
+    const line = "mysql -h " + shellWord(flashbackHost(fb)) + " -P " + fb.port + " -u " + (user ? shellWord(user) : "<server-name>") + " -p";
+    body.append(el("div", { class: "cn-urlrow" },
+      el("code", { class: "stg-code cn-url", text: line }),
+      el("button", { class: "btn btn-sm", type: "button", text: "Copy", onclick: () => copyText(line, "mysql command") })));
+    body.append(el("p", { class: "cn-sql-row", text: "Paste the token at the password prompt." }));
+  }
+  body.append(cnFine("What to run, and other machines",
+    el("p", { class: "form-hint" }, "Ask for a table as it was: ",
+      el("code", { text: "SELECT * FROM _flashback.orders AS OF '10 minutes ago' WHERE id = 1;" }),
+      " Use _snapshot for the whole table (needs a backup) and _diff for what changed between two moments. The user picks the server, so each server has its own line; pick another in the sidebar and copy again."),
+    el("p", { class: "form-hint", text: fb.host
+      ? "The port answers on that address only. Run mysql where it can reach it (on the daemon's machine when it is 127.0.0.1), or open a tunnel to it."
+      : "The port answers on every network address of the daemon's machine; the command uses the name this page was opened with." })));
   return panel;
 }
 

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -2087,6 +2087,10 @@ button { font-family: inherit; }
 .cn-links { display: flex; gap: 8px; flex-wrap: wrap; margin: 10px 0; }
 .cn-snippet { display: block; margin: 8px 0 10px; white-space: pre; }
 .cn-other .form-hint { margin-top: 8px; }
+.cn-sql-body { padding: 0 14px 14px; }
+.cn-sql-row { margin: 0 0 8px; font-size: 13px; color: var(--ink-2); }
+.cn-sql-row code { font-family: var(--f-mono); font-size: 12px; }
+.cn-sql .cn-fine { margin-top: 4px; }
 
 /* ============================================================
    date/time picker (Since/Until/At filters)

--- a/internal/console/authz.go
+++ b/internal/console/authz.go
@@ -159,6 +159,10 @@ var apiRoutePerms = []routePerm{
 	{"GET", "/api/mcp-token", ext.PermSettingsRead},
 	{"POST", "/api/mcp-token", ext.PermSettingsRead},
 	{"DELETE", "/api/mcp-token", ext.PermSettingsRead},
+	// The time-travel port's address is daemon configuration shown on the
+	// Connect page, beside the MCP token status: settings vocabulary, no row
+	// data, and never the token that authenticates the port.
+	{"GET", "/api/flashback", ext.PermSettingsRead},
 
 	// The capabilities oracle and the session's own auth self-management: any
 	// authenticated session, regardless of policy.

--- a/internal/console/authz_test.go
+++ b/internal/console/authz_test.go
@@ -72,6 +72,7 @@ var registeredAPIPatterns = []struct{ method, pattern string }{
 	{"GET", "/api/mcp-token"},
 	{"POST", "/api/mcp-token"},
 	{"DELETE", "/api/mcp-token"},
+	{"GET", "/api/flashback"},
 }
 
 // concretePath turns a table pattern into a real path by giving every "{}" a

--- a/internal/console/flashback_api.go
+++ b/internal/console/flashback_api.go
@@ -1,0 +1,56 @@
+package console
+
+import (
+	"net"
+	"net/http"
+)
+
+// flashbackStatusDTO is the wire view of the embedded MySQL-protocol
+// time-travel port (#996) for the Connect page (#1446): whether it is on and
+// where it listens. The password that authenticates it is the console token,
+// which is never serialized; the username rule (a server's registry id or
+// name, "default" for the boot entry) is the same selector the /mcp path
+// uses, so the frontend derives it from the server list it already holds.
+type flashbackStatusDTO struct {
+	// Enabled: this process bound the port (Config.FlashbackListen). False on
+	// the standalone serve, which owns no such port, and on a watch daemon
+	// that did not opt in.
+	Enabled bool `json:"enabled"`
+	// Listen is the bind address exactly as configured (host:port).
+	Listen string `json:"listen,omitempty"`
+	// Host and Port are Listen split for the ready-to-copy mysql line. Host
+	// is EMPTY when the bind is on every interface (":3308", "0.0.0.0:3308",
+	// "[::]:3308"): the daemon cannot know which name the browser reaches it
+	// by, so the page fills in the address it was opened on.
+	Host string `json:"host,omitempty"`
+	Port string `json:"port,omitempty"`
+}
+
+func (s *Server) flashbackStatus() flashbackStatusDTO {
+	if s.flashbackListen == "" {
+		return flashbackStatusDTO{}
+	}
+	dto := flashbackStatusDTO{Enabled: true, Listen: s.flashbackListen}
+	// A value net.Listen would have refused (no port) cannot reach here from
+	// watch, whose bind failure aborts startup; report the raw address alone
+	// rather than guess a split.
+	host, port, err := net.SplitHostPort(s.flashbackListen)
+	if err != nil {
+		return dto
+	}
+	dto.Port = port
+	switch host {
+	case "", "0.0.0.0", "::":
+		// Wildcard bind: no single host to name.
+	default:
+		dto.Host = host
+	}
+	return dto
+}
+
+// handleFlashbackGet reports the time-travel port's state and address, never
+// the token that authenticates it. Behind tokenMiddleware like every /api
+// route; classified settings:read (it is daemon configuration, not row data).
+func (s *Server) handleFlashbackGet(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, s.flashbackStatus())
+}

--- a/internal/console/flashback_api_test.go
+++ b/internal/console/flashback_api_test.go
@@ -1,0 +1,93 @@
+package console
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// newFlashbackStatusServer builds a token-authenticated server with the embedded
+// time-travel port reported at listen ("" = the port is off, as on serve).
+func newFlashbackStatusServer(t *testing.T, listen string) *Server {
+	t.Helper()
+	s, err := New(Config{Listen: "127.0.0.1:8090", Token: "secret-tok", FlashbackListen: listen})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+// TestFlashbackAPI_Off pins the standalone-serve / not-opted-in shape: the
+// port reports off and carries NO address fields, so the Connect page cannot
+// render a stale or guessed address as reachable.
+func TestFlashbackAPI_Off(t *testing.T) {
+	s := newFlashbackStatusServer(t, "")
+	rec := doJSON(t, s, "GET", "/api/flashback", "secret-tok")
+	if rec.Code != 200 {
+		t.Fatalf("code = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v (%s)", err, rec.Body.String())
+	}
+	if got["enabled"] != false {
+		t.Errorf("enabled = %v, want false", got["enabled"])
+	}
+	for _, k := range []string{"listen", "host", "port"} {
+		if _, present := got[k]; present {
+			t.Errorf("off state serializes %q = %v; an address must not appear when the port is off", k, got[k])
+		}
+	}
+}
+
+// TestFlashbackAPI_On drives the enabled shape through the real route for a
+// loopback bind and the three wildcard spellings: the split host/port the
+// mysql line needs, with host EMPTY on a wildcard bind (the daemon cannot
+// know the name the browser reaches it by).
+func TestFlashbackAPI_On(t *testing.T) {
+	cases := []struct {
+		listen, wantHost, wantPort string
+	}{
+		{"127.0.0.1:3308", "127.0.0.1", "3308"},
+		{"db-host.internal:13308", "db-host.internal", "13308"},
+		{":3308", "", "3308"},
+		{"0.0.0.0:3308", "", "3308"},
+		{"[::]:3308", "", "3308"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.listen, func(t *testing.T) {
+			s := newFlashbackStatusServer(t, tc.listen)
+			rec := doJSON(t, s, "GET", "/api/flashback", "secret-tok")
+			if rec.Code != 200 {
+				t.Fatalf("code = %d, want 200: %s", rec.Code, rec.Body.String())
+			}
+			var got flashbackStatusDTO
+			if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+				t.Fatalf("decode: %v (%s)", err, rec.Body.String())
+			}
+			if !got.Enabled {
+				t.Errorf("enabled = false, want true for a bound port")
+			}
+			if got.Listen != tc.listen {
+				t.Errorf("listen = %q, want the configured %q", got.Listen, tc.listen)
+			}
+			if got.Host != tc.wantHost || got.Port != tc.wantPort {
+				t.Errorf("host/port = %q/%q, want %q/%q", got.Host, got.Port, tc.wantHost, tc.wantPort)
+			}
+			// The port authenticates on the console token; the status must
+			// describe the rule, never carry the value.
+			if strings.Contains(rec.Body.String(), "secret-tok") {
+				t.Errorf("response leaks the console token: %s", rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestFlashbackAPI_RequiresAuth: the address is daemon configuration behind
+// the same credential as every /api route.
+func TestFlashbackAPI_RequiresAuth(t *testing.T) {
+	s := newFlashbackStatusServer(t, "127.0.0.1:3308")
+	if rec := doJSON(t, s, "GET", "/api/flashback", ""); rec.Code != 401 {
+		t.Errorf("without token: code = %d, want 401", rec.Code)
+	}
+}

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -189,6 +189,15 @@ type Config struct {
 	// for the layered posture). Off by default; the callers wire it from
 	// BINTRAIL_CONSOLE_SQL_PANEL=1, mirroring the baseline-trigger opt-in.
 	SQLPanel bool
+	// FlashbackListen is the address the embedded MySQL-protocol time-travel
+	// port (#996) is bound on, reported by GET /api/flashback so the Connect
+	// page can show how to reach it (#1446). Set ONLY by `bintrail-console
+	// watch --flashback-listen`, which refuses to start when that bind fails,
+	// so a non-empty value means the port is up. Empty on the standalone
+	// serve (which owns no such port) and on a watch that did not opt in;
+	// the page then reports the port as off. Display only: the console never
+	// opens or closes the port itself.
+	FlashbackListen string
 }
 
 // RotationDefaults is the daemon-side built-in-rotation policy, surfaced to the
@@ -322,6 +331,9 @@ type Server struct {
 	// servers need no initialization).
 	sqlPanel     bool
 	sqlPanelBusy atomic.Bool
+	// flashbackListen: the embedded time-travel port's bind address
+	// (Config.FlashbackListen); empty = the port is off (or this is serve).
+	flashbackListen string
 }
 
 // serverHeader selects the target server per request. Selection is stateless —
@@ -500,6 +512,7 @@ func New(cfg Config) (*Server, error) {
 		mcpTokenPath:            mcpTokenPath,
 		sessionProfiles:         newProfileRuleCache(),
 		sqlPanel:                cfg.SQLPanel,
+		flashbackListen:         cfg.FlashbackListen,
 		archiveFetcher:          parquetquery.Fetch,
 	}
 	s.managedTok.initFromDisk(mcpTokenPath, mcpTokFile)
@@ -676,6 +689,10 @@ func (s *Server) buildHandler() http.Handler {
 	api.HandleFunc("GET /api/mcp-token", s.handleMCPTokenGet)
 	api.HandleFunc("POST /api/mcp-token", s.handleMCPTokenGenerate)
 	api.HandleFunc("DELETE /api/mcp-token", s.handleMCPTokenRevoke)
+	// Embedded time-travel port (#1446): where it listens and whether it is
+	// on, so the Connect page can show a ready-to-copy mysql line. Read-only;
+	// the token that authenticates the port is never serialized.
+	api.HandleFunc("GET /api/flashback", s.handleFlashbackGet)
 
 	root := http.NewServeMux()
 	root.HandleFunc("GET /api/healthz", s.handleHealthz) // unauthenticated liveness

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -193,10 +193,12 @@ type Config struct {
 	// port (#996) is bound on, reported by GET /api/flashback so the Connect
 	// page can show how to reach it (#1446). Set ONLY by `bintrail-console
 	// watch --flashback-listen`, which refuses to start when that bind fails,
-	// so a non-empty value means the port is up. Empty on the standalone
-	// serve (which owns no such port) and on a watch that did not opt in;
-	// the page then reports the port as off. Display only: the console never
-	// opens or closes the port itself.
+	// so a non-empty value is an address that was bound at startup. It is
+	// NOT a liveness signal: a mid-run serve failure on that port is logged
+	// and swallowed (startFlashbackPort), and nothing here re-probes it.
+	// Empty on the standalone serve (which owns no such port) and on a watch
+	// that did not opt in; the page then reports the port as off. Display
+	// only: the console never opens or closes the port itself.
 	FlashbackListen string
 }
 

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -3681,6 +3681,21 @@ try {
   (cn.once && cn.addrCopy && cn.downloadLinks === 0)
     ? ok("connect: one-time warning visible, address one click to copy, no 404able download link")
     : bad("connect: one-time warning visible, address one click to copy, no 404able download link", JSON.stringify({ once: cn.once, addrCopy: cn.addrCopy, downloadLinks: cn.downloadLinks }));
+  // The SQL client panel (#1446). run.sh opens the daemon's time-travel port,
+  // so the ENABLED shape is what gets photographed: a mysql line carrying the
+  // port and the selected server as its user (never a placeholder), with
+  // the console token nowhere on the page. The panel is NOT a .cn-card, so
+  // the three-badge assertion above stays at three.
+  const fbPort = process.env.E2E_FLASHBACK_PORT || "13308";
+  const sq = await page.evaluate(() => {
+    const p = document.querySelector(".view .cn-sql");
+    const code = p ? p.querySelector("code.cn-url") : null;
+    return { present: !!p, line: code ? code.textContent : "", text: p ? p.innerText : "" };
+  });
+  const sqLineRE = new RegExp("^mysql -h 127\\.0\\.0\\.1 -P " + fbPort + " -u \\S+ -p$");
+  (sq.present && sqLineRE.test(sq.line) && !sq.line.includes("<server") && !(TOKEN && sq.text.includes(TOKEN)))
+    ? ok("connect: SQL client panel shows the time-travel port with a mysql line for the selected server")
+    : bad("connect: SQL client panel shows the time-travel port with a mysql line for the selected server", JSON.stringify({ present: sq.present, line: sq.line }));
 
   // ── Scenario 17f — the Events skeleton is visible (#1397) ──
   //

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -3621,7 +3621,12 @@ try {
   // open page counts against the cap. The cap (1500)
   // sits ~50% above the measured page (869-985 chars across the token states)
   // and 35% below the pre-simplify page (2304 measured, RED verified), so a
-  // copy edit breathes but a wall of text rings.
+  // copy edit breathes but a wall of text rings. The SQL client panel below
+  // the steps (#1446) is EXCLUDED from that measurement: the budget was
+  // calibrated on the three MCP steps, and the panel's enabled shape alone
+  // measures ~330 chars (1316 with it, 985 without), which would leave ~12%
+  // headroom and make a legit copy edit on the panel ring a guard about a
+  // different page. The panel has its own assertion further down.
   // Limit worth naming: run.sh builds without -ldflags, so this only ever
   // photographs the UNVERSIONED bundle arm.
   await page.evaluate(() => navigate("connect"));
@@ -3653,11 +3658,14 @@ try {
     const badges = Array.from(document.querySelectorAll(".view .card .cn-num")).map((n) => n.textContent).join("");
     const labels = Array.from(document.querySelectorAll(".cn-mock .cn-mock-label")).map((n) => n.textContent);
     const addrCard = document.querySelectorAll(".view .cn-card")[1];
-    const visible = (document.querySelector(".view") || { innerText: "" }).innerText;
+    const view = document.querySelector(".view") || { innerText: "", querySelector: () => null };
+    const visible = view.innerText;
+    const sqlPanel = view.querySelector(".cn-sql");
     return {
       badges,
       labels,
-      visibleChars: visible.length,
+      // Minus the SQL client panel's own text (see the budget note above).
+      visibleChars: visible.length - (sqlPanel ? sqlPanel.innerText.length : 0),
       fine: document.querySelectorAll(".view details.cn-fine").length,
       addrCopy: addrCard ? Array.from(addrCard.querySelectorAll("button")).some((b) => b.textContent === "Copy") : false,
       once: /shown only once/.test(visible),

--- a/test/console-e2e/run.sh
+++ b/test/console-e2e/run.sh
@@ -19,6 +19,7 @@
 #   MYSQL_CONTAINER     docker container running test MySQL, default bintrail-test-mysql
 #   CONSOLE_BIN         path to a prebuilt bintrail-console (else it is built)
 #   PW_CHANNEL          playwright browser channel (e.g. "chrome"); default bundled chromium
+#   E2E_FLASHBACK_PORT  port for the daemon's embedded time-travel SQL port, default 13308
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/test/console-e2e/run.sh
+++ b/test/console-e2e/run.sh
@@ -27,6 +27,9 @@ ROOT="$(cd "$HERE/../.." && pwd)"
 BASE_DSN="${BINTRAIL_TEST_DSN:-root:testroot@tcp(127.0.0.1:13306)}"
 MYSQL_CONTAINER="${MYSQL_CONTAINER:-bintrail-test-mysql}"
 PORT="${E2E_PORT:-8090}"
+# The daemon's embedded time-travel SQL port (#996), opened so scenario 17g
+# photographs the Connect page's SQL client panel in its enabled shape (#1446).
+FLASHBACK_PORT="${E2E_FLASHBACK_PORT:-13308}"
 TOKEN="${E2E_TOKEN:-e2e-console-token}"
 IDX_DB="bintrail_e2e_idx"
 ARC_DB="bintrail_e2e_arc"
@@ -205,6 +208,7 @@ BINTRAIL_CONSOLE_TOKEN="$TOKEN" BINTRAIL_CONSOLE_BASELINE_TRIGGER=1 BINTRAIL_CON
   --console-token "$TOKEN" \
   --console-servers-file "$SERVERS_FILE" \
   --baseline-dir "$BASELINE_ROOT" \
+  --flashback-listen "127.0.0.1:$FLASHBACK_PORT" \
   --console-allow-setup >"$E2E_ARTIFACT_DIR/console-e2e-daemon.log" 2>&1 &
 DAEMON_PID=$!
 
@@ -235,4 +239,4 @@ cd "$HERE"
 CONSOLE_URL="http://127.0.0.1:$PORT" E2E_ARC_DB="$ARC_DB" \
   E2E_ARC_GAP_SINCE="$ARC_GAP_SINCE" E2E_ARC_GAP_UNTIL="$ARC_GAP_UNTIL" CONSOLE_TOKEN="$TOKEN" \
   E2E_FIX_SCHEMA="$FIX_SCHEMA" E2E_TT_AT="$TT_AT" E2E_BASELINE_DIR="$BASELINE_ROOT" \
-  E2E_IDX_DB="$IDX_DB" E2E_MYSQL_CONTAINER="$MYSQL_CONTAINER" node console_e2e.mjs
+  E2E_IDX_DB="$IDX_DB" E2E_MYSQL_CONTAINER="$MYSQL_CONTAINER" E2E_FLASHBACK_PORT="$FLASHBACK_PORT" node console_e2e.mjs


### PR DESCRIPTION
closes #1446

## Summary

- **Settings → Connect AI gains a "Connect a SQL client" panel** for the embedded MySQL-protocol time-travel port (`bintrail-console watch --flashback-listen`, #996). Four shapes, all display only:
  - **on**: the listen address, the user rule (the server picked in the sidebar, by registry name or id, `default` for the command-line entry; the same selector `/mcp` uses, so `mcpSelector` is reused), the password rule (the console token, never displayed) and a ready-to-copy `mysql -h <host> -P <port> -u <server> -p` line with a Copy button. Folded fine print carries an example `AS OF` query and the "other machine / tunnel" note.
  - **off on `watch`**: "Off. The port is set when the daemon starts, not from this page." plus folded "How to turn it on" naming `(CLI: --flashback-listen ...)` / `BINTRAIL_CONSOLE_FLASHBACK_LISTEN` and the console token requirement.
  - **standalone `serve`** (no monitor capability): says the port belongs to the watch daemon instead of pointing at a flag this process does not have.
  - **status fetch failed**: says it could not check; never guesses an address.
- **New read-only `GET /api/flashback`** → `{enabled, listen, host, port}`; `settings:read` in `apiRoutePerms` and the mirror list. The off state serializes `enabled:false` alone (no address fields). `host` is empty on a wildcard bind (`:3308`, `0.0.0.0:3308`, `[::]:3308`) and the page fills in the name it was opened with. The token never serializes.
- **`console.Config.FlashbackListen`**, threaded from `consoleOpts` in `watch` (`upConsoleOpts` → `upConsoleConfig`). `startFlashbackPort` aborts the daemon when the bind fails, so a reported address is one the port serves. `serve` never sets it.
- The panel is not a `.cn-card`, so 17g's three-badge assertion stays at three; the e2e daemon now opens the port (`E2E_FLASHBACK_PORT`, default 13308) and 17g asserts the enabled shape (mysql line with the port and the selected server, token nowhere on the page).
- Docs: `docs/console.md` (API table row, Connect AI paragraph, flashback-port section) and `docs/time-travel-sql.md` (embedded port section). CHANGELOG under Added.

Not done on purpose: the issue's optional per-server line on the server detail (the Connect page covers the ask; the server detail has no connect surface today), and any runtime toggle (the issue defers that).

## Test plan

- [x] `go build ./...`, `go vet ./internal/console/ ./consoleapp/`, `gofmt -l` clean on touched files
- [x] `go test ./internal/console/ -run 'TestFlashbackAPI|TestRouteTable|TestRoutePerm|TestMuxAPIRequiresToken' -count=1` green; `go test ./consoleapp/ -run 'TestUpConsoleConfig$' -count=1` green
- [x] Red-then-green: commenting out the `flashbackListen: cfg.FlashbackListen` copy in `New` fails `TestFlashbackAPI_On`; commenting out the `GET /api/flashback` registration fails `TestFlashbackAPI_Off` and `_On` (404); commenting out `FlashbackListen: opts.FlashbackListen` in `upConsoleConfig` fails `TestUpConsoleConfig` (`FlashbackListen="", want verbatim pass-through`). All restored, green again.
- [x] `go test ./... -count=1`: no FAIL lines (every package ok / no test files)
- [x] `node --check` on app.js and console_e2e.mjs, `bash -n run.sh`
- [x] `test/console-e2e/run.sh` (headless Chromium against the final build, Docker MySQL on 13306): 321/321 passed, including the new `connect: SQL client panel shows the time-travel port with a mysql line for the selected server`; the existing three-badge and visible-text-budget assertions still pass with the panel on the page (1316 visible chars measured on a page with one server, cap 1500)
- [x] Rendered all three shapes with a throwaway daemon each and photographed the panel: `watch --flashback-listen` (address, user, password rule, mysql line, Copy), `watch` without the flag (Off + folded how-to), and `serve` (port belongs to watch). `GET /api/flashback` answered `{"enabled":true,"listen":"127.0.0.1:13398","host":"127.0.0.1","port":"13398"}` / `{"enabled":false}` / `{"enabled":false}` respectively
- [x] The printed line works as printed: `mysql -h 127.0.0.1 -P 13398 -u prod-1 -p<token>` authenticated on the port and was routed to server `prod-1` (the only error was that server's unprovisioned per-source index, i.e. past auth and routing)
