### PR TITLE
console: bind the SQL panel's views with I/O concurrency, not the CPU budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **SQL panel: the view build no longer runs one S3 round trip at a time**
+  (#1535). A statement over the `events` view is bound before it runs, and
+  `union_by_name = true` makes DuckDB open one Parquet footer per file in the
+  layout to compute the unified schema. Over an S3 archive each of those is a
+  network round trip, and the panel bound them at the daemon's 2-thread CPU
+  budget, so `select * from events limit 1` could spend its whole 30s setup
+  budget binding and fail with `set up views over the Parquet layout: context
+  deadline exceeded` without ever running. The bind now holds a wider thread
+  count and the sandbox restores the daemon budget before the statement
+  executes. Measured on one archive source of 164 files, varying only this
+  setting: 2 threads 60.2s, 8 threads 15.8s, 16 threads 8.1s, while user CPU
+  stayed between 2.2s and 3.3s across the range. The wait is latency, not
+  compute, so the widening buys wall-clock without buying CPU on a process that
+  may also be capturing. This is a constant factor and not a cure: the bind is
+  still O(archived files) and #1535 carries the design that bounds it by
+  distinct schemas instead.
+
 ## [0.73.0] - 2026-08-30
 
 ### Added

--- a/internal/console/sqlpanel.go
+++ b/internal/console/sqlpanel.go
@@ -60,6 +60,7 @@ import (
 	"math/big"
 	"net/http"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -100,6 +101,38 @@ var sqlPanelTimeout = 60 * time.Second
 // So the setup gives up at the first statement boundary after the budget runs
 // out rather than at the instant it does.
 var sqlPanelSetupTimeout = 30 * time.Second
+
+// sqlPanelBindThreads is the DuckDB thread count to hold WHILE the view DDL
+// binds, and only while it binds — the sandbox restores the daemon budget a few
+// statements later, before lock_configuration freezes it.
+//
+// The daemon budget (2 threads, #510) is a CPU bound, and it is the right bound
+// for executing a statement: that reads row groups and this process may co-host
+// the stream supervisor. Binding is not that work. `union_by_name = true` makes
+// DuckDB open one Parquet footer per file in the layout to compute the unified
+// schema, and over an S3 layout each of those is a network round trip. Measured
+// on one archive source of 164 files, varying only this setting: 1 thread
+// 124.9s, 2 threads 60.2s, 8 threads 15.8s, 16 threads 8.1s, 32 threads 4.5s —
+// while user CPU stayed between 2.2s and 3.3s across the whole range. The wait
+// is latency, so widening it buys wall-clock without buying CPU, and holding
+// the CPU bound over it spends minutes to protect nothing.
+//
+// This is a constant factor, NOT a fix: the bind is still O(archived files) and
+// returns to a timeout as the archive grows. #1535 carries the measurements and
+// the design that bounds it by distinct schemas instead.
+//
+// A func var so tests can pin the value and observe that it was consulted at
+// all — the setting is deliberately restored, so its effect cannot be read back
+// off the finished session.
+var sqlPanelBindThreads = defaultBindThreads
+
+// defaultBindThreads scales the bind-time concurrency with the host rather than
+// pinning a number measured on one laptop. The ceiling matters more than the
+// slope: these threads are waiting on S3, so a one-core container has no reason
+// to hold only one in flight, and no host has a reason to open 64.
+func defaultBindThreads() int {
+	return min(16, 8*runtime.NumCPU())
+}
 
 // forensicsEventColumns are the paid-tier forensics columns the console must
 // NOT serve as row data: the SAME set eventDTO omits (connection_id is the free
@@ -669,6 +702,22 @@ func openSandboxedSession(ctx context.Context, in views.Input, only views.ViewSe
 	// Empty means the statement needs no view; DuckDB answers an empty script
 	// with "empty query", so there is nothing to run rather than nothing to say.
 	if ddl != "" {
+		// Bind-time concurrency, held only across the DDL — see
+		// sqlPanelBindThreads. Unconditional rather than scoped to an S3
+		// layout: the bind opens one footer per file either way, so the thread
+		// count does not change how much CPU that costs, only how much of the
+		// waiting overlaps. The sustained parallel scan is the QUERY, and the
+		// sandbox below puts it back under the daemon budget before it runs.
+		//
+		// Best-effort on purpose, and the ONE statement here that is: every
+		// other one is a sandbox bound, where a silent failure would leave a
+		// carve-out open. This is a speed knob, and a session that binds slowly
+		// is strictly better than a request that fails because a SET did not
+		// apply.
+		n := sqlPanelBindThreads()
+		if _, err := db.ExecContext(ctx, fmt.Sprintf("SET threads = %d", n)); err != nil {
+			slog.Warn("sql panel: could not widen threads for the view bind; it will bind at the daemon budget and may exceed the setup timeout on a large archive", "threads", n, "error", err)
+		}
 		if _, err := db.ExecContext(ctx, ddl); err != nil {
 			return fail(fmt.Errorf("set up views over the Parquet layout: %w", err))
 		}

--- a/internal/console/sqlpanel_bindthreads_test.go
+++ b/internal/console/sqlpanel_bindthreads_test.go
@@ -1,0 +1,99 @@
+package console
+
+import (
+	"context"
+	"runtime"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/duckdbutil"
+	"github.com/dbtrail/dbtrail/internal/views"
+)
+
+// The view DDL binds a Parquet footer per file in the layout, which is latency,
+// not CPU (#1535). The panel widens DuckDB's thread count across that bind and
+// the sandbox puts the daemon budget back before the user's statement runs.
+//
+// Both halves need a guard, and they fail in opposite directions: without the
+// widen the bind runs at the daemon budget and a large archive times out;
+// without the restore the user's statement executes on a wide pool in a process
+// that may also be capturing. The restore half is readable off the finished
+// session. The widen half is NOT — it is deliberately overwritten a few
+// statements later — which is why sqlPanelBindThreads is a func var: consulting
+// it is the only observable trace that the widen ran at all.
+
+// TestSQLPanelBindWidensThreadsThenRestoresTheDaemonBudget drives the real
+// openSandboxedSession over a real local baseline and asserts both halves.
+func TestSQLPanelBindWidensThreadsThenRestoresTheDaemonBudget(t *testing.T) {
+	baselineRoot, baselinePath := writeSQLPanelBaseline(t)
+
+	consulted := 0
+	orig := sqlPanelBindThreads
+	sqlPanelBindThreads = func() int { consulted++; return 9 }
+	t.Cleanup(func() { sqlPanelBindThreads = orig })
+
+	db, cleanup, err := openSandboxedSession(context.Background(),
+		panelInput(nil, baselineRoot, baselinePath), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	if consulted != 1 {
+		t.Errorf("bind-thread count consulted %d times, want exactly 1: the widen "+
+			"before the view DDL is what keeps a large archive inside the setup "+
+			"timeout", consulted)
+	}
+
+	// The value the SESSION ends on, which is the one the user's statement runs
+	// under. Asserted against the daemon budget rather than against 9, so the
+	// test fails if the widen leaks past the sandbox.
+	var got int
+	if err := db.QueryRow(`SELECT current_setting('threads')`).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if want := duckdbutil.DefaultTuning().Threads; got != want {
+		t.Errorf("session executes statements with threads = %d, want the daemon "+
+			"budget %d: the bind widening must not survive into the query", got, want)
+	}
+}
+
+// TestSQLPanelBindThreadsUntouchedWithNoDDL pins the widen INSIDE the
+// build-the-views branch. A statement that names no view (SELECT 1) builds
+// nothing, so there is no footer to read and no reason to touch the pool.
+func TestSQLPanelBindThreadsUntouchedWithNoDDL(t *testing.T) {
+	baselineRoot, baselinePath := writeSQLPanelBaseline(t)
+
+	consulted := 0
+	orig := sqlPanelBindThreads
+	sqlPanelBindThreads = func() int { consulted++; return 9 }
+	t.Cleanup(func() { sqlPanelBindThreads = orig })
+
+	_, cleanup, err := openSandboxedSession(context.Background(),
+		panelInput(nil, baselineRoot, baselinePath), views.ViewSet{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	if consulted != 0 {
+		t.Errorf("bind-thread count consulted %d times for a session that builds "+
+			"no view, want 0", consulted)
+	}
+}
+
+// TestDefaultBindThreads pins the two properties the ceiling exists for: a
+// one-core container still overlaps more than one S3 round trip, and no host
+// opens an unbounded number of them.
+func TestDefaultBindThreads(t *testing.T) {
+	got := defaultBindThreads()
+	if got < 2 {
+		t.Errorf("defaultBindThreads() = %d on a %d-core host; below 2 the bind "+
+			"overlaps nothing and is the state #1535 measured at 124.9s",
+			got, runtime.NumCPU())
+	}
+	if got > 16 {
+		t.Errorf("defaultBindThreads() = %d, want at most 16: these threads wait "+
+			"on object storage, and the ceiling is what keeps a large host from "+
+			"opening an unbounded number of reads", got)
+	}
+}


### PR DESCRIPTION
Closes part of #1535 (the constant-factor half).

## What was wrong

`select * from events limit 1` in the SQL panel failed after ~47s with
`set up views over the Parquet layout: context deadline exceeded`. The query
never ran; the time went into `CREATE VIEW`.

`union_by_name = true` makes DuckDB open one Parquet footer per file in the
layout to compute the unified schema, and over an S3 archive each of those is a
network round trip. The DDL runs before the sandbox `SET`s (deliberately, so the
glob resolves while the session is unlocked), so it inherited whatever DuckDB
defaults to, which on a small daemon host is a couple of threads.

## What changed

The thread count is widened across the DDL only. The sandbox's existing
`SET threads` is the restore, and it already sits ahead of `lock_configuration`,
so the user's statement runs under the daemon budget as before.

Widening is safe here because binding is latency, not compute. Measured on one
real archive source of 164 files, varying only this setting:

| threads | wall | user CPU |
|---|---|---|
| 1 | 124.9s | 3.0s |
| 2 | 60.2s | 2.8s |
| 8 | 15.8s | 3.3s |
| 16 | 8.1s | 2.7s |
| 32 | 4.5s | 2.2s |

CPU is flat across the whole range. The threads are waiting on object storage,
so this buys wall-clock without taking CPU from a process that may also be
capturing. The sustained parallel scan is the query, and that keeps the 2-thread
budget.

`defaultBindThreads` is `min(16, 8*NumCPU)`: a one-core container still overlaps
more than one round trip, and no host opens an unbounded number.

## Honest limits

This is a constant factor. The bind is still O(archived files) and returns to a
timeout as the archive grows. #1535 keeps the measurements and the design that
bounds it by distinct schemas (recording the column set per partition in
`archive_state`, backfillable by `archive reconcile` since #392 makes it a
rebuildable cache).

## Guards

`sqlPanelBindThreads` is a func var because the widen is deliberately overwritten
a few statements later, so consulting it is the only observable trace that it
ran. Three mutations, each seen red before green:

| mutation | result |
|---|---|
| delete the widen | `--- FAIL` bind-thread count consulted 0 times, want exactly 1 |
| delete the sandbox restore | `--- FAIL` session executes statements with threads = 9, want the daemon budget 2 |
| hoist the widen out of the `if ddl != ""` branch | `--- FAIL` consulted 1 times for a session that builds no view, want 0 |

Note the second mutation initially reported SURVIVED because the edit matched the
identical `SET threads` line in `openParseSession` instead of the sandbox. It was
re-applied to the right site to get the failure above.

Full `internal/console` suite green (27.6s); `go vet` clean.