### PR TITLE
views: stop demanding --index-dsn for a baselines-only file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`bintrail views` no longer demands `--index-dsn` for a baselines-only
+  file** (#1552). Only the `events` view reads an archive source, and since
+  0.74.0 that view is opt-in, so the default file defines `state_*` views over
+  a baseline location and names no archive path at all. The check was not
+  revisited when the default flipped, so it went on asking for the index in
+  order to discover sources the file would never use — and refused the exact
+  shape a snapshot downloaded from the console arrives in, on a machine that
+  may not reach the index at all. The documented way around it was to invent
+  an `--archive-dir`, which produced the file that had just been refused.
+
+  `--baseline-dir`/`--baseline-s3` on its own is now enough. `--include-events`
+  without `--index-dsn` and without `--archive-dir`/`--archive-s3` is still
+  refused, and names the view that needs the source rather than the flag that
+  supplies it. A file that would define nothing at all is still refused, by the
+  check keyed on what the file would contain, so the reason names the file
+  rather than a flag combination.
+
 ## [0.74.0] - 2026-08-31
 
 ### Changed

--- a/internal/cli/views.go
+++ b/internal/cli/views.go
@@ -72,6 +72,11 @@ Archive sources come from the index's archive_state registry by default. Pass
 --archive-dir/--archive-s3 with --bintrail-id to name one explicitly instead;
 in that case --index-dsn is not needed at all.
 
+Only the events view reads an archive source, so a baselines-only file needs
+neither: --baseline-dir/--baseline-s3 on its own is enough. That is what a
+snapshot downloaded from the console arrives as, and it can be queried on a
+machine that cannot reach the index at all.
+
 The file is a snapshot of the layout, not a live binding. The state views point
 at one snapshot: regenerate after taking or refreshing a baseline. A daemon
 running bintrail-console watch --baseline-refresh-interval publishes a new
@@ -114,7 +119,7 @@ var (
 )
 
 func init() {
-	viewsCmd.Flags().StringVar(&vIndexDSN, "index-dsn", "", "DSN for the index MySQL database (used to discover archive sources; not needed with --archive-dir/--archive-s3)")
+	viewsCmd.Flags().StringVar(&vIndexDSN, "index-dsn", "", "DSN for the index MySQL database (used to discover archive sources; not needed with --archive-dir/--archive-s3, nor for a baselines-only file)")
 	viewsCmd.Flags().StringVar(&vArchiveDir, "archive-dir", "", "Local root directory of Parquet archives (requires --bintrail-id)")
 	viewsCmd.Flags().StringVar(&vArchiveS3, "archive-s3", "", "S3 root URL prefix of Parquet archives (requires --bintrail-id; e.g. s3://bucket/prefix/)")
 	viewsCmd.Flags().StringVar(&vBintrailID, "bintrail-id", "", "Server identity UUID (required when --archive-dir or --archive-s3 is set)")
@@ -149,9 +154,22 @@ func runViews(cmd *cobra.Command, _ []string) error {
 			"define: pass --include-events with it")
 	}
 	explicitArchives := vArchiveDir != "" || vArchiveS3 != ""
-	if vIndexDSN == "" && !explicitArchives {
-		return fmt.Errorf("--index-dsn is required (it is where archive sources are discovered); " +
-			"or name a source directly with --archive-dir/--archive-s3 plus --bintrail-id")
+	// An archive source is required only by the view that READS one. Since
+	// #1546 the events view is opt-in, so the default file defines state views
+	// over a baseline location and nothing else: demanding the index for it
+	// asks for a host the reader may not reach, to discover paths the file
+	// will never name. That is the shape a downloaded snapshot arrives in
+	// (GET /api/baselines/download), and the old check sent that reader to
+	// invent an --archive-dir to get the file it had just been refused.
+	//
+	// Keyed on --include-events rather than on "did anything get discovered":
+	// the operator asked for the view, so the refusal names what they asked
+	// for. A file that ends up defining nothing at all is still caught below
+	// by RendersAnyView, which reports the reason that actually applies.
+	if vIncludeEvents && vIndexDSN == "" && !explicitArchives {
+		return fmt.Errorf("--include-events needs an archive source: pass --index-dsn (it is where " +
+			"archive sources are discovered), or name one directly with --archive-dir/--archive-s3 " +
+			"plus --bintrail-id")
 	}
 
 	in := views.Input{
@@ -163,15 +181,20 @@ func runViews(cmd *cobra.Command, _ []string) error {
 		OmitEvents:    !vIncludeEvents,
 	}
 
-	if explicitArchives {
+	switch {
+	case explicitArchives:
 		in.ArchiveSources = explicitArchiveSources()
-	} else {
+	case vIndexDSN != "":
 		sources, err := discoverArchiveSources(cmd.Context(), vIndexDSN)
 		if err != nil {
 			return err
 		}
 		in.ArchiveSources = sources
 		in.PortableRouting = true
+	default:
+		// No index and nothing named: a baselines-only file. Discovery is
+		// SKIPPED rather than run against an empty DSN, which would fail on
+		// the connection and report it as an index fault.
 	}
 
 	if vIncludeLive {

--- a/internal/cli/views_follow_test.go
+++ b/internal/cli/views_follow_test.go
@@ -31,11 +31,16 @@ func baselineDirWithTwoSnapshots(t *testing.T) (root, older, newer string) {
 
 // runViewsOverBaselines runs the command with only a baseline root configured
 // and returns the generated SQL.
+//
+// "Only" is literal now (#1552). This used to pass a throwaway --archive-dir,
+// because runViews refused a file with no archive source even when the file
+// defined no view that reads one — so the helper's own name was wrong, and the
+// dummy quietly gave these tests an archive source the scenario never had.
 func runViewsOverBaselines(t *testing.T, root string, pin bool) string {
 	t.Helper()
 	saveViewsFlags(t)
-	vIndexDSN, vArchiveDir, vArchiveS3, vBaselineS3 = "", t.TempDir(), "", ""
-	vBintrailID, vBaselineDir, vOut = "aaaa", root, "-"
+	vIndexDSN, vArchiveDir, vArchiveS3, vBaselineS3 = "", "", "", ""
+	vBintrailID, vBaselineDir, vOut = "", root, "-"
 	vNoBaselines, vIncludeLive, vIncludeEvents, vPinSnapshot = false, false, false, pin
 	out, err := runViewsToString(t)
 	if err != nil {

--- a/internal/cli/views_test.go
+++ b/internal/cli/views_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -10,10 +12,15 @@ import (
 // resetViewsFlags clears the package-level flag vars between subtests. The
 // command's flags are package globals (the convention throughout this package),
 // so a test that sets one leaks into the next without this.
+// The bool half must list EVERY bool flag, not the ones that existed when this
+// was written: vIncludeEvents (#1546), vIncludeLive (#1480) and vPinSnapshot
+// (#1547) were each added later and each leaked into every subtest that ran
+// after the one setting it, silently, because a leaked bool changes which
+// refusal fires rather than producing an obviously wrong value.
 func resetViewsFlags() {
 	vIndexDSN, vArchiveDir, vArchiveS3, vBintrailID = "", "", "", ""
 	vRegion, vBaselineDir, vBaselineS3, vOut = "", "", "", "views.sql"
-	vNoBaselines = false
+	vNoBaselines, vIncludeEvents, vIncludeLive, vPinSnapshot = false, false, false, false
 }
 
 // TestRunViews_flagValidation covers the refusals that must happen BEFORE any
@@ -44,11 +51,20 @@ func TestRunViews_flagValidation(t *testing.T) {
 			wantErr: "mutually exclusive",
 		},
 		{
-			// Nothing to discover from and nothing named: the file would be an
-			// empty shell of comments.
-			name:    "no index and no explicit archives",
-			set:     func() { vBaselineDir = "/b" },
-			wantErr: "--index-dsn is required",
+			// Only the events view reads an archive source, so asking for it
+			// with nowhere to read from is the refusal. A baselines-only file
+			// is NOT refused here: see
+			// TestRunViews_baselinesOnlyNeedsNoIndex.
+			name:    "include-events with no index and no explicit archives",
+			set:     func() { vBaselineDir = "/b"; vIncludeEvents = true },
+			wantErr: "--include-events needs an archive source",
+		},
+		{
+			// The empty file stays refused, and by RendersAnyView rather than
+			// by a flag check, so the reason names what the file would hold.
+			name:    "nothing named at all",
+			set:     func() {},
+			wantErr: "no view at all",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -100,4 +116,46 @@ func TestViewsCmd_registered(t *testing.T) {
 		}
 	}
 	t.Fatal("`views` is not registered by AddReadCommands")
+}
+
+// TestRunViews_baselinesOnlyNeedsNoIndex is THE assertion for #1552: a
+// snapshot downloaded from the console (GET /api/baselines/download) is
+// extracted on a machine that may not reach the index at all, and the file
+// that reads it defines state views and nothing else. Requiring --index-dsn
+// there asked for a host to discover paths the file never names, and the
+// documented way around it was to invent an --archive-dir, which produced the
+// very file that had just been refused.
+//
+// Driven through runViews, not the generator: the refusal lives in the command
+// layer, so a generator-level test could not see it.
+func TestRunViews_baselinesOnlyNeedsNoIndex(t *testing.T) {
+	root := t.TempDir()
+	p := filepath.Join(root, "2026-08-31T06-00-00Z", "wp", "wp_posts.parquet")
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	saveViewsFlags(t)
+	// Every archive-side flag empty: this is exactly what an operator has
+	// after extracting the tarball, and nothing else.
+	vIndexDSN, vArchiveDir, vArchiveS3, vBintrailID, vBaselineS3 = "", "", "", "", ""
+	vBaselineDir, vOut = root, "-"
+	vNoBaselines, vIncludeLive, vIncludeEvents, vPinSnapshot = false, false, false, false
+
+	out, err := runViewsToString(t)
+	if err != nil {
+		t.Fatalf("runViews over a baselines-only root: %v", err)
+	}
+	if !strings.Contains(out, `CREATE OR REPLACE VIEW "state_wp_wp_posts"`) {
+		t.Errorf("no state view for the snapshot's table in:\n%s", out)
+	}
+	// The events view reads an archive source and there is none, so it must
+	// not be defined. Asserting its ABSENCE alone would pass on a file that
+	// defines nothing at all, which is why the state view is checked above.
+	if strings.Contains(out, `CREATE OR REPLACE VIEW "events"`) {
+		t.Errorf("defined an events view with no archive source:\n%s", out)
+	}
 }


### PR DESCRIPTION
closes #1552

## Summary

Only the `events` view reads an archive source. #1546 made that view opt-in, so the default generated file defines `state_*` views over a baseline location and names no archive path at all. The check requiring an index was not revisited when the default flipped.

The shape it refused is the one a downloaded snapshot arrives in. The console already streams a whole snapshot as a tar.gz (`GET /api/baselines/download`); extract it on a laptop and ask for the file that reads it:

```
$ bintrail views --baseline-dir ./extracted --out -
--index-dsn is required (it is where archive sources are discovered); or name a
source directly with --archive-dir/--archive-s3 plus --bintrail-id
```

Naming an archive that does not exist produced the file it had just refused, so the requirement protected nothing:

```
$ bintrail views --baseline-dir ./extracted \
    --archive-dir /dev/null --bintrail-id 00000000-0000-0000-0000-000000000000 --out -
CREATE OR REPLACE VIEW "state_wp_wp_posts" AS ...
```

## What changed

- The refusal is keyed on `--include-events`, so it names the view that needs the source rather than the flag that supplies it.
- Archive discovery is skipped when there is no index DSN and nothing named, rather than run against an empty DSN (which fails on the connection and reports a missing flag as an index fault).
- A file that would define nothing at all stays refused by `RendersAnyView`, which reports what the file would hold.

## Two test defects this surfaced

`runViewsOverBaselines` documented itself as running "with only a baseline root configured" while passing a throwaway `--archive-dir`. That dummy was this same workaround inside the suite, and it handed four follow tests an archive source their scenario never had.

`resetViewsFlags` claimed to clear the package-level flag vars between subtests and cleared only those that existed when it was written. `vIncludeEvents` (#1546), `vIncludeLive` (#1480) and `vPinSnapshot` (#1547) each leaked into every later subtest, silently, because a leaked bool changes which refusal fires rather than producing a visibly wrong value.

## Test plan

- [x] Four guards seen RED on the unfixed source, each failing with the old message
- [x] `go test ./... -count=1` — 55 packages ok
- [x] `go vet -tags integration ./internal/cli/ ./internal/views/`
- [x] Verified against a real extracted snapshot with a built binary: baselines-only emits; `--include-events` with no source refused; nothing named refused by `RendersAnyView`