### PR TITLE
pgbaseline: select the snapshot dir by name, not by counting entries

### DIFF
--- a/internal/pgbaseline/guarantees_integration_test.go
+++ b/internal/pgbaseline/guarantees_integration_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/dbtrail/dbtrail/internal/event"
 	"github.com/dbtrail/dbtrail/internal/pgbaseline"
 	"github.com/dbtrail/dbtrail/internal/pgcapture"
+	"github.com/dbtrail/dbtrail/internal/snapshotdir"
 	"github.com/dbtrail/dbtrail/internal/testutil"
 )
 
@@ -523,13 +524,35 @@ func parseLSNText(t *testing.T, s string) pglogrepl.LSN {
 	return lsn
 }
 
+// singleSnapshotDir returns the one snapshot directory a baseline run wrote
+// under outDir.
+//
+// It SELECTS by name rather than asserting the directory holds exactly one
+// entry. A baselines root carries pointer machinery beside its snapshots since
+// #1484 -- the `current` symlink and its flock file -- so a count is no longer
+// a statement about how many snapshots were written, which is the thing these
+// tests actually mean. Selecting on the timestamp name is the same predicate
+// every discovery path uses, so this cannot drift from what the product reads.
 func singleSnapshotDir(t *testing.T, outDir string) string {
 	t.Helper()
 	entries, err := os.ReadDir(outDir)
-	if err != nil || len(entries) != 1 {
-		t.Fatalf("expected exactly one snapshot dir in %s: err=%v entries=%d", outDir, err, len(entries))
+	if err != nil {
+		t.Fatalf("read %s: %v", outDir, err)
 	}
-	return filepath.Join(outDir, entries[0].Name())
+	var snapshots []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if _, ok := snapshotdir.ParseTime(e.Name()); ok {
+			snapshots = append(snapshots, e.Name())
+		}
+	}
+	if len(snapshots) != 1 {
+		t.Fatalf("expected exactly one snapshot dir in %s, got %v (all entries: %v)",
+			outDir, snapshots, entries)
+	}
+	return filepath.Join(outDir, snapshots[0])
 }
 
 // limitedDSN rewrites the test DSN's credentials to the restricted role.

--- a/internal/pgbaseline/pgbaseline_integration_test.go
+++ b/internal/pgbaseline/pgbaseline_integration_test.go
@@ -139,11 +139,7 @@ func TestPGBaseline_Integration(t *testing.T) {
 	}
 
 	// ── Snapshot directory, markers, manifest ──
-	entries, err := os.ReadDir(outDir)
-	if err != nil || len(entries) != 1 {
-		t.Fatalf("expected exactly one snapshot dir in %s: %v (%d entries)", outDir, err, len(entries))
-	}
-	snapDir := filepath.Join(outDir, entries[0].Name())
+	snapDir := singleSnapshotDir(t, outDir)
 	if _, err := os.Stat(filepath.Join(snapDir, baseline.SuccessMarker)); err != nil {
 		t.Errorf("_SUCCESS marker missing: %v", err)
 	}

--- a/internal/pgbaseline/pgbaseline_integration_test.go
+++ b/internal/pgbaseline/pgbaseline_integration_test.go
@@ -280,11 +280,7 @@ func TestPGBaseline_Integration(t *testing.T) {
 	if stats2.AnchorLSN < stats.AnchorLSN {
 		t.Errorf("re-baseline anchor %d < first anchor %d — anchors must be monotonic", stats2.AnchorLSN, stats.AnchorLSN)
 	}
-	entries2, err := os.ReadDir(outDir2)
-	if err != nil || len(entries2) != 1 {
-		t.Fatalf("re-baseline snapshot dir: %v (%d entries)", err, len(entries2))
-	}
-	snapDir2 := filepath.Join(outDir2, entries2[0].Name())
+	snapDir2 := singleSnapshotDir(t, outDir2)
 	if !baseline.SnapshotComplete(snapDir2) {
 		t.Error("re-baseline snapshot not complete")
 	}


### PR DESCRIPTION
Fixes main, red since #1547.

The Postgres integration tests asserted that a baseline run leaves **exactly one entry** under its output root, then took `entries[0]` as the snapshot directory. A baselines root now carries pointer machinery beside its snapshots (#1484): the `current` symlink and its flock file. Three entries, four tests red.

Counting was never what these tests meant. They mean *one snapshot was written*, so they now **select** the directory whose name parses as a snapshot timestamp — the same predicate every discovery path uses, so the fixture cannot drift from what the product actually reads. The failure message now lists the snapshots it found and every entry, so the next surprise in that directory is legible instead of a bare count.

The inline copy in `pgbaseline_integration_test.go` now calls the `singleSnapshotDir` helper that already existed for this in `guarantees_integration_test.go`.

## Why it reached main

I audited `os.ReadDir` assertions in integration tests before merging #1547 and scoped the grep to four directories, leaving out `internal/pgbaseline/` — even though the first grep in that work had already listed `internal/pgbaseline/pgbaseline.go:377` as one of the three `WriteSuccessMarker` callers. The producer list and the consumer audit were done against different sets.

## Checked, not assumed

The other two count assertions in the package are unaffected: `guarantees_integration_test.go:340` and `pgbaseline_integration_test.go:424` both run after a cancelled or refused run, where `WriteSuccessMarker` never executes, so neither the pointer nor its lock exists. `go vet -tags integration ./...` is clean.