### PR TITLE
Split the Storage page, and move two cards to the pages they belong to (#1543)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **The Storage page is split in two, and two of its cards moved to the pages
+  they belong to** (#1543, part of #1528). Storage had become a drawer: seven
+  cards from five unrelated concerns, on a page you had to read rather than
+  use. It is now **Retention** (the rotation policy and per-source S3
+  archiving: what happens to your data as it ages) and **This daemon** (AWS
+  credential signals, staged downloads and the telemetry opt-out: what this
+  process can reach, is holding, and sends). *File reuse for unchanged tables*
+  is now **Backups & disk space** and lives on the Backups page directly under
+  **Scheduled backups** — the two names both promised "backups,
+  automatically" from different pages for unrelated settings, and side by side
+  under names that say what each does, the difference needs no paragraph. The
+  *Download a DuckDB schema* card moved to the SQL page, which queries the
+  same data. The Backups summary card is gone: Backups has its own sidebar
+  entry, and the pointer existed only because the page it pointed away from
+  was a drawer. Existing `/storage` links still work and land on Retention.
+
+### Changed
 - **A scheduled backup on a server whose backups go to S3 no longer forces a
   full read of your database every slot** (#1539). The daemon has two ways to
   produce a backup: a full one it dumps from the source, and an update of the

--- a/docs/console.md
+++ b/docs/console.md
@@ -195,7 +195,7 @@ and searching events:
    **Verification** (run
    `bintrail verify` and read past runs). These produce and validate the
    artifacts a restore depends on, so they are operations rather than
-   settings; they lived on the Storage page until they outgrew it.
+   settings; they lived on the old Storage page until they outgrew it.
    A staged `.sql` build does not stay on disk: it is removed as soon as a
    download completes, 4 hours after the build finished if nobody
    downloaded it (the Ready line shows the deadline and the size), when a
@@ -205,13 +205,13 @@ and searching events:
    why, and the daemon retries every minute. If a new build starts and the
    previous one cannot be removed, the new build still runs and stays
    downloadable; its status names the previous build's directory until that
-   removal succeeds. The Storage page shows what is staged while it exists,
-   previous builds that could not be removed included.
-8. **Settings** (under `watch` only) — **Storage** (rotation policy,
-   per-source S3 archiving, a baseline summary card, AWS credential signals,
-   and a usage-telemetry opt-out — see
-   [The Storage page](#the-storage-page)) and **Rotation** (opens the
-   rotation dialog).
+   removal succeeds. The This daemon page shows what is staged while it
+   exists, previous builds that could not be removed included.
+8. **Settings** (under `watch` only) — **Retention** (rotation policy and
+   per-source S3 archiving), **This daemon** (AWS credential signals, staged
+   downloads and a usage-telemetry opt-out — see
+   [The Retention and This daemon pages](#the-retention-and-this-daemon-pages))
+   and **Rotation** (opens the rotation dialog).
 
 Every view whose subject has a page on www.dbtrail.com/docs (Events, Restore,
 Backups, Verification, Storage, Connect AI) shows a small **Docs** link beside
@@ -412,7 +412,7 @@ editing flags or restarting:
 ### The Protect pages
 
 Under `watch` the sidebar carries a **Protect** group with two pages. They were
-part of the Storage page until they outgrew it: both are operations that
+part of the old Storage page until they outgrew it: both are operations that
 produce and validate the artifacts a restore depends on, rather than settings,
 and the snapshot listing is unbounded in practice — it pushed verification, the
 panel that answers whether a restore would work, far below the fold.
@@ -499,39 +499,59 @@ panel that answers whether a restore would work, far below the fold.
 **Protect → Verification** carries the verification runner and the history of
 past runs for the selected server.
 
-The Storage page keeps a compact **Baselines** summary card (count and age)
-alongside the rest of the storage picture.
+The Backups summary card that used to point here from Storage is gone (#1543):
+Backups has its own entry in the same sidebar, and the pointer only existed
+because the page it pointed away from was a drawer.
 
-### The Storage page
+### The Retention and This daemon pages
 
-Under `watch` the sidebar grows a **Settings → Storage** page that gathers
-storage policy in one place (it was previously scattered across the rotation
-dialog and the per-server edit form). The full baseline listing and the
-verification runner moved to their own **Protect** group; Storage keeps a
-compact baseline summary card and links onward:
+Under `watch` the sidebar grows two settings pages. They were one page,
+Storage, which had become a drawer: seven cards from five unrelated concerns
+(#1543). They are split by the question each answers.
+
+**Retention** — what happens to your data as it ages:
 
 - **Rotation** — the effective policy (override vs daemon defaults) with an
   edit shortcut to the rotation dialog.
-- **File reuse for unchanged tables** (#1528, formerly *Automatic backup
-  refresh*) — the one storage behaviour behind
+- **S3 archiving per source** — every monitored server with its
+  `Archive to S3` destination (or `drop-only` when none), with a shortcut into
+  that server's edit form. The boot (cli) index always rotates drop-only.
+
+**This daemon** — what this process can reach, is holding, and sends:
+
+- **AWS credentials** — which credential signals this process sees. Presence
+  and the non-secret profile and region names only; no value is ever shown or
+  stored.
+- **Staged downloads**, and **Usage telemetry**, both described below.
+
+Two cards left the page entirely. **Backups & disk space** moved to the
+Backups page, beside the **Scheduled backups** it was being confused with:
+those two names both promised "backups, automatically" from different pages,
+for unrelated settings, and side by side the difference needs no paragraph.
+**Download a DuckDB schema** moved to the SQL page, which queries the same
+data. The old `/storage` link still works and lands on Retention.
+
+- **Backups & disk space** (#1528/#1543, formerly *File reuse for unchanged
+  tables*, and before that *Automatic backup refresh*) — the one behaviour
+  behind
   `--baseline-carry-forward-unchanged`: whether a table with no changes in the
   window keeps its previous Parquet file instead of being written again. It has
-  no timetable in it, which the old name promised and which **Scheduled
-  backups** on the Backups page actually is. The saving is real and it is not
-  free: where the filesystem allows a hard link, two backups then
-  share the same bytes on disk, so deleting the older one frees nothing while
-  the newer one still points at it, and a `du` per snapshot directory
-  double-counts it (one `du` over the baseline root reports the truth). The setting is
-  **process-global** (`GET`/`PUT /api/baseline-refresh`), which is why it stays
-  on this page rather than moving beside the per-server schedule it used to be
-  confused with. It is consumed by the daemon-wide refresh interval, by the
+  no timetable in it, which the first name promised and which **Scheduled
+  backups**, now directly above it, actually is. The saving is real and it is
+  not free, which is what the name says: where the filesystem allows a hard
+  link, two backups then share the same bytes on disk, so deleting the older
+  one frees nothing while the newer one still points at it, and a `du` per
+  snapshot directory double-counts it (one `du` over the baseline root reports
+  the truth). It does not apply when the previous snapshot is read from S3,
+  which is what a per-server schedule on an S3-backed server does: linking a
+  file needs both ends on a filesystem, so those runs take the ordinary path
+  and the daemon log says so. The setting is
+  **process-global** (`GET`/`PUT /api/baseline-refresh`) even though it sits
+  beside a per-server schedule; the card says so. It is consumed by the daemon-wide refresh interval, by the
   per-server backup schedules, and by point-in-time restores; the card says
   which of those are live. Saving here overrides the daemon flag without a
   restart, and a **Use the daemon setting** button then clears the override.
   See [dump-and-baseline.md](dump-and-baseline.md#refreshing-on-a-schedule).
-- **S3 archiving per source** — every monitored server with its
-  `Archive to S3` destination (or `drop-only` when none), with a shortcut into
-  that server's edit form. The boot (cli) index always rotates drop-only.
 - **Staged downloads**: the `.sql` backups built from the Backups page that
   are waiting on the daemon's disk for their download: each build's server,
   size and download deadline, the total, and where they live. A build is
@@ -540,7 +560,7 @@ compact baseline summary card and links onward:
   could not be removed stays listed with the reason (a previous build a
   newer one could not clear included) and is retried every minute. Shown
   only on a daemon that can build `.sql` backups.
-- **Download a DuckDB schema** (#1528, formerly *Query in DuckDB*) — a one-click download of `views.sql`: a ready-made
+- **Download a DuckDB schema** (#1528, formerly *Query in DuckDB*; on the SQL page since #1543) — a one-click download of `views.sql`: a ready-made
   DuckDB schema over the selected server's own Parquet — an `events` view
   across every archive source registered in `archive_state`, plus one
   `state_<schema>_<table>` view per table in the newest baseline snapshot. It

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -244,7 +244,7 @@ What a stale compose file costs:
 | What your file is missing | What it costs | How it looks |
 |---|---|---|
 | the console state paths on the `bintrail-state` volume | your console username and password, the servers you added, and the AI connection token live inside the container, so the next `up -d` that recreates it deletes them | **Silent.** The console comes back asking you to create a password, exactly like a fresh install, and reports no loss. Fix this one first |
-| the read-only index mount plus `BINTRAIL_INDEX_DATADIR_RO` | free disk space for the index cannot be measured | The preflight and the Storage page report it as not measurable |
+| the read-only index mount plus `BINTRAIL_INDEX_DATADIR_RO` | free disk space for the index cannot be measured | The preflight and the Retention page report it as not measurable |
 | the `iceberg-export` profile and its volume | there is no one-shot Iceberg export to run | `docker compose --profile iceberg-export run ...` says the service does not exist |
 | `BINTRAIL_CONSOLE_SQL_PANEL` (the current file does not set it) | nothing: the SQL page is on by default in the daemon | If you kept `SQL_PANEL=0` in `.env` to hide the page, the current file ignores it. Add `BINTRAIL_CONSOLE_SQL_PANEL: "0"` to the `bintrail` service instead |
 

--- a/docs/dump-and-baseline.md
+++ b/docs/dump-and-baseline.md
@@ -438,7 +438,7 @@ These properties are deliberate:
   | `bintrail baseline refresh` | `--carry-forward-unchanged` |
   | `bintrail reconstruct --output-format parquet` | `--carry-forward-unchanged` |
   | `bintrail-console watch` | `--baseline-carry-forward-unchanged`, or `BINTRAIL_BASELINE_CARRY_FORWARD_UNCHANGED` (a true/false value: `1`, `true`, `0`, `false`) |
-  | Console | Settings, Storage, the **File reuse for unchanged tables** card |
+  | Console | Backups, the **Backups & disk space** card, beside the schedule |
 
   The console setting overrides the daemon flag and applies on the next cycle without a restart. Once you have saved one there, the card grows a **Use the daemon setting** button that clears it again.
 

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -49,7 +49,12 @@ const EVENT_EXPORT_MAX = 1000;
 const BADGE_CLASS = { UPDATE: "b-update", INSERT: "b-insert", DELETE: "b-delete" };
 function badgeClass(t) { return BADGE_CLASS[t] || "b-baseline"; }
 
-const ROUTES = ["overview", "events", "schema-changes", "timetravel", "recover", "sql", "status", "storage", "connect",
+const ROUTES = ["overview", "events", "schema-changes", "timetravel", "recover", "sql", "status", "storage",
+  // Storage was a drawer: seven cards from five unrelated concerns (#1543).
+  // Split by the question each half answers — what happens to your data over
+  // time, and what this daemon is touching. "storage" stays a KNOWN route so
+  // old bookmarks and Back entries land on Retention instead of Overview.
+  "retention", "daemon", "connect",
   // Access profiles (#1445): author the flags/profiles/rules a data profile
   // enforces. Not monitor-gated: the standalone serve can author too, the
   // write goes to the selected server's index, not to daemon state.
@@ -867,8 +872,12 @@ function navigate(route, params, push = true) {
   // Time-travel merged into Restore (#1298). The route stays known so old
   // bookmarks and Back entries land somewhere useful instead of on Overview.
   if (route === "timetravel") route = "recover";
-  // Storage is a watch-daemon surface (rotation + archiving live there).
-  if (route === "storage" && !capsCache.monitor) route = "overview";
+  // Storage split into Retention and This daemon (#1543). The old route is
+  // rewritten rather than merely aliased, so the address bar stops naming a
+  // page that no longer exists.
+  if (route === "storage") { route = "retention"; history.replaceState({}, "", "/retention"); }
+  // Both halves are watch-daemon surfaces (rotation, archiving, staging).
+  if ((route === "retention" || route === "daemon") && !capsCache.monitor) route = "overview";
   // Protect shares that gate: both routes read watch-daemon state (the
   // snapshot listing and the verification runner). Same treatment, so a
   // bookmark to either lands on Overview rather than an empty page.
@@ -921,7 +930,8 @@ function renderRoute() {
     case "recover": return renderRecover(params);
     case "sql": return renderSQL();
     case "status": return renderStatus();
-    case "storage": return renderStorage();
+    case "retention": return renderRetention();
+    case "daemon": return renderDaemon();
     case "baselines": return renderBaselines();
     case "verification": return renderVerification();
     case "connect": return renderConnect();
@@ -3760,7 +3770,7 @@ function updateSideMeta(status) {
 
 // ── Storage (rotation · S3 archiving · credentials · telemetry) ──────────────
 
-async function renderStorage() {
+async function renderRetention() {
   // Gated like Time-travel: a direct URL / Back with the capability off must
   // REWRITE the URL (replaceState) before re-dispatching — see renderTimetravel.
   if (!capsCache.monitor) { history.replaceState({}, "", "/overview"); renderRoute(); return; }
@@ -3770,64 +3780,79 @@ async function renderStorage() {
   // instead of one error wiping the whole page. (A 401 inside api() raises the
   // sign-in gate and bumps serverGen, so the stale-render guard below bails.)
   const asErr = (err) => ({ error: (err && err.message) || String(err) });
-  const [serversRes, rotation, backupRefresh, storage, baselines, telemetry] = await Promise.all([
+  const [serversRes, rotation] = await Promise.all([
     api("/api/servers").catch(asErr),
     api("/api/rotation").catch(asErr),
-    api("/api/baseline-refresh").catch(asErr),
-    api("/api/storage").catch(asErr),
-    api("/api/baselines").catch(asErr),
-    api("/api/telemetry").catch(asErr),
   ]);
   if (gen !== serverGen || vgen !== viewGen) return;
   // Same guard as renderOverview: a throw inside the build must show an
   // error, never leave the "Loading…" skeleton up forever.
   try {
-    buildStorage(serversRes, rotation, backupRefresh, storage, baselines, telemetry);
+    buildRetention(serversRes, rotation);
   } catch (err) {
-    const v = VIEW(); clear(v); v.append(pageHead("Storage", null)); renderError(v, err);
+    const v = VIEW(); clear(v); v.append(pageHead("Retention", null)); renderError(v, err);
   }
 }
 
-function buildStorage(serversRes, rotation, backupRefresh, storage, baselines, telemetry) {
+// Retention answers one question: what happens to your data as it ages. The
+// rotation policy decides when index partitions are archived and dropped, and
+// the archiving panel says where each source's archives go. Nothing else on
+// the old Storage page answered that (#1543).
+function buildRetention(serversRes, rotation) {
   // serversRes is the raw /api/servers payload or {error} — archivingPanel
   // must be able to tell "failed to load" from "genuinely no sources", or a
   // transient 500 would render the affirmative "No monitored sources yet" lie.
   const servers = (serversRes && serversRes.servers) || [];
   const serversErr = serversRes && serversRes.error;
   const v = VIEW(); clear(v);
-  const sub = el("p", { class: "page-sub" },
-    "Where old data goes, how long it's kept, and the snapshots Time-travel uses. ",
-    el("b", { text: "No credentials are stored here." }));
-  v.append(pageHead("Storage", sub));
+  v.append(pageHead("Retention", el("p", { class: "page-sub" },
+    "How long indexed data is kept, and where it goes when it ages out.")));
 
   const cards = el("div", { class: "cards" });
-  const cur = servers.find((s) => s.id === (currentServer || defaultServerId));
-  // Order (#1528): what this daemon does with your data first (rotation,
-  // file reuse), then where it reaches and what it is holding (credentials,
-  // staged downloads), then the pointer onward, then the two cards that are
-  // about neither storage nor this page. This page is still a drawer; the
-  // split is proposed in the issue, and the order is what is safe to change
-  // without moving a route. The tint rotation is positional, so the first two
-  // cards must stay two DIFFERENT unconditional cards.
   cards.append(rotationCard(rotation));
-  cards.append(backupRefreshCard(backupRefresh));
-  cards.append(credentialsCard(storage));
-  const staging = stagingCard(storage, servers);
-  if (staging) cards.append(staging);
-  cards.append(baselineSummaryCard(baselines, cur, { linkOnward: true }));
-  if (capsCache.views) cards.append(duckdbCard());
-  cards.append(telemetryCard(telemetry));
   v.append(cards);
 
-  // Storage keeps storage POLICY. Baselines and verification moved to their
-  // own routes (#1384): the snapshot list is unbounded, so it used to push
-  // verification off the fold inside a grid built for two panels (the
-  // verification builder is verifyRegions since #1419). baselineSummaryCard
-  // stays as the pointer — the count and age belong on a storage overview,
-  // the full list does not.
   const grid = el("div", { class: "ov-grid", style: "margin-top:18px" });
   grid.append(archivingPanel(servers, serversErr));
   v.append(grid);
+  viewEnter();
+}
+
+async function renderDaemon() {
+  if (!capsCache.monitor) { history.replaceState({}, "", "/overview"); renderRoute(); return; }
+  const gen = serverGen, vgen = viewGen;
+  viewLoading();
+  const asErr = (err) => ({ error: (err && err.message) || String(err) });
+  const [serversRes, storage, telemetry] = await Promise.all([
+    api("/api/servers").catch(asErr),
+    api("/api/storage").catch(asErr),
+    api("/api/telemetry").catch(asErr),
+  ]);
+  if (gen !== serverGen || vgen !== viewGen) return;
+  try {
+    buildDaemon(serversRes, storage, telemetry);
+  } catch (err) {
+    const v = VIEW(); clear(v); v.append(pageHead("This daemon", null)); renderError(v, err);
+  }
+}
+
+// This daemon answers the other question the old Storage page mixed in: what
+// is THIS process reaching, holding and sending. All three are properties of
+// the machine, not of your data, which is why they read as noise beside a
+// retention policy and as a coherent page here (#1543).
+function buildDaemon(serversRes, storage, telemetry) {
+  const servers = (serversRes && serversRes.servers) || [];
+  const v = VIEW(); clear(v);
+  v.append(pageHead("This daemon", el("p", { class: "page-sub" },
+    "What this daemon can reach, what it is holding on disk, and what it sends. ",
+    el("b", { text: "No credentials are stored here." }))));
+
+  const cards = el("div", { class: "cards" });
+  cards.append(credentialsCard(storage));
+  const staging = stagingCard(storage, servers);
+  if (staging) cards.append(staging);
+  cards.append(telemetryCard(telemetry));
+  v.append(cards);
   viewEnter();
 }
 
@@ -3845,9 +3870,13 @@ async function renderBaselines() {
   // Independent degradation, as on Storage: a panel renders its own failure
   // note rather than one error blanking the page.
   const asErr = (err) => ({ error: (err && err.message) || String(err) });
-  const [serversRes, baselines] = await Promise.all([
+  const [serversRes, baselines, backupRefresh] = await Promise.all([
     api("/api/servers").catch(asErr),
     api("/api/baselines").catch(asErr),
+    // File reuse moved here from Storage (#1528/#1543): it decides how a
+    // backup is PRODUCED, so it belongs beside the schedule it was being
+    // confused with, not on a page about where old data goes.
+    api("/api/baseline-refresh").catch(asErr),
   ]);
   if (gen !== serverGen || vgen !== viewGen) return;
   // Run states for the selected server: only the endpoints this daemon
@@ -3883,6 +3912,12 @@ async function renderBaselines() {
     // anything.
     const scheduleCard = backupScheduleCard(cur, baselines);
     if (scheduleCard) v.append(scheduleCard);
+    // Directly under the schedule, because the two were the pair #1528 named:
+    // "Automatic backup refresh" and "Scheduled backups" both promised
+    // "backups, automatically" from different pages, for unrelated settings.
+    // Side by side, under names that say what each does, the difference needs
+    // no paragraph.
+    v.append(el("div", { class: "cards" }, backupRefreshCard(backupRefresh)));
     // A visible in-progress region (mirrors the verification page): while a
     // backup is being created or restored, the page must look like a page
     // doing work, not a stale list.
@@ -3979,7 +4014,7 @@ function rotationCard(rot) {
 // disk, where the filesystem allows it) is a thing a reader wants while
 // reading docs, not while flipping the switch: docs/console.md carries it.
 function backupRefreshCard(br) {
-  const card = el("div", { class: "card" }, el("div", { class: "card-title", text: "File reuse for unchanged tables" }));
+  const card = el("div", { class: "card" }, el("div", { class: "card-title", text: "Backups & disk space" }));
   if (!br || br.error) {
     card.append(el("p", { class: "form-hint", text: "Could not load the reuse setting" + (br && br.error ? ": " + br.error : ".") }));
     return card;
@@ -4228,6 +4263,10 @@ async function renderSQL() {
 
   const results = el("div", { id: "sql-results" });
   v.append(results);
+  // Moved from Storage (#1543): it generates the view definitions for the
+  // SAME data this page queries, for a client that is not this page. It read
+  // as a storage setting only because Storage was where unplaced cards went.
+  if (capsCache.views) v.append(el("div", { class: "cards", style: "margin-top:18px" }, duckdbCard()));
   viewEnter();
 
   const run = () => runSQL(input.value, { runBtn, cancelBtn, statusLine, results });
@@ -4376,41 +4415,7 @@ async function setTelemetry(enabled) {
     return;
   }
   toast(enabled ? "Telemetry turned on." : "Telemetry turned off. This daemon stops sending now.");
-  renderStorage();
-}
-
-// On Storage this card is the POINTER to Protect > Baselines, so it carries a
-// link there — docs/console.md says it "links onward" and, before this, it did
-// not. On the Baselines page itself the link would point at the current page,
-// so the caller omits it.
-function baselineSummaryCard(b, cur, opts) {
-  const card = el("div", { class: "card" }, el("div", { class: "card-title", text: "Backups" }));
-  // Appended at every exit, so the link is the card's FOOT rather than sitting
-  // above an error message. Every branch returns through here.
-  const done = () => {
-    if (opts && opts.linkOnward) {
-      card.append(el("div", { class: "stg-cardfoot" },
-        el("button", { class: "btn btn-sm", type: "button", text: "All snapshots \u2192",
-          onclick: () => navigate("baselines") })));
-    }
-    return card;
-  };
-  if (!b || b.error) {
-    card.append(el("p", { class: "form-hint", text: "Could not list backups: " + ((b && b.error) || "unavailable") }));
-    return done();
-  }
-  if (!b.configured) {
-    kvRow(card, "source", "not configured");
-    kvRow(card, "time-travel", "off");
-    return done();
-  }
-  const snaps = b.snapshots || [];
-  kvRow(card, "source", b.source);
-  kvRow(card, "snapshots", String(snaps.length) + (b.truncated ? "+" : ""));
-  kvRow(card, "latest (UTC)", snaps.length ? snaps[0].time : "none yet");
-  if (snaps.length) kvRow(card, "age", formatAge(snaps[0].age_hours));
-  kvRow(card, "time-travel", b.reconstruct ? "enabled" : "off (archives disabled)");
-  return done();
+  renderDaemon();
 }
 
 // baselineConfigHint: the boot (cli) entry is not editable from the UI — its
@@ -7818,7 +7823,8 @@ function cmdkCommands() {
   if (capsCache.sql) cmds.push({ group: "Navigate", label: "SQL", run: () => navigate("sql") });
   if (capsCache.monitor) cmds.push({ group: "Navigate", label: "Backups", run: () => navigate("baselines") });
   if (capsCache.monitor) cmds.push({ group: "Navigate", label: "Verification", run: () => navigate("verification") });
-  if (capsCache.monitor) cmds.push({ group: "Navigate", label: "Storage", run: () => navigate("storage") });
+  if (capsCache.monitor) cmds.push({ group: "Navigate", label: "Retention", run: () => navigate("retention") });
+  if (capsCache.monitor) cmds.push({ group: "Navigate", label: "This daemon", run: () => navigate("daemon") });
   cmds.push({ group: "Navigate", label: "Access profiles", run: () => navigate("access-profiles") });
   cmds.push({ group: "Navigate", label: "Connect AI", run: () => navigate("connect") });
   cmds.push({ group: "Actions", label: "Manage servers", run: () => { closeCmdk(); openServersModal(); } });

--- a/internal/console/assets/index.html
+++ b/internal/console/assets/index.html
@@ -132,9 +132,17 @@
             <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 11h-6"/><path d="M19 8v6"/></svg></span>
             <span>Access profiles</span>
           </a>
-          <a class="nav-item" data-route="storage" href="/storage" data-capability="monitor">
+          <!-- Storage was a drawer of five unrelated concerns (#1543). Split
+               by the question each half answers: what happens to your data
+               over time, and what this daemon is touching. /storage stays a
+               known route in app.js and rewrites to /retention. -->
+          <a class="nav-item" data-route="retention" href="/retention" data-capability="monitor">
             <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="8" ry="3"/><path d="M4 5v14c0 1.66 3.58 3 8 3s8-1.34 8-3V5"/><path d="M4 12c0 1.66 3.58 3 8 3s8-1.34 8-3"/></svg></span>
-            <span>Storage</span>
+            <span>Retention</span>
+          </a>
+          <a class="nav-item" data-route="daemon" href="/daemon" data-capability="monitor">
+            <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="7" rx="2"/><rect x="2" y="14" width="20" height="6" rx="2"/><path d="M6 7.5h.01M6 17h.01"/></svg></span>
+            <span>This daemon</span>
           </a>
           <button class="nav-item" id="nav-rotation" type="button" data-capability="monitor">
             <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 0 1 15.5-6.2L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-15.5 6.2L3 16"/><path d="M3 21v-5h5"/></svg></span>

--- a/internal/console/assets_backuprefresh_test.go
+++ b/internal/console/assets_backuprefresh_test.go
@@ -177,22 +177,81 @@ func TestBackupRefreshWireNamesMatchTheFrontend(t *testing.T) {
 	}
 }
 
-// TestStoragePanelStillMountsTheRefreshCard: the card can be unmounted, or its
+// TestBackupsPageStillMountsTheRefreshCard: the card can be unmounted, or its
 // fetch removed, with the whole suite green.
 //
 // The two guards above check what the card renders once it is called. Neither
-// notices if nothing calls it: dropping the append makes the settings panel
-// vanish, and dropping the fetch makes it render its error branch forever. A
-// setting an operator cannot reach is the same as a setting that does not
-// exist.
-func TestStoragePanelStillMountsTheRefreshCard(t *testing.T) {
-	body := jsFunctionBody(t, readAsset(t, "app.js"), "buildStorage")
-	if !strings.Contains(body, "backupRefreshCard(") {
-		t.Error("buildStorage no longer mounts backupRefreshCard, so the reuse setting has no UI at all")
-	}
+// notices if nothing calls it: dropping the append makes the setting vanish,
+// and dropping the fetch makes it render its error branch forever. A setting
+// an operator cannot reach is the same as a setting that does not exist.
+//
+// It moved from Storage to Backups (#1543), beside the schedule it was being
+// confused with, which is the pairing #1528 asked for. The guard follows the
+// card rather than the page, and it checks the page it is ON so the move
+// cannot be half-done: a card mounted on neither page passes a guard that
+// only asks "does some function call it".
+func TestBackupsPageStillMountsTheRefreshCard(t *testing.T) {
 	js := readAsset(t, "app.js")
-	if !strings.Contains(js, `api("/api/baseline-refresh")`) {
-		t.Error("nothing fetches /api/baseline-refresh, so the card can only ever render its error branch")
+	body := jsFunctionBody(t, js, "renderBaselines")
+	if !strings.Contains(body, "backupRefreshCard(") {
+		t.Error("the Backups page no longer mounts backupRefreshCard, so the reuse setting has no UI at all")
+	}
+	// Beside the schedule, not somewhere else on the page: the whole reason
+	// for the move is that the two controls have to be read together.
+	sched, reuse := strings.Index(body, "backupScheduleCard("), strings.Index(body, "backupRefreshCard(")
+	if sched < 0 {
+		t.Fatal("the schedule card is gone from the Backups page; this guard can no longer check the pairing")
+	}
+	if reuse < sched && reuse >= 0 {
+		t.Error("file reuse is mounted above the schedule; #1528 pairs them in that order so the timetable reads first")
+	}
+	if !strings.Contains(body, `api("/api/baseline-refresh")`) {
+		t.Error("the Backups page does not fetch /api/baseline-refresh, so the card can only ever render its error branch")
+	}
+}
+
+// The split itself (#1543): Storage held seven cards from five concerns, and
+// the two halves answer different questions. A card that drifts back, or a
+// half that quietly absorbs the other, is the failure this guards.
+func TestStorageSplit_eachHalfHoldsOnlyItsOwnConcern(t *testing.T) {
+	js := readAsset(t, "app.js")
+	if strings.Contains(js, "function buildStorage(") {
+		t.Fatal("buildStorage is back; Storage was split into Retention and This daemon (#1543)")
+	}
+	for _, tc := range []struct {
+		fn    string
+		want  []string
+		never []string
+	}{
+		// What happens to your data over time. Nothing about this process.
+		{"buildRetention", []string{"rotationCard(", "archivingPanel("},
+			[]string{"credentialsCard(", "stagingCard(", "telemetryCard(", "backupRefreshCard(", "duckdbCard("}},
+		// What this process is reaching, holding and sending. Nothing about
+		// the data lifecycle.
+		{"buildDaemon", []string{"credentialsCard(", "stagingCard(", "telemetryCard("},
+			[]string{"rotationCard(", "archivingPanel(", "backupRefreshCard(", "duckdbCard("}},
+	} {
+		body := jsFunctionBody(t, js, tc.fn)
+		for _, w := range tc.want {
+			if !strings.Contains(body, w) {
+				t.Errorf("%s does not mount %s, so that card is unreachable", tc.fn, w)
+			}
+		}
+		for _, n := range tc.never {
+			if strings.Contains(body, n) {
+				t.Errorf("%s mounts %s, which belongs to the other half; the page is a drawer again", tc.fn, n)
+			}
+		}
+	}
+	// The old route must keep resolving, or every existing link and bookmark
+	// lands on Overview with no explanation.
+	if !strings.Contains(js, `route === "storage"`) {
+		t.Error("nothing handles the old /storage route, so existing links break")
+	}
+	// And the DuckDB schema download has to be ON the page that queries the
+	// same data, not merely absent from the two halves above.
+	if !strings.Contains(jsFunctionBody(t, js, "renderSQL"), "duckdbCard(") {
+		t.Error("the SQL page does not mount duckdbCard, so it moved off Storage to nowhere")
 	}
 }
 
@@ -220,8 +279,17 @@ func TestBackupRefreshCard_titleSaysWhatItDoes(t *testing.T) {
 				"puts it back beside Scheduled backups, which is the timetable", title, banned)
 		}
 	}
-	if !strings.Contains(strings.ToLower(title), "reuse") {
-		t.Errorf("the card title %q does not name what the control does (reuse a file)", title)
+	// It sits on the Backups page beside the schedule (#1543), so the title
+	// says which of the two it is and what it costs or saves. Disk is the
+	// whole trade: reusing a file means two snapshots share one, so a prune
+	// reports space it will not reclaim while the newer one references it.
+	low := strings.ToLower(title)
+	if !strings.HasPrefix(low, "backups") {
+		t.Errorf("the card title %q does not start with Backups, so on the Backups page it does not say "+
+			"which control it is", title)
+	}
+	if !strings.Contains(low, "disk") {
+		t.Errorf("the card title %q does not name what the control trades (disk space)", title)
 	}
 	if !strings.Contains(js, `"Scheduled backups: none"`) {
 		t.Fatal("the schedule summary is no longer called Scheduled backups; the collision was resolved from " +

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -2781,15 +2781,35 @@ try {
     ? ok("verification: LAST VERIFIED wears the age treatment, distinct from RUNNING")
     : bad("verification: LAST VERIFIED wears the age treatment, distinct from RUNNING", JSON.stringify(vfyHist));
 
+  // Storage became Retention (#1543). Navigating to the OLD route is the
+  // check: it must land on the new page with the URL rewritten, or every
+  // existing link and bookmark drops the operator on Overview.
   await page.evaluate(() => navigate("storage"));
-  await page.waitForFunction(() => location.pathname === "/storage"
+  await page.waitForFunction(() => location.pathname === "/retention"
     && Array.from(document.querySelectorAll(".ov-panel-title")).some((h) => /S3 archiving/.test(h.textContent)),
     { timeout: 10000 });
   const storageTitles = await page.evaluate(() =>
     Array.from(document.querySelectorAll(".ov-panel-title")).map((h) => h.textContent));
   (!storageTitles.some((t) => /Baseline snapshots|Backups|Verification/.test(t)))
-    ? ok("protect: Storage no longer carries the moved panels")
-    : bad("protect: Storage no longer carries the moved panels", JSON.stringify(storageTitles));
+    ? ok("protect: the old /storage link lands on Retention, without the moved panels")
+    : bad("protect: the old /storage link lands on Retention, without the moved panels", JSON.stringify(storageTitles));
+
+  // The split itself: each half holds only its own concern, photographed
+  // rather than grepped. Retention must NOT carry the daemon's cards.
+  const halves = await page.evaluate(async () => {
+    const titles = () => Array.from(document.querySelectorAll(".card-title")).map((h) => h.textContent);
+    const retention = titles();
+    navigate("daemon");
+    await new Promise((r) => setTimeout(r, 1200));
+    return { retention: retention, daemon: titles(), path: location.pathname };
+  });
+  (halves.path === "/daemon"
+    && !halves.retention.some((t) => /AWS credentials|Usage telemetry|File reuse/.test(t))
+    && halves.daemon.some((t) => /AWS credentials/.test(t))
+    && halves.daemon.some((t) => /Usage telemetry/.test(t))
+    && !halves.daemon.some((t) => /Rotation/.test(t)))
+    ? ok("storage split: Retention holds the data lifecycle, This daemon holds the process")
+    : bad("storage split: Retention holds the data lifecycle, This daemon holds the process", JSON.stringify(halves));
 
   // Scenario 15e — motion that cannot be seen from Go (#1385).
   //
@@ -3798,8 +3818,10 @@ try {
   // The card tint rotation, on the page from the user's own screenshot. Two
   // distinct tinted grounds prove rotation; "not white" alone would pass a
   // single flat tint.
-  await page.evaluate(() => navigate("storage"));
-  await page.waitForFunction(() => location.pathname === "/storage" && document.querySelectorAll(".cards .card").length >= 2, { timeout: 10000 });
+  // On This daemon, which is the half that still carries two or more
+  // unconditional cards after the split (#1543); Retention has one.
+  await page.evaluate(() => navigate("daemon"));
+  await page.waitForFunction(() => location.pathname === "/daemon" && document.querySelectorAll(".cards .card").length >= 2, { timeout: 10000 });
   const tints = await page.evaluate(() => {
     const cards = Array.from(document.querySelectorAll(".cards .card")).slice(0, 2);
     return cards.map((c) => getComputedStyle(c).backgroundColor);
@@ -3809,7 +3831,7 @@ try {
     : bad("tropical: config cards rotate through the home's tint palette", JSON.stringify(tints));
 
   // ── Scenario 17h — the telemetry card shows the exact sample event (#1447) ──
-  // Still on /storage. The "Show a sample event" fold must be closed by
+  // Still on /daemon. The "Show a sample event" fold must be closed by
   // default, open on click, and carry the daemon's `sample_event` string
   // VERBATIM in a read-only <pre>: the daemon renders it through the same
   // function `bintrail telemetry show` prints through, and a JSON.stringify


### PR DESCRIPTION
Closes #1543. Part of #1528.

## The problem

Storage held seven cards from five unrelated concerns. Rotation policy sat beside AWS credential signals, a telemetry opt-out, a pointer to a page that has its own sidebar entry, and a schema download for a client that is not the console. That is a page you read rather than use.

## The split

**Retention** (replaces `/storage`) — what happens to your data as it ages: rotation policy, S3 archiving per source.

**This daemon** (new) — what this process can reach, is holding, and sends: AWS credential signals, staged downloads, usage telemetry. All three are properties of the machine rather than of your data.

## The two moves

**`File reuse for unchanged tables` → `Backups & disk space`, on the Backups page**, directly under **Scheduled backups**. This is the pairing #1528 asks for by name: the two were *Automatic backup refresh* and *Scheduled backups*, both promising "backups, automatically", from different pages, for unrelated settings. The new name says which control it is and what it trades, and side by side the difference needs no paragraph.

**`Download a DuckDB schema` → the SQL page**, which queries the same data.

The **Backups summary card is deleted**, not moved. Backups has its own sidebar entry; the pointer existed only because the page it pointed away from was a drawer. `baselineSummaryCard` had no other caller.

`/storage` stays a known route and rewrites to `/retention`, so existing links, bookmarks and the command palette land on the new page with the address bar corrected.

## Guards

The guard that pinned the reuse card's mount followed the card to its new page, and now also pins the **order** against the schedule, since being read together is the whole reason for the move. A new guard asserts each half holds only its own concern, and refuses `buildStorage` coming back.

Five mutations confirmed red: the reuse card drifting off Backups, telemetry drifting into Retention, the DuckDB card landing nowhere, the old route ceasing to resolve, and the reuse card mounted above the schedule.

The e2e navigates the **old** route to prove the rewrite, then photographs both halves' card titles in a real browser rather than grepping the source. I could not run it locally (no Docker here), so CI is where that check actually executes.