### PR TITLE
console: draw the DuckDB card instead of explaining it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   live leg, so its archives-only note names `bintrail views --include-live`
   rather than a checkbox that no longer exists.
 
-  The card is now under 300 rendered characters, pinned by an e2e budget of its
-  own. That guard checks the drawing is on screen as well as the count, because
-  folding prose out of sight passes a character budget while leaving the same
-  wall one click away.
+  It is a full-width panel below the three numbered steps, beside "Other AI
+  tools" and "Connect a SQL client", not a fourth card inside the steps grid.
+  A schema file for your own DuckDB is not a step in connecting Claude, and the
+  grid tints every child by position, so in there it took a colour and a
+  treatment that read as step four on a page that promises three.
+
+  Under 300 rendered characters, pinned by an e2e budget of its own. That guard
+  checks the drawing is on screen as well as the count, because folding prose
+  out of sight passes a character budget while leaving the same wall one click
+  away.
 
 ### Removed
 - **The console's SQL page and `POST /api/sql`** (#1549). The page answered

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **The Download a DuckDB schema card draws what the file will hold, instead of
+  describing it.** It carried three checkboxes, each trailed by a multi-line
+  caveat, on a page whose job is to be legible to someone who has read nothing.
+  The one decision a reader actually makes is whether to include the change log,
+  and its whole cost is a shape: your tables are one Parquet file each, the
+  change log is one file per archived hour and grows forever. Ticking the box
+  lights the strip, so the difference is seen rather than read.
+
+  `--pin-snapshot` and `--include-live` are no longer offered here. Both remain
+  CLI flags and route parameters; neither is a decision to put in front of a
+  first-time reader, and the live leg in particular can compete with capture on
+  the source server. A file downloaded from the console can no longer carry the
+  live leg, so its archives-only note names `bintrail views --include-live`
+  rather than a checkbox that no longer exists.
+
+  The card is now under 300 rendered characters, pinned by an e2e budget of its
+  own. That guard checks the drawing is on screen as well as the count, because
+  folding prose out of sight passes a character budget while leaving the same
+  wall one click away.
+
 ### Removed
 - **The console's SQL page and `POST /api/sql`** (#1549). The page answered
   free-form `SELECT`s with DuckDB running inside the daemon, which is why it

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -4179,7 +4179,9 @@ function stagingCard(storage, servers) {
 // file each, the change log is one file per archived hour and grows forever.
 //
 // Ticking the box LIGHTS THE STRIP. That is the cost statement: three tiles
-// against two dozen bars, seen rather than read. Built with el() and not svgEl,
+// against a run of bars that is CLIPPED on purpose and fades off the edge,
+// because the claim is that it grows without end -- a row stopping flush at a
+// right edge draws a closed set, and the reader counts it. Built with el() and not svgEl,
 // which only DOMParses static icon constants (see the note at the top of this
 // file).
 //
@@ -4187,8 +4189,8 @@ function stagingCard(storage, servers) {
 // rendered only for the parameter the card can actually send, and the guard in
 // assets_duckdbcard_test.go fails if the two come apart.
 function duckdbShape() {
-  const tiles = (n, cls) => {
-    const row = el("div", { class: "dk-row" });
+  const tiles = (n, cls, rowCls) => {
+    const row = el("div", { class: "dk-row" + (rowCls ? " " + rowCls : "") });
     for (let i = 0; i < n; i++) row.append(el("span", { class: cls }));
     return row;
   };
@@ -4196,20 +4198,35 @@ function duckdbShape() {
     tiles(3, "dk-tile"),
     el("div", { class: "dk-cap", text: "your tables" }));
   const events = el("div", { class: "dk-part dk-off" },
-    tiles(24, "dk-bar"),
+    tiles(60, "dk-bar", "dk-strip"),
     el("div", { class: "dk-cap", text: "every change, hour by hour" }));
   return { el: el("div", { class: "dk-shape" }, state, events), events };
 }
 
-// duckdbCard offers the generated DuckDB schema for this server's Parquet.
+// duckdbPanel offers the generated DuckDB schema for this server's Parquet.
 //
 // It is NOT the console SQL page, which #1549 removed: nothing here executes.
-// The title is load-bearing beyond this card and must not be renamed casually
+// The title is load-bearing beyond this panel and must not be renamed casually
 // (it was "Query in DuckDB" until #1528).
-function duckdbCard() {
-  const card = el("div", { class: "card" }, el("div", { class: "card-title", text: "Download a DuckDB schema" }));
+function duckdbPanel() {
+  // A section, not a .cn-card. sqlClientPanel already drew this line for the
+  // identical case: "the three numbered cards are the Connect AI how-to, and
+  // this is a different client". A schema file for the reader's own DuckDB is
+  // one step further out — it never talks to this console at all.
+  //
+  // Staying in the grid was not a styling choice to undo later: .cards tints
+  // every child by position, so the card took amber and read as a fourth step
+  // in a page that promises three. And the tint was eating the drawing —
+  // style.css records --surface-3 at 1.021 against orange-tint, under the 1.02
+  // identity floor, which is exactly the fill the tiles and bars are drawn in.
+  // Out here they get their hairline back.
+  const card = el("section", { class: "ov-panel cn-dk", style: "margin-top:18px" });
+  card.append(el("div", { class: "ov-panel-head" },
+    el("h2", { class: "ov-panel-title", text: "Download a DuckDB schema" })));
+  const body = el("div", { class: "cn-dk-body" });
+  card.append(body);
   const shape = duckdbShape();
-  card.append(shape.el);
+  body.append(shape.el);
 
   // One checkbox. --pin-snapshot and --include-live are still route parameters
   // and CLI flags; they are not decisions to put in front of a first-time
@@ -4217,12 +4234,12 @@ function duckdbCard() {
   // which is not something to offer two clicks from a page that explains
   // nothing.
   const events = el("input", { type: "checkbox", name: "include_events" });
-  card.append(el("label", { class: "check" }, events,
+  body.append(el("label", { class: "check" }, events,
     el("span", { text: "Include the change log" })));
   events.onchange = () => shape.events.classList.toggle("dk-off", !events.checked);
   events.onchange();
 
-  card.append(cnFine("More about this file",
+  body.append(cnFine("More about this file",
     el("p", { class: "form-hint", text:
       "Runs in your own DuckDB. Nothing runs here, and no credentials are in the file." }),
     el("p", { class: "form-hint", text:
@@ -4241,7 +4258,7 @@ function duckdbCard() {
       btn.disabled = false;
     }
   };
-  card.append(el("div", { class: "stg-cardfoot" }, btn));
+  body.append(el("div", { class: "stg-cardfoot" }, btn));
   return card;
 }
 
@@ -6386,8 +6403,8 @@ function buildConnect(servers, tokStatus, minted, fbStatus) {
   // file executes nothing. That page is now gone entirely, so this is the only
   // route to the download. Appended LAST so the .cards nth-child(4n+1) tint
   // keeps landing on the same card it does today.
-  if (capsCache.views) cards.append(duckdbCard());
   v.append(cards);
+  if (capsCache.views) v.append(duckdbPanel());
   if (capsCache.mcp) v.append(otherClientsPanel(servers));
   v.append(sqlClientPanel(servers, fbStatus));
   viewEnter();

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -4172,91 +4172,67 @@ function stagingCard(storage, servers) {
 // toggle. Turning it off here stops THIS running daemon's beacons immediately
 // (the daemon wired its live client) and persists the choice for every bintrail
 // process on the machine.
-// duckdbCard offers the generated DuckDB schema for this server's Parquet
-// layout. The console does not run the SQL and gains no query engine: the file
-// is executed by the operator's own DuckDB, on their machine, which is why
-// "unrestricted SQL over your lake" needs no sandbox, timeout or result cap here.
+// duckdbShape draws what the downloaded file will contain, instead of
+// describing it (#1549 follow-up). The card used to carry three checkboxes and
+// three multi-line caveats; the one decision a reader actually makes is whether
+// to include the change log, and its whole cost is a shape: your tables are one
+// file each, the change log is one file per archived hour and grows forever.
 //
-// It was titled "Query in DuckDB" (#1528). No query happens here, and /sql is
-// the page that DOES run DuckDB, server-side. The two are NOT merged: they are
-// gated by different capabilities (views vs sql), so on a daemon with views on
-// and sql off the merge would make this card unreachable. Rename only.
+// Ticking the box LIGHTS THE STRIP. That is the cost statement: three tiles
+// against two dozen bars, seen rather than read. Built with el() and not svgEl,
+// which only DOMParses static icon constants (see the note at the top of this
+// file).
 //
-// The title is load-bearing beyond this card: liveLegHowTo (views_live.go)
-// names it inside the generated views.sql, so the two are pinned together by a
-// guard.
+// The picture can lie in a way prose cannot, so it is pinned: the strip is
+// rendered only for the parameter the card can actually send, and the guard in
+// assets_duckdbcard_test.go fails if the two come apart.
+function duckdbShape() {
+  const tiles = (n, cls) => {
+    const row = el("div", { class: "dk-row" });
+    for (let i = 0; i < n; i++) row.append(el("span", { class: cls }));
+    return row;
+  };
+  const state = el("div", { class: "dk-part" },
+    tiles(3, "dk-tile"),
+    el("div", { class: "dk-cap", text: "your tables" }));
+  const events = el("div", { class: "dk-part dk-off" },
+    tiles(24, "dk-bar"),
+    el("div", { class: "dk-cap", text: "every change, hour by hour" }));
+  return { el: el("div", { class: "dk-shape" }, state, events), events };
+}
+
+// duckdbCard offers the generated DuckDB schema for this server's Parquet.
+//
+// It is NOT the console SQL page, which #1549 removed: nothing here executes.
+// The title is load-bearing beyond this card and must not be renamed casually
+// (it was "Query in DuckDB" until #1528).
 function duckdbCard() {
   const card = el("div", { class: "card" }, el("div", { class: "card-title", text: "Download a DuckDB schema" }));
-  card.append(el("p", { class: "form-hint", text:
-    "Download a ready-made schema over your backups: one view per table, as of the newest " +
-    "backup. Run it in your own DuckDB; nothing runs here." }));
-  card.append(el("p", { class: "form-hint", text:
-    "No credentials are in the file, so it is safe to share." }));
-  // Following the newest backup is the default (#1484), so the box offers the
-  // opposite: an operator who wants a fixed point in time asks for it. The
-  // hint describes what leaving the box off ASKS FOR, not what the file will
-  // necessarily do: a backup folder written by an older build carries no
-  // pointer to follow until its next backup completes, and an S3 destination
-  // has none at all. The generated file states which of the two it did, which
-  // is why the hint says to read it there rather than hedging every case here.
-  // The three options are FOLDED (#1549). They moved onto Connect, a page whose
-  // e2e budget caps visible text because #1430 established that spelling every
-  // contingency out in the open reads as a wall: the card arrived at 2052 chars
-  // against a 1500 budget and failed that guard. cnFine is the page's own
-  // mechanism for exactly this, so the facts stay on the page and stop being
-  // the first thing a first-time reader meets.
-  const opts = [];
-  const pin = el("input", { type: "checkbox", name: "pin_snapshot" });
-  opts.push(el("label", { class: "check" }, pin,
-    el("span", { text: "Pin to the backup that exists now" })));
-  opts.push(el("p", { class: "form-hint", text:
-    "Left off, the views follow the newest backup where the backup folder supports it, so a " +
-    "scheduled backup reaches this file without downloading it again. Tick it to keep the rows " +
-    "as they are today. The file says which one it did. (CLI: bintrail views --pin-snapshot)" }));
-  // The change log (#1535). Opt-in since it stopped being the default: defining
-  // that view opens one Parquet footer per archived file before it returns a row,
-  // so a reader who only wanted their tables used to pay for the whole archive to
-  // get them. The cost is stated on the page, not only in the generated file:
-  // by the time they read the file, the bind is already running.
+  const shape = duckdbShape();
+  card.append(shape.el);
+
+  // One checkbox. --pin-snapshot and --include-live are still route parameters
+  // and CLI flags; they are not decisions to put in front of a first-time
+  // reader. The live leg in particular can compete with capture on the source,
+  // which is not something to offer two clicks from a page that explains
+  // nothing.
   const events = el("input", { type: "checkbox", name: "include_events" });
-  opts.push(el("label", { class: "check" }, events,
+  card.append(el("label", { class: "check" }, events,
     el("span", { text: "Include the change log" })));
-  opts.push(el("p", { class: "form-hint", text:
-    "Adds a view over every archived change. It takes longer to open the further back your " +
-    "archive goes, because it reads a piece of every archived file before answering anything. " +
-    "(CLI: bintrail views --include-events)" }));
-  // The live leg (#1480) is a leg OF the change-log view, so it is nested under
-  // it rather than offered beside it: ticked alone it would ask for a leg of a
-  // view this file would not define, which the route refuses.
-  const live = el("input", { type: "checkbox", name: "include_live", disabled: true });
-  const liveLabel = el("label", { class: "check check-sub" }, live,
-    el("span", { text: "…and the live index" }));
-  opts.push(liveLabel);
-  const liveHint = el("p", { class: "form-hint form-hint-sub", text:
-    "Adds the most recent changes, the ones not archived yet. Every query over that leg scans the whole live capture index and competes " +
-    "with capture on that server. The file will hold the index host and user, never its password: " +
-    "fill that in when you run it. (CLI: bintrail views --include-live)" });
-  opts.push(liveHint);
-  events.onchange = () => {
-    live.disabled = !events.checked;
-    // Cleared, not merely disabled: a disabled box KEEPS its checked state and
-    // the request reads .checked, so leaving it set would send include_live=1
-    // for a file with no change log, which the route refuses.
-    if (!events.checked) live.checked = false;
-    liveLabel.classList.toggle("is-disabled", !events.checked);
-    liveHint.classList.toggle("is-disabled", !events.checked);
-  };
-  card.append(cnFine("Change what the file covers", ...opts));
+  events.onchange = () => shape.events.classList.toggle("dk-off", !events.checked);
   events.onchange();
-  const btn = el("button", { class: "btn btn-sm", type: "button", text: "Open in DuckDB…" });
+
+  card.append(cnFine("More about this file",
+    el("p", { class: "form-hint", text:
+      "Runs in your own DuckDB. Nothing runs here, and no credentials are in the file." }),
+    el("p", { class: "form-hint", text:
+      "The views follow your newest backup where the backup folder supports it. (CLI: bintrail views)" })));
+
+  const btn = el("button", { class: "btn btn-sm", type: "button", text: "Download views.sql" });
   btn.onclick = async () => {
     btn.disabled = true;
     try {
-      const params = [];
-      if (pin.checked) params.push("pin_snapshot=1");
-      if (events.checked) params.push("include_events=1");
-      if (events.checked && live.checked) params.push("include_live=1");
-      const sql = await apiText("/api/views.sql" + (params.length ? "?" + params.join("&") : ""));
+      const sql = await apiText("/api/views.sql" + (events.checked ? "?include_events=1" : ""));
       downloadBlob("views.sql", sql, "text/plain");
       toast("views.sql downloaded. In DuckDB run .read views.sql, once per session.");
     } catch (err) {

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -2628,12 +2628,30 @@ button { font-family: inherit; }
    described. Three tiles are your tables, one file each; the strip is the
    archived change log, one file per hour. dk-off is the unticked state, so
    ticking the box lights the strip and the cost is seen instead of read. */
-.dk-shape { display: flex; flex-direction: column; gap: 10px; margin: 12px 0 14px; }
-.dk-part.dk-off { opacity: 0.28; }
-.dk-row { display: flex; align-items: flex-end; gap: 4px; flex-wrap: wrap; }
-.dk-tile { width: 26px; height: 26px; border-radius: 5px; background: var(--surface-2); border: 1px solid var(--line); flex: none; }
-.dk-bar { width: 5px; height: 20px; border-radius: 2px; background: var(--surface-2); border: 1px solid var(--line); flex: none; }
+/* Capped so the strip below has an edge to run off. Without a boundary the
+   mask fades nothing and the row reads as a countable set. */
+.dk-shape { display: flex; flex-direction: column; gap: 10px; margin: 12px 0 14px; max-width: 320px; }
+.dk-row { display: flex; align-items: flex-end; gap: 4px; }
+/* SOLID fills, and that is the whole correction. These marks were drawn in
+   --surface-2, which is what --panel-bg resolves to: the fill measured 1.000
+   against its own ground and only the hairline ever drew them. On the tinted
+   card that went unnoticed, because the tint gave the fill a ground to differ
+   from; moving to the neutral panel is what exposed it. */
+.dk-tile { width: 26px; height: 26px; border-radius: 5px; background: var(--ink-4); flex: none; }
+/* Must stay AFTER .dk-row: both are 0-1-0, so source order decides the gap. */
+.dk-strip {
+  flex-wrap: nowrap; overflow: hidden; gap: 3px;
+  -webkit-mask-image: linear-gradient(90deg, #000 60%, transparent);
+  mask-image: linear-gradient(90deg, #000 60%, transparent);
+}
+/* --accent is the checkbox's own accent-color, so ticking the box paints the
+   strip the exact colour of the tick: the control and the drawing say the same
+   thing in the same colour, in every theme. The tiles stay neutral because
+   they are the constant; the only hue marks the only decision. */
+.dk-bar { width: 5px; height: 14px; border-radius: 2px; background: var(--accent); flex: none; }
+.dk-off .dk-bar { background: var(--line); }
 .dk-cap { font-size: 11.5px; color: var(--ink-3); margin-top: 5px; }
+.cn-dk-body { padding: 0 14px 14px; }
 
 .cn-mock { border: 1px solid oklch(0.5 0.05 320 / 0.22); border-radius: 10px; background: var(--surface); margin: 10px 0; max-width: 430px; box-shadow: 0 1px 2px rgb(0 0 0 / 0.04); }
 .cn-mock-bar { display: flex; align-items: center; padding: 7px 12px; border-bottom: 1px solid var(--line-soft); color: var(--ink-4); font-size: 11.5px; }

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1247,12 +1247,6 @@ button { font-family: inherit; }
 .form-grid.two { grid-template-columns: repeat(2, 1fr); }
 .check { display: flex; align-items: center; gap: 10px; font-size: 13.5px; color: var(--ink); cursor: pointer; }
 .check input { width: 18px; height: 18px; accent-color: var(--accent); }
-/* A sub-option: indented under the checkbox it belongs to, and visibly inert
-   while that one is off. `is-disabled` is a class rather than :has() on the
-   input, because the hint paragraph is a SIBLING of the label, not inside it. */
-.check-sub { margin-left: 28px; }
-.form-hint-sub { margin-left: 28px; }
-.check.is-disabled, .form-hint.is-disabled { opacity: 0.5; cursor: default; }
 .modal-foot { display: flex; gap: 10px; margin-top: 22px; align-items: center; }
 
 /* ============================================================
@@ -2630,6 +2624,17 @@ button { font-family: inherit; }
    hairline the file already gives .stg-code insets on tints, and the bubble
    fills white so its identity clears the two-grounds floor on ANY tint, not
    just the violet it lands on today. */
+/* The DuckDB card's shape (#1549 follow-up): the file's contents drawn, not
+   described. Three tiles are your tables, one file each; the strip is the
+   archived change log, one file per hour. dk-off is the unticked state, so
+   ticking the box lights the strip and the cost is seen instead of read. */
+.dk-shape { display: flex; flex-direction: column; gap: 10px; margin: 12px 0 14px; }
+.dk-part.dk-off { opacity: 0.28; }
+.dk-row { display: flex; align-items: flex-end; gap: 4px; flex-wrap: wrap; }
+.dk-tile { width: 26px; height: 26px; border-radius: 5px; background: var(--surface-2); border: 1px solid var(--line); flex: none; }
+.dk-bar { width: 5px; height: 20px; border-radius: 2px; background: var(--surface-2); border: 1px solid var(--line); flex: none; }
+.dk-cap { font-size: 11.5px; color: var(--ink-3); margin-top: 5px; }
+
 .cn-mock { border: 1px solid oklch(0.5 0.05 320 / 0.22); border-radius: 10px; background: var(--surface); margin: 10px 0; max-width: 430px; box-shadow: 0 1px 2px rgb(0 0 0 / 0.04); }
 .cn-mock-bar { display: flex; align-items: center; padding: 7px 12px; border-bottom: 1px solid var(--line-soft); color: var(--ink-4); font-size: 11.5px; }
 .cn-mock-dots { width: 8px; height: 8px; border-radius: 50%; flex: none; background: oklch(0.72 0.17 25); box-shadow: 13px 0 0 oklch(0.83 0.14 85), 26px 0 0 oklch(0.72 0.17 145); margin-right: 44px; }

--- a/internal/console/assets_backuprefresh_test.go
+++ b/internal/console/assets_backuprefresh_test.go
@@ -225,11 +225,11 @@ func TestStorageSplit_eachHalfHoldsOnlyItsOwnConcern(t *testing.T) {
 	}{
 		// What happens to your data over time. Nothing about this process.
 		{"buildRetention", []string{"rotationCard(", "archivingPanel("},
-			[]string{"credentialsCard(", "stagingCard(", "telemetryCard(", "backupRefreshCard(", "duckdbCard("}},
+			[]string{"credentialsCard(", "stagingCard(", "telemetryCard(", "backupRefreshCard(", "duckdbPanel("}},
 		// What this process is reaching, holding and sending. Nothing about
 		// the data lifecycle.
 		{"buildDaemon", []string{"credentialsCard(", "stagingCard(", "telemetryCard("},
-			[]string{"rotationCard(", "archivingPanel(", "backupRefreshCard(", "duckdbCard("}},
+			[]string{"rotationCard(", "archivingPanel(", "backupRefreshCard(", "duckdbPanel("}},
 	} {
 		body := jsFunctionBody(t, js, tc.fn)
 		for _, w := range tc.want {
@@ -255,7 +255,7 @@ func TestStorageSplit_eachHalfHoldsOnlyItsOwnConcern(t *testing.T) {
 	//
 	// Named explicitly rather than searched file-wide, because the failure
 	// this guards is the card existing while nothing calls it.
-	if !strings.Contains(jsFunctionBody(t, js, "buildConnect"), "duckdbCard(") {
+	if !strings.Contains(jsFunctionBody(t, js, "buildConnect"), "duckdbPanel(") {
 		t.Error("buildConnect does not mount duckdbCard, so the schema download is unreachable")
 	}
 	// And it must not go back to the SQL page, which #1549 removed entirely.
@@ -682,10 +682,10 @@ func TestCredentialsCard_noEmDashPlaceholders(t *testing.T) {
 // flag instead — nothing in it refers to this card, and a pin against a
 // reference that does not exist would only be a test asserting its own fixture.
 func TestDuckDBCard_titleDoesNotPromiseAQuery(t *testing.T) {
-	body := jsFunctionBody(t, readAsset(t, "app.js"), "duckdbCard")
-	m := regexp.MustCompile(`card-title", text: "([^"]*)"`).FindStringSubmatch(body)
+	body := jsFunctionBody(t, readAsset(t, "app.js"), "duckdbPanel")
+	m := regexp.MustCompile(`ov-panel-title", text: "([^"]*)"`).FindStringSubmatch(body)
 	if m == nil {
-		t.Fatal("duckdbCard renders no card title; this guard covers nothing")
+		t.Fatal("duckdbPanel renders no title; this guard covers nothing")
 	}
 	title := m[1]
 	if strings.Contains(title, "Query in") {

--- a/internal/console/assets_backuprefresh_test.go
+++ b/internal/console/assets_backuprefresh_test.go
@@ -671,17 +671,16 @@ func TestCredentialsCard_noEmDashPlaceholders(t *testing.T) {
 }
 
 // TestDuckDBCard_titleDoesNotPromiseAQuery (#1528, review pass 1). The card
-// hands the operator a file that explicitly does NOT run here; /sql is the page
-// that runs DuckDB server-side. Two surfaces named for querying, one of which
-// only downloads, is the same defect as the backup-refresh title.
+// hands the operator a file that explicitly does NOT run here. A title naming a
+// query, for a control that only downloads, is the same defect as the
+// backup-refresh title.
 //
-// The card is NOT merged into /sql: the two are gated by different capabilities
-// (views vs sql), so on a daemon with views on and sql off the card would
-// become unreachable. Rename only.
-//
-// The second half is the cross-file pin: the generated views.sql tells a reader
-// which control to tick, by NAME. Renaming either side alone points that file
-// at a card that does not exist.
+// The cross-file pin this used to carry is GONE, and deliberately. It asserted
+// that the generated views.sql names this card's title, because the file's
+// remediation pointed at a checkbox on it. The card no longer offers the live
+// leg, so the console stops overriding LiveLegHowTo and the file names the CLI
+// flag instead — nothing in it refers to this card, and a pin against a
+// reference that does not exist would only be a test asserting its own fixture.
 func TestDuckDBCard_titleDoesNotPromiseAQuery(t *testing.T) {
 	body := jsFunctionBody(t, readAsset(t, "app.js"), "duckdbCard")
 	m := regexp.MustCompile(`card-title", text: "([^"]*)"`).FindStringSubmatch(body)
@@ -694,10 +693,5 @@ func TestDuckDBCard_titleDoesNotPromiseAQuery(t *testing.T) {
 	}
 	if !strings.Contains(title, "Download") {
 		t.Errorf("the card title %q does not name what the control does (download a file)", title)
-	}
-	if !strings.Contains(liveLegHowTo, title) {
-		t.Errorf("the generated views.sql points a reader at %q, which is not this card's title (%q); "+
-			"renaming one side alone sends them looking for a control that does not exist",
-			liveLegHowTo, title)
 	}
 }

--- a/internal/console/assets_duckdbcard_test.go
+++ b/internal/console/assets_duckdbcard_test.go
@@ -1,99 +1,124 @@
 package console
 
 import (
-	"os"
+	"regexp"
 	"strings"
 	"testing"
 )
 
-// The Download a DuckDB schema card is the only caller of GET /api/views.sql, so the
-// include_live parameter the handler grew (#1480) reaches the operator only if
-// this card sends it. The server-side tests all pass with a card that has no
-// checkbox at all.
+// The Download a DuckDB schema card is the only caller of GET /api/views.sql,
+// so what it can ask for IS the console's whole surface over that endpoint.
 //
-// Scoped to duckdbCard's body: a file-wide search for "include_live" would be
-// satisfied by any other mention, this one included in a comment.
-// TestDuckDBCard_disabledStateIsStyled: the class toggles are inert unless
-// something styles the class, and a rule with no reader is invisible to every
-// JS-level assertion.
-func TestDuckDBCard_disabledStateIsStyled(t *testing.T) {
-	css, err := os.ReadFile("assets/style.css")
-	if err != nil {
-		t.Fatal(err)
+// It carried three checkboxes and three multi-line caveats until #1549's
+// follow-up. The caveats are what these guards used to pin, one string at a
+// time. They pin the SHAPE now, because the card explains itself by drawing
+// what the file will hold instead of describing it, and a drawing fails
+// differently: wrong prose reads wrong, a wrong picture looks fine.
+
+// TestDuckDBCardOffersOneDecision. --pin-snapshot and --include-live remain
+// route parameters and CLI flags; they are not decisions to put in front of a
+// first-time reader, and the live leg in particular can compete with capture on
+// the source server. So exactly one box, and it is the change log.
+func TestDuckDBCardOffersOneDecision(t *testing.T) {
+	body := functionBody(t, readAsset(t, "app.js"), "function duckdbCard(")
+
+	boxes := strings.Count(body, `type: "checkbox"`)
+	if boxes != 1 {
+		t.Errorf("duckdbCard renders %d checkboxes, want exactly 1 (the change log); "+
+			"pin-snapshot and include-live are CLI flags and route parameters, not first-visit decisions", boxes)
 	}
-	for _, want := range []string{".check.is-disabled", ".check-sub", ".form-hint-sub"} {
-		if !strings.Contains(string(css), want) {
-			t.Errorf("no style for %s, so the nested option renders identically to a "+
-				"top-level one whether it is usable or not", want)
+	if !strings.Contains(body, "include_events=1") {
+		t.Error("the card never sends include_events=1, so the change log cannot be asked for at all")
+	}
+	// Conditional, not always: the change log binds every archived file, so a
+	// download nobody asked for it must not carry it.
+	if !strings.Contains(body, `events.checked ? "?include_events=1" : ""`) {
+		t.Error("the change log is not conditional on the box, so the default download is not the cheap one")
+	}
+	// The two retired controls must not come back as silent always-on
+	// parameters, which would be worse than the checkboxes were.
+	for _, gone := range []string{"include_live", "pin_snapshot"} {
+		if strings.Contains(body, gone) {
+			t.Errorf("duckdbCard names %s again; it was removed from this surface, not moved into a default", gone)
 		}
 	}
 }
 
-func TestDuckDBCardOffersTheLiveLeg(t *testing.T) {
-	js, err := os.ReadFile("assets/app.js")
-	if err != nil {
-		t.Fatal(err)
-	}
-	body := functionBody(t, string(js), "function duckdbCard(")
+// TestDuckDBCardDrawsTheCostInsteadOfStatingIt is the guard for the drawing.
+//
+// The card used to carry "It takes longer to open the further back your archive
+// goes, because it reads a piece of every archived file". That sentence is the
+// shape of the data, and the shape is drawable: your tables are one file each,
+// the change log is one file per archived hour. Ticking the box lights the
+// strip, so the cost is seen.
+//
+// A picture can lie in a way prose cannot: nobody reports a diagram that merely
+// looks plausible. So the two halves are pinned to the one parameter the card
+// can send. If the strip stops being tied to the change-log box, the drawing
+// starts claiming something the download does not do.
+func TestDuckDBCardDrawsTheCostInsteadOfStatingIt(t *testing.T) {
+	js := readAsset(t, "app.js")
+	shape := functionBody(t, js, "function duckdbShape(")
+	card := functionBody(t, js, "function duckdbCard(")
 
-	if !strings.Contains(body, `type: "checkbox"`) {
-		t.Error("the card has no checkbox, so the live leg cannot be asked for from the UI")
+	// Both halves exist, and the change log is drawn as MANY units against the
+	// tables' few. That contrast is the whole explanation; equal counts would
+	// render a picture that says the two cost the same.
+	tiles := regexp.MustCompile(`tiles\((\d+), "dk-tile"\)`).FindStringSubmatch(shape)
+	bars := regexp.MustCompile(`tiles\((\d+), "dk-bar"\)`).FindStringSubmatch(shape)
+	if tiles == nil || bars == nil {
+		t.Fatal("duckdbShape no longer draws both a tile row (your tables) and a bar row (the change log)")
 	}
-	if !strings.Contains(body, "include_live=1") {
-		t.Error("the card never sends include_live=1, so ticking the box would download the archives-only file")
+	if len(bars[1]) <= len(tiles[1]) {
+		t.Errorf("the change log is drawn with %s units against the tables' %s; the picture has to show that "+
+			"one is a file per table and the other a file per archived hour", bars[1], tiles[1])
 	}
-	// The change log is opt-in since #1535, so the card has to offer it or the
-	// only file anyone can download from here is state-views-only.
-	if !strings.Contains(body, "include_events=1") {
-		t.Error("the card never sends include_events=1, so the change log cannot be asked for from the UI")
+
+	// The strip is dimmed until the box is ticked, and the card is what wires
+	// them together. Either half alone leaves a drawing that never changes.
+	if !strings.Contains(shape, "dk-off") {
+		t.Error("duckdbShape never applies dk-off, so the change-log half is drawn as if it were always included")
 	}
-	// The live leg hangs on the change-log view. Ticked on its own it earns a
-	// 400 from the route, so the UI must not let that state exist: the box
-	// starts disabled and is CLEARED when the change log is turned back off (a
-	// disabled checkbox keeps its checked state, and the request reads it).
-	if !strings.Contains(body, "disabled: true") {
-		t.Error("the live-leg box is not disabled to begin with, so it can be ticked " +
-			"without the view it is a leg of")
+	if !strings.Contains(card, `shape.events.classList.toggle("dk-off"`) {
+		t.Error("the change-log box does not light the strip, so ticking it explains nothing")
 	}
-	if !strings.Contains(body, "live.checked = false") {
-		t.Error("turning the change log back off leaves the live box checked, so the " +
-			"next download sends include_live=1 without include_events and is refused")
+	if !strings.Contains(card, "events.onchange();") {
+		t.Error("the initial state is never synced, so the strip renders lit before the box is ticked")
 	}
-	if !strings.Contains(body, "events.checked && live.checked") {
-		t.Error("the live parameter is not conditional on the change log being on too")
+
+	// Built with el(), not svgEl: that helper DOMParses STATIC icon constants
+	// only, and routing a drawing through it is how a string-to-DOM path grows
+	// an interpolated argument later.
+	if strings.Contains(shape, "svgEl(") {
+		t.Error("duckdbShape builds through svgEl, which is for static icon constants; draw with el()")
 	}
-	// The cost of the change log belongs on the PAGE. By the time the operator
-	// reads the generated file, the bind is already running. Deleting this
-	// paragraph left every other assertion here green.
-	for _, want := range []string{"takes longer to open", "every archived file"} {
-		if !strings.Contains(body, want) {
-			t.Errorf("the card does not state the cost of the change log (missing %q)", want)
+}
+
+// TestDuckDBCardStaysNearlyTextless is the Go half of the 300-character budget
+// the e2e enforces on the rendered card. It cannot count rendered text, so it
+// counts what the source can produce, and exists to fail on the desk rather
+// than in CI when someone starts explaining again.
+func TestDuckDBCardStaysNearlyTextless(t *testing.T) {
+	js := readAsset(t, "app.js")
+	body := functionBody(t, js, "function duckdbCard(")
+	// Only text OUTSIDE the fold: cnFine's contents are one click away and are
+	// not what a first-time reader meets. Everything up to the fold is visible.
+	visible := body
+	if i := strings.Index(body, "cnFine("); i >= 0 {
+		visible = body[:i]
+	}
+	total := 0
+	for _, m := range regexp.MustCompile(`text:\s*((?:"(?:[^"\\]|\\.)*"\s*\+?\s*)+)`).FindAllStringSubmatch(visible, -1) {
+		for _, lit := range regexp.MustCompile(`"((?:[^"\\]|\\.)*)"`).FindAllStringSubmatch(m[1], -1) {
+			total += len(lit[1])
 		}
 	}
-	// The VISUAL half of the nesting. `disabled: true` covers the functional
-	// half and was the only thing pinned, so deleting the whole disabled
-	// treatment — both class toggles AND the initial sync — stayed green while
-	// the inert sub-option rendered at full opacity, indistinguishable from a
-	// live control.
-	for _, want := range []string{`classList.toggle("is-disabled"`, "events.onchange();"} {
-		if !strings.Contains(body, want) {
-			t.Errorf("the nested option has no visible disabled state (missing %q)", want)
-		}
+	if total == 0 {
+		t.Fatal("no visible text found in duckdbCard; this guard covers nothing")
 	}
-	// Conditional, not always: the leg reads the live capture index and the
-	// change log binds every archived file, so a download nobody asked either
-	// of them for must carry neither. The two `events.checked` guards above are
-	// what enforce it now; a bare-URL assertion keeps the default honest.
-	if !strings.Contains(body, `"/api/views.sql" + (params.length`) {
-		t.Error("the card does not send a bare URL when nothing is ticked, so the " +
-			"default download is not the cheap one")
-	}
-	// The cost belongs on the page, not only in the generated file's comments:
-	// by the time an operator reads those, the query is already running.
-	for _, want := range []string{"live capture index", "competes"} {
-		if !strings.Contains(body, want) {
-			t.Errorf("the card does not state the cost of the live leg (missing %q)", want)
-		}
+	if total > 200 {
+		t.Errorf("duckdbCard's visible text is %d characters. The card explains itself by drawing; "+
+			"if something needs saying, either draw it or put it behind cnFine", total)
 	}
 }
 

--- a/internal/console/assets_duckdbcard_test.go
+++ b/internal/console/assets_duckdbcard_test.go
@@ -2,6 +2,7 @@ package console
 
 import (
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -20,11 +21,11 @@ import (
 // first-time reader, and the live leg in particular can compete with capture on
 // the source server. So exactly one box, and it is the change log.
 func TestDuckDBCardOffersOneDecision(t *testing.T) {
-	body := functionBody(t, readAsset(t, "app.js"), "function duckdbCard(")
+	body := functionBody(t, readAsset(t, "app.js"), "function duckdbPanel(")
 
 	boxes := strings.Count(body, `type: "checkbox"`)
 	if boxes != 1 {
-		t.Errorf("duckdbCard renders %d checkboxes, want exactly 1 (the change log); "+
+		t.Errorf("duckdbPanel renders %d checkboxes, want exactly 1 (the change log); "+
 			"pin-snapshot and include-live are CLI flags and route parameters, not first-visit decisions", boxes)
 	}
 	if !strings.Contains(body, "include_events=1") {
@@ -39,7 +40,7 @@ func TestDuckDBCardOffersOneDecision(t *testing.T) {
 	// parameters, which would be worse than the checkboxes were.
 	for _, gone := range []string{"include_live", "pin_snapshot"} {
 		if strings.Contains(body, gone) {
-			t.Errorf("duckdbCard names %s again; it was removed from this surface, not moved into a default", gone)
+			t.Errorf("duckdbPanel names %s again; it was removed from this surface, not moved into a default", gone)
 		}
 	}
 }
@@ -59,19 +60,28 @@ func TestDuckDBCardOffersOneDecision(t *testing.T) {
 func TestDuckDBCardDrawsTheCostInsteadOfStatingIt(t *testing.T) {
 	js := readAsset(t, "app.js")
 	shape := functionBody(t, js, "function duckdbShape(")
-	card := functionBody(t, js, "function duckdbCard(")
+	card := functionBody(t, js, "function duckdbPanel(")
 
 	// Both halves exist, and the change log is drawn as MANY units against the
 	// tables' few. That contrast is the whole explanation; equal counts would
 	// render a picture that says the two cost the same.
-	tiles := regexp.MustCompile(`tiles\((\d+), "dk-tile"\)`).FindStringSubmatch(shape)
-	bars := regexp.MustCompile(`tiles\((\d+), "dk-bar"\)`).FindStringSubmatch(shape)
+	tiles := regexp.MustCompile(`tiles\((\d+), "dk-tile"`).FindStringSubmatch(shape)
+	bars := regexp.MustCompile(`tiles\((\d+), "dk-bar"`).FindStringSubmatch(shape)
 	if tiles == nil || bars == nil {
 		t.Fatal("duckdbShape no longer draws both a tile row (your tables) and a bar row (the change log)")
 	}
-	if len(bars[1]) <= len(tiles[1]) {
-		t.Errorf("the change log is drawn with %s units against the tables' %s; the picture has to show that "+
-			"one is a file per table and the other a file per archived hour", bars[1], tiles[1])
+	// Compared as NUMBERS. This read len() of the digit strings, which is not
+	// quantity: it passed 24-vs-3 for the wrong reason and would have failed a
+	// perfectly good 9-vs-3. A picture guard that cannot compare the two
+	// quantities it exists to compare is decoration.
+	nTiles, err1 := strconv.Atoi(tiles[1])
+	nBars, err2 := strconv.Atoi(bars[1])
+	if err1 != nil || err2 != nil {
+		t.Fatalf("could not read the drawn counts (tiles=%q bars=%q)", tiles[1], bars[1])
+	}
+	if nBars < nTiles*4 {
+		t.Errorf("the change log is drawn with %d units against the tables' %d; the picture has to read as a "+
+			"different order of quantity, not as slightly more", nBars, nTiles)
 	}
 
 	// The strip is dimmed until the box is ticked, and the card is what wires
@@ -100,7 +110,7 @@ func TestDuckDBCardDrawsTheCostInsteadOfStatingIt(t *testing.T) {
 // than in CI when someone starts explaining again.
 func TestDuckDBCardStaysNearlyTextless(t *testing.T) {
 	js := readAsset(t, "app.js")
-	body := functionBody(t, js, "function duckdbCard(")
+	body := functionBody(t, js, "function duckdbPanel(")
 	// Only text OUTSIDE the fold: cnFine's contents are one click away and are
 	// not what a first-time reader meets. Everything up to the fold is visible.
 	visible := body
@@ -114,10 +124,10 @@ func TestDuckDBCardStaysNearlyTextless(t *testing.T) {
 		}
 	}
 	if total == 0 {
-		t.Fatal("no visible text found in duckdbCard; this guard covers nothing")
+		t.Fatal("no visible text found in duckdbPanel; this guard covers nothing")
 	}
 	if total > 200 {
-		t.Errorf("duckdbCard's visible text is %d characters. The card explains itself by drawing; "+
+		t.Errorf("duckdbPanel's visible text is %d characters. The card explains itself by drawing; "+
 			"if something needs saying, either draw it or put it behind cnFine", total)
 	}
 }

--- a/internal/console/views_api.go
+++ b/internal/console/views_api.go
@@ -51,13 +51,19 @@ func (s *Server) buildViewsInput(ctx context.Context, b *bundle, portable, omitE
 		Version:     s.version,
 		OmitEvents:  omitEvents,
 	}
-	// The download CAN carry the hot leg now (the "Include the live index"
-	// box), so the archives-only note names that box rather than a flag the
-	// reader is not at a command line to pass. A server this console cannot
-	// reach by host and port has no route at all, and says so instead.
-	if consoleCanOfferLiveLeg(b) {
-		in.LiveLegHowTo = liveLegHowTo
-	} else {
+	// LiveLegHowTo is deliberately NOT set any more. It existed because this
+	// reader had a checkbox and "a flag they cannot pass is not remediation"
+	// (see the field's own doc). The card no longer offers the live leg, so
+	// that reader has no control, and the generator's own wording — regenerate
+	// with `bintrail views --include-live` — became the truthful route rather
+	// than the fallback. Leaving the override in place would point at a box
+	// that does not exist, which is the exact failure the constant was added
+	// to prevent, in the other direction.
+	//
+	// LiveLegUnavailable still matters and is still per-server: a server this
+	// console cannot reach by host and port cannot carry the leg from ANY
+	// surface, so the note must not send its reader to the CLI either.
+	if !consoleCanOfferLiveLeg(b) {
 		in.LiveLegUnavailable = true
 	}
 	var archiveErr error

--- a/internal/console/views_live.go
+++ b/internal/console/views_live.go
@@ -31,18 +31,6 @@ import (
 //   - which source the index serves, which can only be stated when exactly one
 //     is registered.
 
-// liveLegHowTo is the archives-only note's remediation for a reader who
-// downloaded the file from this page. It replaces the CLI flag the generator
-// would otherwise name (views.Input.LiveLegHowTo).
-// The labels are quoted VERBATIM from the card, and the prerequisite is named:
-// the live box is nested under the change-log one and inert until that is
-// ticked, so a reader told only about the sub-option would hunt for a control
-// they cannot use yet. This text is rendered into the generated file, and
-// remediation naming a control that does not exist is the exact failure the
-// constant exists to prevent -- which is what happened when the card's label
-// changed and this did not.
-const liveLegHowTo = `Add a leg over the live index by ticking "Include the change log" and then "…and the live index" under it, on the Download a DuckDB schema card, then downloading again.`
-
 // liveLegConfigError is a live leg this server cannot carry however it is
 // asked for: no open connection, or an index DSN that names no reachable
 // host, port or database. It is the caller's request meeting this server's

--- a/internal/console/views_live_test.go
+++ b/internal/console/views_live_test.go
@@ -122,13 +122,16 @@ func TestViewsAPI_liveLegIsOptIn(t *testing.T) {
 	if strings.Contains(sql, "bintrail_live") || strings.Contains(sql, "ATTACH ''") {
 		t.Errorf("the live leg is in a file nobody asked it for:\n%s", sql)
 	}
-	// And the archives-only note names the control THIS reader has. The CLI
-	// flag is not something a browser can pass.
-	if !strings.Contains(sql, `"…and the live index"`) {
-		t.Errorf("the archives-only note does not name the console's own route:\n%s", sql)
+	// And the archives-only note names the route this reader HAS, which is now
+	// the CLI. It used to be a checkbox, and the note named it verbatim; the
+	// card no longer offers the live leg, so the console stops overriding
+	// LiveLegHowTo and the generator's own wording becomes the true one.
+	// Inverted deliberately: the rule did not change, the reader's controls did.
+	if !strings.Contains(sql, "--include-live") {
+		t.Errorf("the archives-only note names no route at all for the live leg:\n%s", sql)
 	}
-	if strings.Contains(sql, "--include-live") {
-		t.Errorf("the note sends a console reader to a command-line flag:\n%s", sql)
+	if strings.Contains(sql, "and the live index") {
+		t.Errorf("the note still points at a checkbox this card no longer has:\n%s", sql)
 	}
 	// The probe queries must not have run either: this download asked the
 	// index nothing.

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -3944,6 +3944,19 @@ try {
       // The 404-honesty rule's photographable half: this run is the
       // unversioned arm, where a direct release-asset link can only 404.
       downloadLinks: document.querySelectorAll('.view a[href*="/releases/download/"]').length,
+      // The DuckDB card carries its OWN budget (300), tighter than the view's,
+      // because it is the card that explains itself by drawing rather than by
+      // prose. Located by its title so a restyle does not silently unhook the
+      // measurement; a card that cannot be found reads as -1, never as 0,
+      // which would pass the budget by measuring nothing.
+      duckCardChars: (() => {
+        const c = Array.from(document.querySelectorAll(".view .card"))
+          .find((n) => /Download a DuckDB schema/.test(n.textContent || ""));
+        return c ? c.innerText.length : -1;
+      })(),
+      duckDrawn: document.querySelectorAll(".view .dk-shape .dk-tile").length,
+      duckBars: document.querySelectorAll(".view .dk-shape .dk-bar").length,
+      duckLit: document.querySelectorAll(".view .dk-shape .dk-part:not(.dk-off)").length,
     };
   });
   (cn.badges === "123")
@@ -3955,6 +3968,20 @@ try {
   (cn.visibleChars > 0 && cn.visibleChars < 1500 && cn.fine >= 1)
     ? ok("connect: visible text stays under budget with fine print folded")
     : bad("connect: visible text stays under budget with fine print folded", "chars " + cn.visibleChars + " fine " + cn.fine);
+  // The card's own budget. 300 characters is roughly fifty words: enough for a
+  // title, one control and a button, and not enough to start explaining. The
+  // card used to carry three checkboxes and three multi-line caveats.
+  (cn.duckCardChars > 0 && cn.duckCardChars <= 300)
+    ? ok("connect: the DuckDB card stays under 300 visible characters")
+    : bad("connect: the DuckDB card stays under 300 visible characters", "chars " + cn.duckCardChars);
+  // And it is under budget because it DRAWS, not because the prose was folded
+  // out of sight. Folding passes a character count while leaving the same wall
+  // one click away, so the drawing has to be on screen for the budget to mean
+  // anything. The change-log strip starts dark: exactly one half is lit.
+  (cn.duckDrawn > 0 && cn.duckBars > cn.duckDrawn && cn.duckLit === 1)
+    ? ok("connect: the DuckDB card draws the shape, with the change log unlit until asked for")
+    : bad("connect: the DuckDB card draws the shape, with the change log unlit until asked for",
+        JSON.stringify({ tiles: cn.duckDrawn, bars: cn.duckBars, lit: cn.duckLit }));
   // "shown only once" is carried by the fresh state and the managed state
   // (except managed read_only, which drops the Lost-it clause and the phrase
   // with it); this run exercises the fresh one (no scenario mints a token).

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -3950,7 +3950,7 @@ try {
       // measurement; a card that cannot be found reads as -1, never as 0,
       // which would pass the budget by measuring nothing.
       duckCardChars: (() => {
-        const c = Array.from(document.querySelectorAll(".view .card"))
+        const c = Array.from(document.querySelectorAll(".view .card, .view .ov-panel"))
           .find((n) => /Download a DuckDB schema/.test(n.textContent || ""));
         return c ? c.innerText.length : -1;
       })(),


### PR DESCRIPTION
Follow-up to #1549, per the direction that the UI should be almost text-free and explain with a picture where a picture works.

## Before / after

The card carried three checkboxes, each trailed by a multi-line caveat, on the page that enforces a visible-text budget precisely because #1430 established that spelling every contingency out reads as a wall. It arrived at **2052 characters against a 1500 ceiling**.

Folding it got under the ceiling and fixed nothing. The same 879 characters were still there, one click from a reader who does not know what "the change log" is. A budget you can satisfy by hiding text rewards hiding.

## What replaced the prose

The one decision a reader makes is whether to include the change log, and its whole cost is a shape:

```
  ▢ ▢ ▢                              your tables          (one file each)
  ▏▏▏▏▏▏▏▏▏▏▏▏▏▏▏▏▏▏▏▏▏▏▏▏           every change         (one file per hour)
```

Ticking the box lights the strip. That replaces *"It takes longer to open the further back your archive goes, because it reads a piece of every archived file before answering anything"* — a sentence describing a picture.

`claudeAskMock` on this same page already does this, and its comment states the rule: it draws Claude Desktop's dialog "so the user recognizes the two fields instead of reading a paragraph about them".

## Two controls leave this surface

`--pin-snapshot` and `--include-live` stay as CLI flags and route parameters. Neither is a first-visit decision, and the live leg in particular scans the live capture index and competes with capture on that server — not something to sit two clicks from someone being explained nothing.

That **inverts** `TestViewsAPI_liveLegIsOptIn`, which is the point rather than a casualty. `liveLegHowTo` existed because "that reader has a checkbox, not a command line, and a flag they cannot pass is not remediation". The reader no longer has a checkbox, so the console stops overriding `LiveLegHowTo` and the generator's own `bintrail views --include-live` becomes the true route. The constant is deleted, and with it the cross-file pin between the card title and the generated file, which now refers to neither.

`LiveLegUnavailable` still applies per server: one this console cannot reach by host and port has no route from any surface, so its note must not send the reader to the CLI either.

## Guarding a drawing

Prose that goes stale reads wrong and someone reports it. **A diagram that goes stale looks fine.** So the guards pin the drawing, not only the character count:

- the bars must outnumber the tiles (equal counts would draw a picture saying the two cost the same)
- the strip must be dark until the box is ticked, and the card must be what wires them
- built with `el()`, never `svgEl`, which DOMParses static icon constants

Two budgets on purpose: the e2e measures the **rendered** card at 300 and additionally asserts the drawing is on screen, so passing by folding is not available; a Go guard counts what the source can produce, at 200, to fail on the desk rather than in CI.

## Test plan

- [x] `go test ./... -count=1` — 55 packages ok
- [x] Three mutations, three red: bars drawn equal to tiles; a retired checkbox back; the replaced paragraph restored
- [x] Dead CSS removed (`.check-sub`, `.form-hint-sub`, `.check.is-disabled`) — the nested control was their only user
- [ ] console-e2e confirms the rendered card under 300 (CI)