### PR TITLE
views: follow a refreshed baseline on an S3 root

### DIFF
--- a/internal/cli/views.go
+++ b/internal/cli/views.go
@@ -77,13 +77,18 @@ neither: --baseline-dir/--baseline-s3 on its own is enough. That is what a
 snapshot downloaded from the console arrives as, and it can be queried on a
 machine that cannot reach the index at all.
 
-The file is a snapshot of the layout, not a live binding. The state views point
-at one snapshot: regenerate after taking or refreshing a baseline. A daemon
-running bintrail-console watch --baseline-refresh-interval publishes a new
-snapshot every interval and this file does not follow it, with no error and no
-warning, so regenerate on that same schedule. (With --include-events, that
-view's globs DO keep picking up newly rotated partitions on their own -- it is
-the one self-following part of the file.)
+The file is a snapshot of the LAYOUT, not of the rows. The state views reach a
+baseline published later on their own, by whichever route the root allows: a
+--baseline-dir file reads through the current/ pointer, and a --baseline-s3
+file, which has no pointer object to read through, has each view select the
+newest snapshot carrying a _SUCCESS marker at the moment it is read. Pass
+--pin-snapshot to bind them to the snapshot that exists now instead.
+
+What does NOT follow is the shape: which views exist, and how each DECIMAL
+column is read, were both decided from the snapshot named in the file.
+Regenerate after a table is added or dropped, after a column changes type, and
+whenever archive sources are added or removed. (With --include-events, that
+view's globs also keep picking up newly rotated partitions on their own.)
 
 Examples:
   # One view per table, as of the newest baseline snapshot
@@ -352,38 +357,8 @@ func resolveBaselineViews(ctx context.Context, in *views.Input) error {
 	// nothing, so every DECIMAL column ships uncast while the file blames an
 	// unreadable footer that was never read.
 	resolveBaselineDecimals(ctx, in)
-	followCurrentPointer(in, vBaselineDir, vPinSnapshot)
+	views.ApplyFollow(in, in.BaselineSource, vPinSnapshot)
 	return nil
-}
-
-// followCurrentPointer repoints the resolved state view paths at the baselines
-// root's `current` symlink, so a snapshot published later reaches an
-// already-generated file (#1484). It reports what it did through
-// in.FollowsSnapshot, which is what makes the generated file describe itself.
-//
-// --pin-snapshot is the only decision made here: the operator asked for today's
-// rows to stay today's. Every other reason to pin belongs to the rule itself
-// and lives in baseline.RewriteToPointer, so the console download cannot end up
-// following under conditions this command would not.
-//
-// root is the LOCAL baselines directory, and is "" under --baseline-s3: an S3
-// root has no pointer to follow.
-func followCurrentPointer(in *views.Input, root string, pin bool) {
-	if pin {
-		return
-	}
-	paths := make([]string, len(in.Baselines))
-	for i, t := range in.Baselines {
-		paths[i] = t.Path
-	}
-	rewritten, ok := baseline.RewriteToPointer(root, paths)
-	if !ok {
-		return
-	}
-	for i := range in.Baselines {
-		in.Baselines[i].Path = rewritten[i]
-	}
-	in.FollowsSnapshot = true
 }
 
 // resolveBaselineDecimals reads each table's column types out of its Parquet

--- a/internal/cli/views.go
+++ b/internal/cli/views.go
@@ -128,7 +128,7 @@ func init() {
 	viewsCmd.Flags().StringVar(&vArchiveDir, "archive-dir", "", "Local root directory of Parquet archives (requires --bintrail-id)")
 	viewsCmd.Flags().StringVar(&vArchiveS3, "archive-s3", "", "S3 root URL prefix of Parquet archives (requires --bintrail-id; e.g. s3://bucket/prefix/)")
 	viewsCmd.Flags().StringVar(&vBintrailID, "bintrail-id", "", "Server identity UUID (required when --archive-dir or --archive-s3 is set)")
-	viewsCmd.Flags().BoolVar(&vPinSnapshot, "pin-snapshot", false, "Bind the state views to the snapshot discovered now, so they keep returning today's rows after a baseline refresh (default: follow the newest snapshot, where the baseline root has a pointer to follow)")
+	viewsCmd.Flags().BoolVar(&vPinSnapshot, "pin-snapshot", false, "Bind the state views to the snapshot discovered now, so they keep returning today's rows after a baseline refresh (default: follow the newest snapshot, through the current/ pointer locally and through the newest _SUCCESS marker on S3)")
 	viewsCmd.Flags().StringVar(&vRegion, "region", "", "AWS region to pin in the generated S3 secret (default: resolved by the credential chain)")
 	viewsCmd.Flags().StringVar(&vBaselineDir, "baseline-dir", "", "Local directory of baseline Parquet snapshots")
 	viewsCmd.Flags().StringVar(&vBaselineS3, "baseline-s3", "", "S3 URL prefix of baseline Parquet snapshots (e.g. s3://bucket/baselines/)")

--- a/internal/cli/views_follow_test.go
+++ b/internal/cli/views_follow_test.go
@@ -149,22 +149,58 @@ func TestRunViews_doesNotFollowWhenTheRootHasNoPointer(t *testing.T) {
 	}
 }
 
-// TestFollowCurrentPointer_declinesForS3 pins that an S3 baseline root is never
-// followed. There is no pointer object to follow there: publishing one would
-// mean copying every table to a second prefix, which is not atomic across
-// tables, so a query could read half of one snapshot and half of another.
-func TestFollowCurrentPointer_declinesForS3(t *testing.T) {
+// TestApplyFollow_s3FollowsByMarkerNotByPointer pins WHICH mechanism an S3
+// baseline root gets (#1550).
+//
+// Never the pointer, and the original reason still holds: there is no pointer
+// object in S3, and publishing one would mean copying every table to a second
+// prefix, which is not atomic across tables, so a query could read half of one
+// snapshot and half of another. What changed is that refusing the pointer is no
+// longer the end of it — the views select the newest marked snapshot when they
+// are READ, which needs no second prefix and no rewritten path.
+//
+// The path staying put is half the assertion: under FollowNewest the following
+// lives in the emitted SQL, so a rewritten path here would mean two mechanisms
+// were applied to one table.
+func TestApplyFollow_s3FollowsByMarkerNotByPointer(t *testing.T) {
 	in := &views.Input{
 		BaselineSource: "s3://bucket/baselines/",
 		Baselines: []views.BaselineTable{
 			{Schema: "shop", Table: "orders", Path: "s3://bucket/baselines/2026-06-10T12-00-00Z/shop/orders.parquet"},
 		},
 	}
-	followCurrentPointer(in, "", false) // --baseline-s3 leaves the local root empty
-	if in.FollowsSnapshot {
-		t.Fatal("an S3 baseline root was marked as following a pointer")
+	views.ApplyFollow(in, in.BaselineSource, false)
+	if in.Follow != views.FollowNewest {
+		t.Fatalf("an S3 baseline root got Follow=%v, want FollowNewest", in.Follow)
 	}
 	if !strings.Contains(in.Baselines[0].Path, "2026-06-10T12-00-00Z") {
 		t.Fatalf("S3 path was rewritten: %q", in.Baselines[0].Path)
+	}
+	if strings.Contains(in.Baselines[0].Path, baseline.CurrentLinkName) {
+		t.Fatalf("S3 path was pointed at a pointer that cannot exist: %q", in.Baselines[0].Path)
+	}
+	if got := in.Baselines[0].Rel; got != "shop/orders.parquet" {
+		t.Errorf("Rel is %q, want the path below the snapshot directory", got)
+	}
+}
+
+// TestApplyFollow_pinRefusesEveryMechanism keeps --pin-snapshot ahead of the
+// mechanism choice. It is the operator asking for today's rows to stay today's,
+// and an answer of "not the pointer, so the marker instead" would honour the
+// letter of the refusal while following anyway.
+func TestApplyFollow_pinRefusesEveryMechanism(t *testing.T) {
+	in := &views.Input{
+		BaselineSource: "s3://bucket/baselines/",
+		Baselines: []views.BaselineTable{
+			{Schema: "shop", Table: "orders", Path: "s3://bucket/baselines/2026-06-10T12-00-00Z/shop/orders.parquet"},
+		},
+	}
+	views.ApplyFollow(in, in.BaselineSource, true)
+	if in.Follow != views.FollowNone {
+		t.Fatalf("--pin-snapshot still followed, with Follow=%v", in.Follow)
+	}
+	if in.Baselines[0].Rel != "" {
+		t.Errorf("a pinned table carries Rel=%q; nothing should have been prepared to follow with",
+			in.Baselines[0].Rel)
 	}
 }

--- a/internal/cli/views_help_test.go
+++ b/internal/cli/views_help_test.go
@@ -30,16 +30,33 @@ func TestIncludeLiveHelp_saysWhatItQueries(t *testing.T) {
 	}
 }
 
-// TestViewsLongHelp_namesTheRefreshInterval is the command-help half of #1484.
+// TestViewsLongHelp_saysTheStateViewsFollow replaces the #1484 guard, whose
+// premise this command has now outgrown.
 //
-// The Long help said to regenerate "after taking or refreshing a baseline",
-// which reads as an action the operator takes. With the refresh on a timer
-// nobody takes it, and nothing regenerates the file.
-func TestViewsLongHelp_namesTheRefreshInterval(t *testing.T) {
-	for _, want := range []string{"--baseline-refresh-interval", "regenerate"} {
-		if !strings.Contains(strings.ToLower(viewsCmd.Long), strings.ToLower(want)) {
-			t.Errorf("the views help does not say %q:\n%s", want, viewsCmd.Long)
+// That guard required the Long help to name --baseline-refresh-interval,
+// because a timer-published snapshot left the file behind and the operator had
+// to regenerate on the same schedule. The state views now reach a later
+// snapshot on their own from either root shape (#1547 local, #1550 S3), so
+// repeating that advice would not merely be redundant, it would send an
+// operator to do work the product already does. What still needs saying is
+// which half does NOT follow, and how to opt out of the half that does.
+func TestViewsLongHelp_saysTheStateViewsFollow(t *testing.T) {
+	long := viewsCmd.Long
+	for _, want := range []string{
+		"current/",       // how a local root follows
+		"_SUCCESS",       // how an S3 root follows, having no pointer
+		"--pin-snapshot", // the opt-out, which is the only reason to mention either
+		"Regenerate after a table is added or dropped", // the half that never follows
+	} {
+		if !strings.Contains(long, want) {
+			t.Errorf("the views help does not say %q:\n%s", want, long)
 		}
+	}
+	// Named rather than left to the positive checks above: the sentence this
+	// replaces is a specific false claim, and a rewrite that reinstated it
+	// alongside the new ones would satisfy every check above.
+	if strings.Contains(long, "does not follow it") {
+		t.Error("the views help still claims the file does not follow a refreshed baseline")
 	}
 }
 

--- a/internal/console/views_api.go
+++ b/internal/console/views_api.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dbtrail/dbtrail/internal/baseline"
 	"github.com/dbtrail/dbtrail/internal/query"
 	"github.com/dbtrail/dbtrail/internal/reconstruct"
 	"github.com/dbtrail/dbtrail/internal/storage"
@@ -100,7 +99,7 @@ func (s *Server) buildViewsInput(ctx context.Context, b *bundle, portable, omitE
 			// file, since following only happens when the pointer names this
 			// snapshot, so reading the pinned one costs nothing.
 			s.resolveBaselineDecimals(ctx, &in)
-			followBaselinePointer(&in, b.baselineSrc, pinSnapshot)
+			views.ApplyFollow(&in, b.baselineSrc, pinSnapshot)
 		}
 	}
 	if len(in.ArchiveSources) == 0 && len(in.Baselines) == 0 {
@@ -351,31 +350,4 @@ func (s *Server) viewsAvailable(r *http.Request, b *bundle) bool {
 	// sources is nil whenever err is set, so the err check is intent, not a
 	// distinct branch: the gate must never say yes on a failed read.
 	return err == nil && len(sources) > 0
-}
-
-// followBaselinePointer is the console's half of "follow the newest snapshot".
-// It mirrors the `bintrail views` wrapper exactly, and both defer the rule
-// itself to baseline.RewriteToPointer, so the two producers of a views file
-// cannot disagree about when following is safe.
-//
-// src may be an s3:// URL, which RewriteToPointer refuses on its own: there is
-// no pointer object in S3 to follow, and it looks for one on the filesystem. A
-// prefix check here would read as the guard while changing nothing, so the rule
-// is left in the one place that enforces it.
-func followBaselinePointer(in *views.Input, src string, pin bool) {
-	if pin {
-		return
-	}
-	paths := make([]string, len(in.Baselines))
-	for i, t := range in.Baselines {
-		paths[i] = t.Path
-	}
-	rewritten, ok := baseline.RewriteToPointer(src, paths)
-	if !ok {
-		return
-	}
-	for i := range in.Baselines {
-		in.Baselines[i].Path = rewritten[i]
-	}
-	in.FollowsSnapshot = true
 }

--- a/internal/console/views_follow_decimal_test.go
+++ b/internal/console/views_follow_decimal_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/dbtrail/dbtrail/internal/baseline"
+	"github.com/dbtrail/dbtrail/internal/views"
 )
 
 // TestViewsAPI_bothShapesOfOneSnapshotKeepTheirCasts is the guard for a bug the
@@ -82,8 +83,9 @@ func TestSQLPanelInput_pins(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildViewsInput: %v", err)
 	}
-	if in.FollowsSnapshot {
-		t.Fatal("the SQL panel's input follows the pointer; it executes its views, so it must pin")
+	if in.Follow != views.FollowNone {
+		t.Fatalf("a pin_snapshot=true download still follows (Follow=%v); pinning is the one "+
+			"request that must reach neither mechanism", in.Follow)
 	}
 	for _, b := range in.Baselines {
 		if strings.Contains(b.Path, baseline.CurrentLinkName) {

--- a/internal/views/follow.go
+++ b/internal/views/follow.go
@@ -1,0 +1,80 @@
+package views
+
+import (
+	"strings"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
+)
+
+// ApplyFollow decides how the state views will reach a snapshot published after
+// this file is generated, and records it on in.
+//
+// One function for both producers on purpose. The CLI and the console download
+// serve the same file to the same reader, and they used to carry a byte-identical
+// copy of this decision each; a mode added to one of them and not the other is a
+// file whose header describes a following its own views do not do.
+//
+// pin is the operator asking for today's rows to stay today's, and it is the only
+// decision made here. Every other reason to refuse belongs to the mechanism:
+// baseline.RewriteToPointer owns the pointer's conditions, and the S3 arm below
+// owns its own.
+func ApplyFollow(in *Input, root string, pin bool) {
+	if pin || len(in.Baselines) == 0 {
+		return
+	}
+	paths := make([]string, len(in.Baselines))
+	for i, t := range in.Baselines {
+		paths[i] = t.Path
+	}
+	if rewritten, ok := baseline.RewriteToPointer(root, paths); ok {
+		for i := range in.Baselines {
+			in.Baselines[i].Path = rewritten[i]
+		}
+		in.Follow = FollowPointer
+		return
+	}
+	// A local root that refused the rewrite stops here rather than falling
+	// through: RewriteToPointer refuses when the pointer names a DIFFERENT
+	// snapshot than the one discovered, and answering that by following
+	// something else is how a file comes to serve rows its header does not
+	// describe. FollowNewest is the S3 answer to having no pointer at all.
+	if !isS3(root) {
+		return
+	}
+	rels := make([]string, len(in.Baselines))
+	for i, t := range in.Baselines {
+		rel, ok := snapshotRel(root, t.Path)
+		if !ok {
+			// All or nothing. A file where some state views follow and others
+			// are pinned reads exactly like one where they all do, and the two
+			// halves would drift apart at the first refresh.
+			return
+		}
+		rels[i] = rel
+	}
+	for i := range in.Baselines {
+		in.Baselines[i].Rel = rels[i]
+	}
+	in.Follow = FollowNewest
+}
+
+// snapshotRel cuts a table's path down to its position inside a snapshot
+// directory: "s3://bucket/baselines/2026-08-31T06-00-45Z/shop/orders.parquet"
+// under root "s3://bucket/baselines/" gives "shop/orders.parquet".
+//
+// String operations, never filepath: filepath.Clean collapses the "//" in a
+// scheme, so every path helper in the standard library turns "s3://bucket/x"
+// into "s3:/bucket/x". Rel happens to survive that because it mangles both
+// sides identically, which is a coincidence and not a contract.
+func snapshotRel(root, path string) (string, bool) {
+	base := strings.TrimSuffix(root, "/") + "/"
+	rel, ok := strings.CutPrefix(path, base)
+	if !ok {
+		return "", false
+	}
+	_, rest, found := strings.Cut(rel, "/")
+	if !found || rest == "" {
+		return "", false
+	}
+	return rest, true
+}

--- a/internal/views/follow_golden_test.go
+++ b/internal/views/follow_golden_test.go
@@ -10,8 +10,9 @@ import (
 )
 
 // followInput is goldenInput moved to a LOCAL baselines root reading through
-// the pointer, which is the only shape that can follow: an S3 root has no
-// pointer, so the shared goldenInput cannot express this render.
+// the pointer. It is one of TWO shapes that follow: an S3 root has no pointer
+// object to rewrite, so it follows by selecting the newest marked snapshot at
+// query time instead, and newestInput below is that render.
 func followInput() Input {
 	in := goldenInput()
 	root := "/data/baselines"
@@ -21,13 +22,13 @@ func followInput() Input {
 		in.Baselines[i].Path = filepath.Join(root, baseline.CurrentLinkName,
 			t.Schema, filepath.Base(t.Path))
 	}
-	in.FollowsSnapshot = true
+	in.Follow = FollowPointer
 	return in
 }
 
-// TestGenerate_followGolden pins the followed render as bytes.
+// TestGenerate_followGolden pins the pointer-followed render as bytes.
 //
-// Every sentence FollowsSnapshot introduces replaces one that says the
+// Every sentence following introduces replaces one that says the
 // opposite: "stays bound to the snapshot it was generated against" becomes
 // "the state views below move to it when it completes". A guard written as an
 // absence check would pass on a revert, because reverting restores the OTHER
@@ -80,12 +81,52 @@ func TestGenerate_followingDropsTheStaleWarning(t *testing.T) {
 	}
 
 	pinned := followInput()
-	pinned.FollowsSnapshot = false
+	pinned.Follow = FollowNone
 	out := Generate(pinned)
 	if !strings.Contains(out, stale) {
 		t.Error("a pinned file dropped the warning that its state views stop changing")
 	}
 	if strings.Contains(out, moves) {
 		t.Error("a pinned file claims its state views move")
+	}
+}
+
+// newestInput is goldenInput following by marker instead of by pointer, which
+// is what an S3 root does. It goes through ApplyFollow rather than setting the
+// mode by hand: the decision to follow an S3 root at all is half of #1550, and
+// a test that assigned FollowNewest itself would still pass if the producer
+// stopped reaching it.
+func newestInput() Input {
+	in := goldenInput()
+	ApplyFollow(&in, in.BaselineSource, false)
+	return in
+}
+
+// TestGenerate_newestGolden pins the marker-followed render as bytes.
+//
+// Its own golden, not a variant of the pointer one: this render is the only
+// place several sentences and the whole CASE body appear, and #1546 already
+// showed that guards phrased as absence checks pass on a revert. A golden is
+// the shape that cannot.
+//
+// Regenerate with `go test ./internal/views -update` after an INTENTIONAL
+// change, and read the diff before committing it.
+func TestGenerate_newestGolden(t *testing.T) {
+	got := Generate(newestInput())
+	golden := filepath.Join("testdata", "views.newest.golden.sql")
+
+	if *update {
+		if err := os.WriteFile(golden, []byte(got), 0o644); err != nil {
+			t.Fatalf("write golden: %v", err)
+		}
+		t.Log("golden updated")
+		return
+	}
+	want, err := os.ReadFile(golden)
+	if err != nil {
+		t.Fatalf("read golden (run with -update to create it): %v", err)
+	}
+	if got != string(want) {
+		t.Errorf("generated SQL differs from %s.\n--- got ---\n%s\n--- want ---\n%s", golden, got, want)
 	}
 }

--- a/internal/views/newest_execute_test.go
+++ b/internal/views/newest_execute_test.go
@@ -1,0 +1,191 @@
+package views
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
+)
+
+// writeSnapshot writes one baseline snapshot holding shop.orders with the given
+// status values, and marks it complete unless marked is false.
+func writeSnapshot(t *testing.T, root, stamp string, marked bool, statuses ...string) string {
+	t.Helper()
+	path := filepath.Join(root, stamp, "shop", "orders.parquet")
+	cols, err := baseline.ParseSchema(writeSchemaFile(t))
+	if err != nil {
+		t.Fatalf("ParseSchema: %v", err)
+	}
+	w, err := baseline.NewWriter(path, cols, baseline.WriterConfig{Compression: "none", RowGroupSize: 100})
+	if err != nil {
+		t.Fatalf("baseline writer: %v", err)
+	}
+	for i, st := range statuses {
+		if err := w.WriteRow([]string{string(rune('1' + i)), st}, []bool{false, false}); err != nil {
+			t.Fatalf("write row: %v", err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	if marked {
+		marker := filepath.Join(root, stamp, baseline.SuccessMarker)
+		if err := os.WriteFile(marker, nil, 0o644); err != nil {
+			t.Fatalf("write marker: %v", err)
+		}
+	}
+	return path
+}
+
+// newestFixture renders the FollowNewest state view over a LOCAL root.
+//
+// Follow and Rel are set directly instead of through ApplyFollow, which reaches
+// this mode only for an s3:// root. What is under test here is the SQL the mode
+// EMITS, and DuckDB reads a local glob and an S3 one through the same code path;
+// that ApplyFollow reaches the mode at all is what the golden covers.
+func newestFixture(t *testing.T, root, tableRel string) string {
+	t.Helper()
+	return Generate(Input{
+		GeneratedAt:      time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
+		Version:          "test",
+		BaselineSource:   root,
+		BaselineSnapshot: time.Date(2026, 4, 30, 3, 0, 0, 0, time.UTC),
+		Follow:           FollowNewest,
+		Baselines: []BaselineTable{{
+			Schema: "shop", Table: "orders",
+			Path: filepath.Join(root, "2026-04-30T03-00-00Z", tableRel),
+			Rel:  tableRel,
+		}},
+	})
+}
+
+func execViews(t *testing.T, sqlText string) *sql.DB {
+	t.Helper()
+	db, err := loadViews(t, sqlText)
+	if err != nil {
+		t.Fatalf("DuckDB rejected the generated views:\n%v\n\n--- generated ---\n%s", err, sqlText)
+	}
+	return db
+}
+
+// loadViews runs the generated file and HANDS BACK the error, for the cases
+// where refusing to load is the behaviour under test.
+func loadViews(t *testing.T, sqlText string) (*sql.DB, error) {
+	t.Helper()
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	_, err = db.Exec(sqlText)
+	return db, err
+}
+
+// TestNewestStateView_readsTheNewestMarkedSnapshot runs the emitted SQL, which
+// the golden cannot do: a file that pins byte-for-byte can still be invalid SQL,
+// or valid SQL that selects the wrong file.
+//
+// The two snapshots hold DIFFERENT rows on purpose. A view that ignored the
+// filter and unioned both, or that picked the older one, returns a row count or
+// a value this asserts against, so the test cannot pass by reading whatever
+// happens to be there.
+func TestNewestStateView_readsTheNewestMarkedSnapshot(t *testing.T) {
+	root := t.TempDir()
+	writeSnapshot(t, root, "2026-04-30T03-00-00Z", true, "old-a", "old-b")
+	writeSnapshot(t, root, "2026-05-30T03-00-00Z", true, "new-a")
+
+	db := execViews(t, newestFixture(t, root, filepath.Join("shop", "orders.parquet")))
+
+	var n int
+	var status string
+	if err := db.QueryRow(`SELECT count(*), min("status") FROM state_shop_orders`).Scan(&n, &status); err != nil {
+		t.Fatalf("query state view: %v", err)
+	}
+	if n != 1 || status != "new-a" {
+		t.Errorf("state view read %d row(s) with status %q; want 1 row of \"new-a\" (the newest marked snapshot)", n, status)
+	}
+}
+
+// TestNewestStateView_ignoresAnUnmarkedNewerSnapshot pins the anchor. A snapshot
+// directory with a later name but no marker is a run that failed or is still
+// writing, and reading it would serve a half-published table as the current one.
+func TestNewestStateView_ignoresAnUnmarkedNewerSnapshot(t *testing.T) {
+	root := t.TempDir()
+	writeSnapshot(t, root, "2026-04-30T03-00-00Z", true, "complete")
+	writeSnapshot(t, root, "2026-05-30T03-00-00Z", false, "half-written")
+
+	db := execViews(t, newestFixture(t, root, filepath.Join("shop", "orders.parquet")))
+
+	var status string
+	if err := db.QueryRow(`SELECT "status" FROM state_shop_orders`).Scan(&status); err != nil {
+		t.Fatalf("query state view: %v", err)
+	}
+	if status != "complete" {
+		t.Errorf("state view read %q; want \"complete\" (the unmarked newer snapshot must not win)", status)
+	}
+}
+
+// TestNewestStateView_raisesWhenTheTableLeftTheNewestSnapshot is the guarantee
+// this mechanism exists to keep, and the one it is easiest to lose.
+//
+// The shape this replaced returned ZERO ROWS with no error when its filter
+// matched nothing, and an empty table that should have had rows is a worse
+// answer than a stale one. Reading one named file cannot fail that way: the
+// path is either there or DuckDB refuses it. This asserts the refusal.
+func TestNewestStateView_raisesWhenTheTableLeftTheNewestSnapshot(t *testing.T) {
+	root := t.TempDir()
+	writeSnapshot(t, root, "2026-04-30T03-00-00Z", true, "here")
+	// A newer complete snapshot that does NOT carry shop.orders. Another table
+	// is what makes it a real snapshot rather than an empty directory.
+	writeSnapshot(t, root, "2026-05-30T03-00-00Z", true, "elsewhere")
+	if err := os.Rename(filepath.Join(root, "2026-05-30T03-00-00Z", "shop"),
+		filepath.Join(root, "2026-05-30T03-00-00Z", "warehouse")); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	_, err := loadViews(t, newestFixture(t, root, filepath.Join("shop", "orders.parquet")))
+	if err == nil {
+		t.Fatal("the generated file loaded cleanly with shop.orders absent from the newest " +
+			"snapshot; a table that left must fail loudly, not read as empty")
+	}
+	// DuckDB's own refusal, which already names the exact path it looked for:
+	// the snapshot the variable resolved to, plus the table. Wrapping that in a
+	// message of our own would restate it and could fall out of step with it.
+	if !strings.Contains(err.Error(), "No files found") {
+		t.Errorf("failed with %v; want the refusal naming the path that is not there", err)
+	}
+	if !strings.Contains(err.Error(), "2026-05-30T03-00-00Z") {
+		t.Errorf("failed with %v; the message must name the snapshot it looked in", err)
+	}
+}
+
+// TestNewestStateView_refusesToLoadWhenNothingIsMarked pins the CASE in the
+// variable lookup, and it asserts a refusal to LOAD rather than to query.
+//
+// With no marker under the root, max() is NULL and the variable is NULL, which
+// read_parquet reports as "cannot take NULL list as parameter". That is true and
+// says nothing about baselines, so the lookup raises first and names the root
+// and the marker. Failing at load also beats failing per query: the operator
+// learns at the moment they open the file, not at the first thing they ask it.
+func TestNewestStateView_refusesToLoadWhenNothingIsMarked(t *testing.T) {
+	root := t.TempDir()
+	writeSnapshot(t, root, "2026-04-30T03-00-00Z", false, "unmarked")
+
+	_, err := loadViews(t, newestFixture(t, root, filepath.Join("shop", "orders.parquet")))
+	if err == nil {
+		t.Fatalf("the generated file loaded cleanly with no %s marker under the root; "+
+			"there is no snapshot for its state views to read", baseline.SuccessMarker)
+	}
+	if !strings.Contains(err.Error(), "no completed snapshot under") {
+		t.Errorf("failed with %v; want the message naming the root", err)
+	}
+	if strings.Contains(err.Error(), "NULL list as parameter") {
+		t.Errorf("failed with DuckDB's raw NULL refusal, which says nothing about baselines: %v", err)
+	}
+}

--- a/internal/views/testdata/views.newest.golden.sql
+++ b/internal/views/testdata/views.newest.golden.sql
@@ -3,7 +3,7 @@
 --
 -- THIS FILE IS A SNAPSHOT OF THE LAYOUT, NOT A LIVE BINDING. The globs below
 -- keep picking up newly rotated partitions, and the baseline state views
--- follow the `current` pointer, so a refreshed baseline reaches them
+-- select the newest completed snapshot, so a refreshed baseline reaches them
 -- on its own. What does NOT follow is this file's idea of the SHAPE of the
 -- data: which views exist, and how each DECIMAL column is read, were decided
 -- from the snapshot named below. Re-run `bintrail views` (or download the file
@@ -23,11 +23,11 @@
 --
 -- A daemon running `bintrail-console watch --baseline-refresh-interval`
 -- publishes a new snapshot every interval, and the state views below move to
--- it when it completes. Replacing the pointer is a single step, so no path
--- ever resolves into a half-published snapshot, and a query already running
--- finishes against the files it opened. Two views resolved either side of that
--- one step can still land on different snapshots; the window is the swap
--- itself, not the hours a file left behind would span.
+-- it once it completes. They resolve which one ONCE, when this file is read,
+-- so every state view shows the same snapshot and none of them can drift
+-- apart mid-session. A refresh published while you are working is picked up
+-- by reading this file again, which is already what an S3 session needs to do
+-- for the secret above.
 --
 -- Nothing here writes: every view is a read over Parquet files you already own.
 --
@@ -38,8 +38,8 @@
 --   /data/archives/bintrail_id=11111111-2222-3333-4444-555555555555
 --   s3://my-bucket/archives/bintrail_id=66666666-7777-8888-9999-000000000000
 -- Baseline snapshot:
---   /data/baselines at 2026-04-30T03:00:00Z (4 table(s))
---   read through /data/baselines/current, which is that snapshot right now
+--   s3://my-bucket/baselines/ at 2026-04-30T03:00:00Z (4 table(s))
+--   read through the newest `_SUCCESS` snapshot, which is that one right now
 
 -- S3 setup, mirroring what bintrail's own DuckDB sessions configure.
 INSTALL httpfs; LOAD httpfs;
@@ -56,8 +56,8 @@ CREATE OR REPLACE SECRET bintrail_s3_chain (TYPE s3, PROVIDER credential_chain, 
 --   CREATE OR REPLACE SECRET bintrail_s3_chain (
 --     TYPE s3, KEY_ID '…', SECRET '…', REGION '…');
 
--- state_<schema>_<table>: each table's full contents as of the snapshot the
--- `current` pointer names, which is whichever one completed most recently.
+-- state_<schema>_<table>: each table's full contents as of the newest snapshot
+-- carrying a `_SUCCESS` marker, chosen when the view is read.
 --
 -- These are the SNAPSHOT's rows, not the table's current state: changes after
 -- the snapshot live in the `events` view.
@@ -78,17 +78,27 @@ CREATE OR REPLACE SECRET bintrail_s3_chain (TYPE s3, PROVIDER credential_chain, 
 -- refreshed; a PostgreSQL-source baseline stores all its values as text and
 -- will not gain them. If a footer could not be read at all, the bintrail log
 -- has the error.
+-- The snapshot every state view below reads through, resolved once, when this
+-- file is read. Re-run this statement to pick up a refresh without reopening
+-- the session; every view follows it, so they never disagree about which
+-- snapshot they are showing.
+SET VARIABLE bintrail_newest_snapshot = (
+  SELECT CASE WHEN max(file) IS NULL
+    THEN error('bintrail views: no completed snapshot under s3://my-bucket/baselines/ (nothing there carries a _SUCCESS marker). Take or refresh a baseline, then read this file again.')
+    ELSE max(regexp_replace(file, '_SUCCESS$', '')) END
+  FROM glob('s3://my-bucket/baselines/*/_SUCCESS'));
+
 -- state_legacy_db_audit_log: this file carries no column types, so nothing is cast; decimal columns read as text
 CREATE OR REPLACE VIEW "state_legacy_db_audit_log" AS
-  SELECT * FROM read_parquet('/data/baselines/current/Legacy-DB/Audit Log.parquet');
+  SELECT * FROM read_parquet(getvariable('bintrail_newest_snapshot') || 'Legacy-DB/Audit Log.parquet');
 CREATE OR REPLACE VIEW "state_shop_order_items" AS
-  SELECT * FROM read_parquet('/data/baselines/current/shop/order_items.parquet');
+  SELECT * FROM read_parquet(getvariable('bintrail_newest_snapshot') || 'shop/order_items.parquet');
 CREATE OR REPLACE VIEW "state_shop_orders" AS
   SELECT * REPLACE (CAST("total" AS DECIMAL(10,2)) AS "total", CAST("tax_rate" AS DECIMAL(6,4)) AS "tax_rate")
-  FROM read_parquet('/data/baselines/current/shop/orders.parquet');
+  FROM read_parquet(getvariable('bintrail_newest_snapshot') || 'shop/orders.parquet');
 -- state_shop_order_items_2: weight is DECIMAL(65,30), wider than DuckDB's 38 digits (left as text)
 CREATE OR REPLACE VIEW "state_shop_order_items_2" AS
-  SELECT * FROM read_parquet('/data/baselines/current/shop_order/items.parquet');
+  SELECT * FROM read_parquet(getvariable('bintrail_newest_snapshot') || 'shop_order/items.parquet');
 
 -- events: every archived binlog event, across all archive sources.
 --

--- a/internal/views/views.go
+++ b/internal/views/views.go
@@ -29,10 +29,48 @@ import (
 )
 
 // BaselineTable names one table's Parquet file inside a baseline snapshot.
+// FollowMode says how the state views reach a snapshot published after this
+// file was generated. The two following modes buy the same thing by different
+// means, and they do NOT cost the reader the same, which is why they are
+// distinct values rather than one bool.
+type FollowMode int
+
+const (
+	// FollowNone pins the views to the snapshot discovered at generation time.
+	// Rows stop changing; regenerating the file is what moves them.
+	FollowNone FollowMode = iota
+	// FollowPointer names the baselines root's `current` symlink in every
+	// path. One rename(2) moves every table at once, so no query can resolve
+	// into a half-published snapshot and no two views can disagree about which
+	// snapshot they are reading.
+	FollowPointer
+	// FollowNewest resolves the newest `_SUCCESS`-marked snapshot into a session
+	// variable that every state view reads through. It is the only following
+	// available on an S3 root, which has no pointer to rewrite.
+	//
+	// One variable, so the views agree with each other the way the pointer makes
+	// them agree. What differs is WHEN: the pointer is followed per query, this
+	// is resolved when the file is read. In practice that is the same session
+	// boundary an S3 file already has, since its credentials do not persist
+	// either.
+	FollowNewest
+)
+
+// follows reports whether the state views move on their own, for the wording
+// both following modes share.
+func (m FollowMode) follows() bool { return m != FollowNone }
+
 type BaselineTable struct {
 	Schema string
 	Table  string
 	Path   string // local path or s3:// URL of the table's .parquet file
+	// Rel is Path relative to its snapshot directory ("schema/table.parquet"),
+	// set by the producer only under FollowNewest. The following there is a SQL
+	// shape rather than a path, and it needs the tail on its own to rebuild the
+	// file name against whichever snapshot the query picks. Deriving it back
+	// out of Path in the generator would be a second opinion about the layout;
+	// the producer already split it once to decide it could follow at all.
+	Rel string
 
 	// Decimals are the table's DECIMAL and NUMERIC columns, which the baseline
 	// writer stores as text (internal/baseline.MysqlToParquetNode says why).
@@ -176,16 +214,10 @@ type Input struct {
 	// the header. BaselineSnapshot is that snapshot's timestamp.
 	BaselineSource   string
 	BaselineSnapshot time.Time
-	// FollowsSnapshot records that the state view paths name the baselines
-	// root's `current` pointer instead of a snapshot directory, so a later
-	// snapshot reaches this file without regenerating it (#1484).
-	//
-	// It changes only what the file SAYS; the following itself is in the paths
-	// the producer put in Baselines. A producer sets it when it rewrote those
-	// paths AND the pointer names the snapshot it selected — following a
-	// pointer that names something else would serve rows the header does not
-	// describe. S3 roots never set it: there is no pointer there to follow.
-	FollowsSnapshot bool
+	// Follow records how, if at all, the state views reach a snapshot published
+	// after this file was generated (#1484, #1550). ApplyFollow is what sets
+	// it; see FollowMode for what each mode costs the reader.
+	Follow FollowMode
 	// Baselines are the tables of the NEWEST discoverable snapshot only. An
 	// older snapshot's rows are a different point in time, and a view union-ing
 	// two of them would silently mix states that never coexisted.
@@ -505,18 +537,26 @@ func writeHeader(b *strings.Builder, in Input) {
 		orUnknown(in.Version), in.GeneratedAt.UTC().Format(time.RFC3339))
 	b.WriteString("--\n")
 	b.WriteString("-- THIS FILE IS A SNAPSHOT OF THE LAYOUT, NOT A LIVE BINDING. ")
-	if in.FollowsSnapshot {
+	if in.Follow.follows() {
 		// The state views follow too, so the sentence above is now only about
 		// SHAPE. Say which shape, concretely: a reader who knows a new table
 		// will not appear on its own can schedule a regeneration; one told
 		// only "not a live binding" cannot tell what still needs doing.
+		//
+		// Which MECHANISM follows is named rather than glossed as "follow":
+		// the two do not fail the same way, and the reader who has to reason
+		// about a mid-session refresh needs to know which one is in the file.
+		how := "follow the `" + baseline.CurrentLinkName + "` pointer"
+		if in.Follow == FollowNewest {
+			how = "select the newest completed snapshot"
+		}
 		if in.rendersEvents() {
 			b.WriteString("The globs below\n")
 			b.WriteString("-- keep picking up newly rotated partitions, and the baseline state views\n")
-			b.WriteString("-- follow the `" + baseline.CurrentLinkName + "` pointer, so a refreshed baseline reaches them\n")
+			b.WriteString("-- " + how + ", so a refreshed baseline reaches them\n")
 		} else {
 			b.WriteString("The baseline state\n")
-			b.WriteString("-- views follow the `" + baseline.CurrentLinkName + "` pointer, so a refreshed baseline reaches them\n")
+			b.WriteString("-- views " + how + ", so a refreshed baseline reaches them\n")
 		}
 		b.WriteString("-- on its own. What does NOT follow is this file's idea of the SHAPE of the\n")
 		b.WriteString("-- data: which views exist, and how each DECIMAL column is read, were decided\n")
@@ -526,8 +566,8 @@ func writeHeader(b *strings.Builder, in Input) {
 		b.WriteString("--\n")
 		b.WriteString("-- Which of those you will notice follows one rule: this file names only the\n")
 		b.WriteString("-- PATHS and the DECIMAL columns, so only those two can fail. A table that\n")
-		b.WriteString("-- leaves the newest snapshot stops resolving and DuckDB names the missing\n")
-		b.WriteString("-- path; a DECIMAL column that is renamed or dropped fails the whole script.\n")
+		b.WriteString("-- leaves the newest snapshot stops resolving and reading this file fails,\n")
+		b.WriteString("-- naming the path; a DECIMAL column renamed or dropped fails the script.\n")
 		b.WriteString("-- Everything else is QUIET, because `SELECT *` passes it through untouched:\n")
 		b.WriteString("-- a table added to the source has no view here, a DECIMAL whose scale grew is\n")
 		b.WriteString("-- read at the old scale with the extra digits rounded away, a column that\n")
@@ -560,15 +600,29 @@ func writeHeader(b *strings.Builder, in Input) {
 	// caveat: the pinned half warns that the rows stop changing, and under
 	// following that warning is simply false. The pinned arm stays phrased so
 	// it holds with no state views at all ("ANY state view below"); the
-	// following arm may assert they exist, because FollowsSnapshot is only ever
-	// set alongside a non-empty Baselines.
+	// following arms may assert they exist, because ApplyFollow only ever
+	// leaves Follow set alongside a non-empty Baselines.
 	//
 	// "nothing regenerates this file", NOT "nothing re-runs this command": the
 	// console download is produced by a page, not a command, which is the same
 	// distinction Input.LiveLegUnavailable exists to make. The paragraph above
 	// already names both routes.
 	b.WriteString("--\n")
-	if in.FollowsSnapshot {
+	switch {
+	case in.Follow == FollowNewest:
+		// The same paragraph as the pointer arm up to the last two sentences,
+		// which is where the two mechanisms actually differ. Stating the
+		// weaker guarantee is not optional: a reader who was told "a single
+		// step" would reasonably assume the whole file moves together, and
+		// here it does not.
+		b.WriteString("-- A daemon running `bintrail-console watch --baseline-refresh-interval`\n")
+		b.WriteString("-- publishes a new snapshot every interval, and the state views below move to\n")
+		b.WriteString("-- it once it completes. They resolve which one ONCE, when this file is read,\n")
+		b.WriteString("-- so every state view shows the same snapshot and none of them can drift\n")
+		b.WriteString("-- apart mid-session. A refresh published while you are working is picked up\n")
+		b.WriteString("-- by reading this file again, which is already what an S3 session needs to do\n")
+		b.WriteString("-- for the secret above.\n")
+	case in.Follow == FollowPointer:
 		// The paragraph this replaces exists because a timer-published
 		// snapshot has no operator action to attach "regenerate" to. Following
 		// removes that need for ROWS and leaves it for SHAPE, so the same
@@ -580,7 +634,7 @@ func writeHeader(b *strings.Builder, in Input) {
 		b.WriteString("-- finishes against the files it opened. Two views resolved either side of that\n")
 		b.WriteString("-- one step can still land on different snapshots; the window is the swap\n")
 		b.WriteString("-- itself, not the hours a file left behind would span.\n")
-	} else {
+	default:
 		b.WriteString("-- A daemon running `bintrail-console watch --baseline-refresh-interval`\n")
 		b.WriteString("-- publishes a new snapshot every interval, and nothing regenerates this file.\n")
 		b.WriteString("-- Any state view below stays bound to the snapshot it was generated against,\n")
@@ -625,13 +679,19 @@ func writeHeader(b *strings.Builder, in Input) {
 	default:
 		fmt.Fprintf(b, "--   %s at %s (%d table(s))\n",
 			in.BaselineSource, in.BaselineSnapshot.UTC().Format(time.RFC3339), len(in.Baselines))
-		if in.FollowsSnapshot {
+		switch in.Follow {
+		case FollowPointer:
 			// Name the timestamp AND the pointer: the timestamp is what the
 			// column types were read from, the pointer is what the views
 			// actually open. Reporting only one of the two would make a
 			// followed file indistinguishable from a pinned one.
 			fmt.Fprintf(b, "--   read through %s/%s, which is that snapshot right now\n",
 				strings.TrimSuffix(in.BaselineSource, "/"), baseline.CurrentLinkName)
+		case FollowNewest:
+			// Same job as the pointer line, and the same reason: the timestamp
+			// above is where the column types came from, not what the views
+			// open. What they open is decided per read.
+			b.WriteString("--   read through the newest `_SUCCESS` snapshot, which is that one right now\n")
 		}
 	}
 	b.WriteString("\n")
@@ -1360,10 +1420,14 @@ func writeStateViews(b *strings.Builder, in Input) bool {
 	if in.OnlyViews != nil && len(wanted) == 0 {
 		return false
 	}
-	if in.FollowsSnapshot {
+	switch in.Follow {
+	case FollowPointer:
 		b.WriteString("-- state_<schema>_<table>: each table's full contents as of the snapshot the\n")
 		b.WriteString("-- `" + baseline.CurrentLinkName + "` pointer names, which is whichever one completed most recently.\n")
-	} else {
+	case FollowNewest:
+		b.WriteString("-- state_<schema>_<table>: each table's full contents as of the newest snapshot\n")
+		b.WriteString("-- carrying a `" + baseline.SuccessMarker + "` marker, chosen when the view is read.\n")
+	default:
 		b.WriteString("-- state_<schema>_<table>: each table's full contents as of the baseline snapshot.\n")
 	}
 	b.WriteString("--\n")
@@ -1393,6 +1457,9 @@ func writeStateViews(b *strings.Builder, in Input) bool {
 		return false
 	}
 	writeDecimalNote(b, in)
+	if in.Follow == FollowNewest {
+		writeNewestSnapshotVar(b, in)
+	}
 
 	for _, p := range wanted {
 		t, name := p.table, p.name
@@ -1400,6 +1467,10 @@ func writeStateViews(b *strings.Builder, in Input) bool {
 			fmt.Fprintf(b, "-- %s: %s\n", name, line)
 		}
 		fmt.Fprintf(b, "CREATE OR REPLACE VIEW %s AS\n", quoteIdent(name))
+		if in.Follow == FollowNewest {
+			writeNewestStateBody(b, t)
+			continue
+		}
 		if replace := decimalReplaceClause(t); replace != "" {
 			fmt.Fprintf(b, "  SELECT * REPLACE (%s)\n", replace)
 			fmt.Fprintf(b, "  FROM read_parquet(%s);\n", sqlString(t.Path))
@@ -1409,6 +1480,62 @@ func writeStateViews(b *strings.Builder, in Input) bool {
 	}
 	b.WriteString("\n")
 	return len(wanted) > 0
+}
+
+// newestVar is the session variable holding the snapshot directory every state
+// view reads through, under FollowNewest.
+//
+// ONE variable for the whole file, which is what makes this mechanism cost what
+// pinning costs. The obvious shape -- each view scanning every snapshot's copy
+// of its table and filtering down to one -- was written, measured and rejected:
+// DuckDB binds a view when it is CREATED, so a glob in the view body pays a
+// storage listing per view, and that listing grows with the root. Against a real
+// S3 root of 24 snapshots it opened a 47-view file in 170s where pinning took
+// 31s, and the gap widens with every refresh published.
+//
+// Resolving once also restores what the `current` pointer gives and the rejected
+// shape could not: every view agrees on one snapshot, because there is one value
+// to disagree about.
+const newestVar = "bintrail_newest_snapshot"
+
+// writeNewestSnapshotVar emits the lookup that picks the snapshot, for a root
+// with no `current` pointer to rewrite (#1550).
+//
+// The CASE is not decoration. With no marker under the root, max() is NULL, and
+// a NULL variable reaches read_parquet as "cannot take NULL list as parameter",
+// which is true and tells the reader nothing about baselines. Raising here names
+// the root and the marker instead, and does it when the FILE IS READ rather than
+// at the first query.
+func writeNewestSnapshotVar(b *strings.Builder, in Input) {
+	root := strings.TrimSuffix(in.BaselineSource, "/")
+	b.WriteString("-- The snapshot every state view below reads through, resolved once, when this\n")
+	b.WriteString("-- file is read. Re-run this statement to pick up a refresh without reopening\n")
+	b.WriteString("-- the session; every view follows it, so they never disagree about which\n")
+	b.WriteString("-- snapshot they are showing.\n")
+	fmt.Fprintf(b, "SET VARIABLE %s = (\n", newestVar)
+	b.WriteString("  SELECT CASE WHEN max(file) IS NULL\n")
+	fmt.Fprintf(b, "    THEN error(%s)\n", sqlString(
+		"bintrail views: no completed snapshot under "+root+"/ (nothing there carries a "+
+			baseline.SuccessMarker+" marker). Take or refresh a baseline, then read this file again."))
+	fmt.Fprintf(b, "    ELSE max(regexp_replace(file, %s, '')) END\n", sqlString(baseline.SuccessMarker+"$"))
+	fmt.Fprintf(b, "  FROM glob(%s));\n\n", sqlString(root+"/*/"+baseline.SuccessMarker))
+}
+
+// writeNewestStateBody emits one state view's body under FollowNewest: a read of
+// ONE Parquet file, whose directory comes from the session variable.
+//
+// A table that has left the newest snapshot fails here, loudly, with DuckDB's
+// own "No files found that match the pattern" naming the exact path it looked
+// for. That is the guarantee this mechanism exists to keep: reading as EMPTY a
+// table that should have had rows is a worse answer than reading a stale one.
+func writeNewestStateBody(b *strings.Builder, t BaselineTable) {
+	read := fmt.Sprintf("read_parquet(getvariable('%s') || %s)", newestVar, sqlString(t.Rel))
+	if replace := decimalReplaceClause(t); replace != "" {
+		fmt.Fprintf(b, "  SELECT * REPLACE (%s)\n", replace)
+		fmt.Fprintf(b, "  FROM %s;\n", read)
+		return
+	}
+	fmt.Fprintf(b, "  SELECT * FROM %s;\n", read)
 }
 
 // stateViewName builds the view identifier for a table and guarantees it is


### PR DESCRIPTION
closes #1550

## Summary

An S3 baselines root has no `current` pointer to rewrite, so a views file generated against one stayed bound to whatever snapshot existed when it was written. A daemon publishing on `--baseline-refresh-interval` left it behind with no error and no warning.

The state views now resolve the newest `_SUCCESS`-marked snapshot into a session variable and read through it:

```sql
SET VARIABLE bintrail_newest_snapshot = (
  SELECT CASE WHEN max(file) IS NULL
    THEN error('bintrail views: no completed snapshot under s3://bucket/baselines/ ...')
    ELSE max(regexp_replace(file, '_SUCCESS$', '')) END
  FROM glob('s3://bucket/baselines/*/_SUCCESS'));

CREATE OR REPLACE VIEW "state_shop_orders" AS
  SELECT * FROM read_parquet(getvariable('bintrail_newest_snapshot') || 'shop/orders.parquet');
```

One lookup for the whole file, so it costs what pinning costs, and every view agrees on one snapshot the way the pointer makes them agree.

## The shape that was rejected, and why

The obvious form was written first, verified loud in both failure shapes, and then rejected on measurement: each view scanning every snapshot's copy of its table and filtering down to one with a `WHERE filename = ...` subquery.

It is correct. `EXPLAIN ANALYZE` even confirms `Total Files Read: 1`, because DuckDB pushes the equality into file selection. But DuckDB binds a view when it is **created**, so a glob in the view body pays a storage listing per view, and that listing grows with the root.

Measured against a real S3 baselines root (24 snapshots, 1108 objects, 47 tables):

| form | open the file | follows | grows with the root |
|---|---|---|---|
| pinned (today) | 31.4s | no | no |
| glob + filter | **170s** | per query | **yes** |
| session variable | **32.8s** | per read | no |

Glob cost against root size, same bucket: 8 snapshots 0.72s, 24 snapshots 1.65s.

## Both failures stay loud

Reading as EMPTY a table that should have had rows is a worse answer than reading a stale one, and it is the failure this mechanism could most easily introduce.

- **No marker anywhere** raises from the lookup itself, naming the root. It has to: `error()` is an ordinary scalar function and PROPAGATES NULL, so a message built by concatenation disarms itself exactly when the value is missing. A NULL variable would otherwise surface as read_parquet's `cannot take NULL list as parameter`, which is true and says nothing about baselines.
- **A table that left the newest snapshot** fails on DuckDB's own `No files found that match the pattern`, naming the path it looked for.

Both fail when the file is READ, not at the first query.

## Also here

- `views.ApplyFollow` replaces the byte-identical follow helper each producer carried (`followCurrentPointer` in the CLI, `followBaselinePointer` in the console), so the two surfaces cannot end up offering different mechanisms. `--pin-snapshot` refuses ahead of the mechanism choice.
- `FollowsSnapshot bool` becomes `Follow FollowMode` (`FollowNone` / `FollowPointer` / `FollowNewest`). The two following modes emit different SQL, so they cannot be one bool.
- The `views` command's Long help said the file "does not follow it, with no error and no warning, so regenerate on that same schedule". That has been false since #1547 and is now false twice over; it sent an operator to do work the product does. Its guard was rewritten rather than deleted.

## Test plan

- [x] `go test ./... -count=1` (55 packages)
- [x] New golden `views.newest.golden.sql`, its own file rather than a variant
- [x] Four tests that EXECUTE the generated SQL in DuckDB: reads the newest marked snapshot, ignores an unmarked newer one, raises when the table left, refuses to load when nothing is marked
- [x] Each of the four mutation-tested to fail: no NULL guard, marker ignored, oldest wins, variable unused
- [x] End to end with the real binary against a real S3 root: 47 views, variable resolves to `2026-08-31T06-00-45Z/`, table reads 285 rows