### PR TITLE
console: let the download choose which backup location it reads

### DIFF
--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -4239,6 +4239,20 @@ function duckdbPanel() {
   events.onchange = () => shape.events.classList.toggle("dk-off", !events.checked);
   events.onchange();
 
+  // The second box, and only for a server whose backups are in two places
+  // (#1551). With one location there is nothing to decide, and a box that
+  // changes nothing to a file is worse than no box at all.
+  //
+  // Phrased as where the file will be OPENED, not as which storage it names:
+  // the reader downloading through a browser knows which machine they are
+  // taking it to, and does not necessarily know where their backups live.
+  let portable = null;
+  if (capsCache.views_portable_baseline) {
+    portable = el("input", { type: "checkbox", name: "portable_baseline" });
+    body.append(el("label", { class: "check" }, portable,
+      el("span", { text: "Works on another machine" })));
+  }
+
   body.append(cnFine("More about this file",
     el("p", { class: "form-hint", text:
       "Runs in your own DuckDB. Nothing runs here, and no credentials are in the file." }),
@@ -4249,9 +4263,16 @@ function duckdbPanel() {
   btn.onclick = async () => {
     btn.disabled = true;
     try {
-      const sql = await apiText("/api/views.sql" + (events.checked ? "?include_events=1" : ""));
-      downloadBlob("views.sql", sql, "text/plain");
-      toast("views.sql downloaded. In DuckDB run .read views.sql, once per session.");
+      const q = [];
+      if (events.checked) q.push("include_events=1");
+      if (portable && portable.checked) q.push("portable_baseline=1");
+      // Its own name. The browser saves into one folder and overwrites a
+      // repeated name without asking, so downloading both would leave the
+      // reader with whichever came last and no way to tell which.
+      const name = portable && portable.checked ? "views-portable.sql" : "views.sql";
+      const sql = await apiText("/api/views.sql" + (q.length ? "?" + q.join("&") : ""));
+      downloadBlob(name, sql, "text/plain");
+      toast(name + " downloaded. In DuckDB run .read " + name + ", once per session.");
     } catch (err) {
       toastError("could not generate views: " + ((err && err.message) || err));
     } finally {

--- a/internal/console/assets_duckdbcard_test.go
+++ b/internal/console/assets_duckdbcard_test.go
@@ -23,18 +23,38 @@ import (
 func TestDuckDBCardOffersOneDecision(t *testing.T) {
 	body := functionBody(t, readAsset(t, "app.js"), "function duckdbPanel(")
 
+	// Two, and the second one is CONDITIONAL. The card is a first visit for
+	// most readers, so the bar for a control is that skipping it would produce
+	// the wrong file: the change log is left out by default and has to be
+	// asked for, and the backup location only has an answer to give when this
+	// server has two of them (#1551). Everything else stays a CLI flag.
 	boxes := strings.Count(body, `type: "checkbox"`)
-	if boxes != 1 {
-		t.Errorf("duckdbPanel renders %d checkboxes, want exactly 1 (the change log); "+
-			"pin-snapshot and include-live are CLI flags and route parameters, not first-visit decisions", boxes)
+	if boxes != 2 {
+		t.Errorf("duckdbPanel renders %d checkboxes, want exactly 2 (the change log, and the "+
+			"backup location when the server has two); pin-snapshot and include-live are CLI "+
+			"flags and route parameters, not first-visit decisions", boxes)
+	}
+	// The point of the pair above: unconditional, it is a control that changes
+	// nothing for every server with one backup location, which is most of them.
+	if !strings.Contains(body, "if (capsCache.views_portable_baseline) {") {
+		t.Error("the backup-location box is not gated on the capability, so it is offered for " +
+			"servers with only one location, where it changes nothing")
 	}
 	if !strings.Contains(body, "include_events=1") {
 		t.Error("the card never sends include_events=1, so the change log cannot be asked for at all")
 	}
+	if !strings.Contains(body, "portable_baseline=1") {
+		t.Error("the card never sends portable_baseline=1, so its box changes nothing")
+	}
 	// Conditional, not always: the change log binds every archived file, so a
 	// download nobody asked for it must not carry it.
-	if !strings.Contains(body, `events.checked ? "?include_events=1" : ""`) {
+	if !strings.Contains(body, `if (events.checked) q.push("include_events=1")`) {
 		t.Error("the change log is not conditional on the box, so the default download is not the cheap one")
+	}
+	// Its own filename. Saved as views.sql, the second download silently
+	// replaces the first in the reader's downloads folder.
+	if !strings.Contains(body, `"views-portable.sql"`) {
+		t.Error("both downloads are saved under one filename, so one silently overwrites the other")
 	}
 	// The two retired controls must not come back as silent always-on
 	// parameters, which would be worse than the checkboxes were.

--- a/internal/console/reconstruct.go
+++ b/internal/console/reconstruct.go
@@ -67,6 +67,13 @@ type capabilitiesResponse struct {
 	// (archives enabled, no active data profile, and something to describe), so
 	// the UI never offers a button that only 404s.
 	Views bool `json:"views"`
+	// ViewsPortableBaseline: this server's backups exist in TWO places, so the
+	// download has a choice to offer between a file that opens fastest here and
+	// one that opens on another machine (#1551). False is the ordinary case of
+	// one location, where there is nothing to decide and the UI shows no
+	// control. Never advertised without Views: a choice about a file the reader
+	// cannot download at all is not a choice.
+	ViewsPortableBaseline bool `json:"views_portable_baseline"`
 	// BaselineTrigger: this process can create baseline snapshots in-process from
 	// the console (the watch daemon opted in with BINTRAIL_CONSOLE_BASELINE_TRIGGER=1).
 	// Process-global, like Monitor — the endpoint does the per-server validation
@@ -219,6 +226,10 @@ func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 		restricted := sessionRestricted(r)
 		resp.Reconstruct = b.baselineConfigured && !restricted
 		resp.Views = s.viewsAvailable(r, b)
+		// Gated on Views for the reason the field's doc gives, and read off the
+		// same bundle field the handler refuses on, so the control cannot be
+		// offered for a server the route would then reject.
+		resp.ViewsPortableBaseline = resp.Views && b.baselineFallbackSrc != ""
 		// Match the recover-cascade handler's Phase-2 gate exactly so the advertised
 		// capability can't over-promise (handler builds the provider only when both
 		// a baseline source and a resolver are present).

--- a/internal/console/views_api.go
+++ b/internal/console/views_api.go
@@ -25,26 +25,44 @@ var errNoViewSources = errors.New("this server has no archived partitions and no
 // sources from archive_state plus the NEWEST baseline snapshot's tables — into
 // the generator input shared by GET /api/views.sql and the SQL panel. A
 // baseline root that is configured but unlistable is an upstream fault worth
+// viewsRequest is what the reader asked the download for, kept apart from what
+// this server can actually offer. Every field defaults to the cheap, local,
+// nothing-extra answer, so a zero value is the file a first-time reader gets.
+type viewsRequest struct {
+	// PortableArchives names each archive by its registered S3 location where
+	// one exists, instead of this host's local copy. The download runs on the
+	// operator's machine, where the local copy is not there (#1456).
+	PortableArchives bool
+	// OmitEvents leaves out the events view. A PARAMETER rather than something
+	// the caller sets afterwards: NeedsS3 asks whether the rendered file reads
+	// any s3:// path, and the events view is the half that reads the archives.
+	// Set after buildViewsInput returns, that gate ran with the zero value and
+	// a default download 502'd over an S3 variable its file never touches,
+	// while the CLI, which knows before it asks, did not.
+	OmitEvents bool
+	// PinSnapshot binds the state views to the snapshot discovered now instead
+	// of letting them follow a later one (#1484).
+	PinSnapshot bool
+	// PortableBaseline reads the state views out of this server's S3 backup
+	// prefix instead of its local backup directory (#1551).
+	//
+	// Only meaningful when the server has BOTH, which is exactly when
+	// bundle.baselineFallbackSrc is set: with one location there is no choice
+	// to make, and emitting a location the snapshots were never written to
+	// produces a file whose every state view fails to resolve.
+	PortableBaseline bool
+}
+
 // naming, not a degrade: silently dropping the baseline half would hand over a
 // layout missing every state view.
 //
-// portable selects which registered location names each archive. The download
-// runs on the operator's machine, where this host's local copy does not exist,
-// so it takes the S3 location whenever one is registered (#1456); the SQL panel
-// runs in this daemon and keeps the local-first routing every other console
-// read uses.
-// omitEvents is a PARAMETER rather than something the caller sets afterwards:
-// NeedsS3 below asks whether the rendered file reads any s3:// path, and the
-// events view is the half that reads the archives. Set after this returns, the
-// gate ran with the zero value and a default download 502'd over an S3 variable
-// its file never touches -- while the CLI, which knows before it asks, did not.
-// The SQL panel passes false: it decides through OnlyViews.
-// pinSnapshot binds the state views to the snapshot discovered now instead of
-// letting them follow the baselines root's `current` pointer (#1484). The SQL
-// panel passes false like the download: the panel executes the views
-// immediately, so following costs it nothing, and one rule across both
-// producers is what keeps them from drifting apart.
-func (s *Server) buildViewsInput(ctx context.Context, b *bundle, portable, omitEvents, pinSnapshot bool) (views.Input, error) {
+// req is what the reader asked for. Its two "portable" fields are DIFFERENT
+// axes over different halves of the file, and the names are spelled out rather
+// than shared because conflating them silently emits the wrong paths: archives
+// feed the events view, baselines feed the state views, and a server can have
+// its archives in S3 while its backups are on local disk or the reverse.
+func (s *Server) buildViewsInput(ctx context.Context, b *bundle, req viewsRequest) (views.Input, error) {
+	portable, omitEvents, pinSnapshot := req.PortableArchives, req.OmitEvents, req.PinSnapshot
 	in := views.Input{
 		GeneratedAt: time.Now().UTC(),
 		Version:     s.version,
@@ -69,9 +87,16 @@ func (s *Server) buildViewsInput(ctx context.Context, b *bundle, portable, omitE
 	in.ArchiveSources, archiveErr = consoleArchiveSources(ctx, b.db, portable)
 	in.PortableRouting = portable
 	in.ArchiveDiscoveryFailed = archiveErr != nil
-	if b.baselineSrc != "" {
-		in.BaselineSource = b.baselineSrc
-		files, err := reconstruct.ListBaselines(ctx, b.baselineSrc)
+	baseSrc := b.baselineSrc
+	if req.PortableBaseline && b.baselineFallbackSrc != "" {
+		// Read from the bundle, never from the request: the two locations this
+		// server actually has are the only two it can be asked for, so a
+		// request cannot name a prefix nothing was written to.
+		baseSrc = b.baselineFallbackSrc
+	}
+	if baseSrc != "" {
+		in.BaselineSource = baseSrc
+		files, err := reconstruct.ListBaselines(ctx, baseSrc)
 		if err != nil {
 			return views.Input{}, fmt.Errorf("list baselines: %w", err)
 		}
@@ -99,7 +124,7 @@ func (s *Server) buildViewsInput(ctx context.Context, b *bundle, portable, omitE
 			// file, since following only happens when the pointer names this
 			// snapshot, so reading the pinned one costs nothing.
 			s.resolveBaselineDecimals(ctx, &in)
-			views.ApplyFollow(&in, b.baselineSrc, pinSnapshot)
+			views.ApplyFollow(&in, baseSrc, pinSnapshot)
 		}
 	}
 	if len(in.ArchiveSources) == 0 && len(in.Baselines) == 0 {
@@ -227,6 +252,23 @@ func (s *Server) handleViewsSQL(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	portableBaseline, err := parseStrictInclude("portable_baseline",
+		"read the state views from this server's S3 backup prefix", r.URL.Query().Get("portable_baseline"))
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	// Refused rather than quietly ignored. Silently falling back to the local
+	// directory hands a laptop a file whose every state view names a path that
+	// machine does not have, which is the failure this parameter exists to
+	// avoid, delivered as a successful download.
+	if portableBaseline && b.baselineFallbackSrc == "" {
+		writeJSONError(w, http.StatusUnprocessableEntity,
+			"this server has no S3 backup prefix to read from: portable_baseline needs a server "+
+				"configured with BOTH a local backup directory and an S3 one, so there are two "+
+				"locations to choose between")
+		return
+	}
 	if includeLive && !includeEvents {
 		writeJSONError(w, http.StatusBadRequest,
 			"include_live adds a leg to the events view, which this file would not define: "+
@@ -234,7 +276,12 @@ func (s *Server) handleViewsSQL(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	in, err := s.buildViewsInput(r.Context(), b, true, !includeEvents, pinSnapshot)
+	in, err := s.buildViewsInput(r.Context(), b, viewsRequest{
+		PortableArchives: true,
+		OmitEvents:       !includeEvents,
+		PinSnapshot:      pinSnapshot,
+		PortableBaseline: portableBaseline,
+	})
 	switch {
 	case errors.Is(err, errNoViewSources):
 		// Nothing to describe. A file of comments explaining that would be a
@@ -291,7 +338,15 @@ func (s *Server) handleViewsSQL(w http.ResponseWriter, r *http.Request) {
 
 	sqlText := views.Generate(in)
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	w.Header().Set("Content-Disposition", `attachment; filename="views.sql"`)
+	// A distinct name for the portable file. Both are downloads of "the schema
+	// for this server", and a browser saving views.sql twice into one folder
+	// overwrites without asking, leaving the reader with whichever they fetched
+	// last and no way to tell which that was.
+	name := "views.sql"
+	if portableBaseline {
+		name = "views-portable.sql"
+	}
+	w.Header().Set("Content-Disposition", `attachment; filename="`+name+`"`)
 	// The file names paths, not data, and it is regenerated from live state on
 	// every request — a cached copy would quietly describe a layout that has
 	// since rotated.

--- a/internal/console/views_follow_decimal_test.go
+++ b/internal/console/views_follow_decimal_test.go
@@ -79,7 +79,7 @@ func TestSQLPanelInput_pins(t *testing.T) {
 	}
 	srv := newViewsServer(t, dir, false)
 
-	in, err := srv.buildViewsInput(t.Context(), srv.cm.boot, false, false, true)
+	in, err := srv.buildViewsInput(t.Context(), srv.cm.boot, viewsRequest{PinSnapshot: true})
 	if err != nil {
 		t.Fatalf("buildViewsInput: %v", err)
 	}

--- a/internal/console/views_portable_baseline_test.go
+++ b/internal/console/views_portable_baseline_test.go
@@ -1,0 +1,123 @@
+package console
+
+import (
+	"strings"
+	"testing"
+)
+
+// newTwoLocationServer is a server whose backups exist in BOTH places: the
+// directory it reads by default, and the copy they were uploaded to. That
+// pairing is what bundle.baselineFallbackSrc means, and it is the only shape
+// where the download has a choice to offer.
+func newTwoLocationServer(t *testing.T, dir, uploaded string) *Server {
+	t.Helper()
+	s := &Server{token: "t", version: "v0.50.0", cm: newConnManager(nil, false)}
+	s.cm.boot = &bundle{
+		baselineSrc:         dir,
+		baselineFallbackSrc: uploaded,
+		baselineConfigured:  dir != "",
+	}
+	s.mux = s.buildHandler()
+	return s
+}
+
+// TestViewsPortableBaseline_readsTheOtherLocation is #1551 itself: the console
+// used to emit whichever location its server happened to be configured with, and
+// the person most likely to want the portable file is the one least likely to
+// have a shell on that host.
+//
+// The second location is a directory here, where production has an s3:// prefix.
+// What is under test is the SELECTION, which does not read the scheme: it takes
+// baselineFallbackSrc, the field that is set only when a server has both. Making
+// it a real bucket would test DuckDB's S3 listing, which is neither new nor what
+// this changes, and would need credentials to run at all.
+//
+// Each location holds a DIFFERENT table, so the assertion is which snapshot was
+// read and not which string appears. Matching on the path alone would pass for a
+// build that emitted the right root and listed the wrong one.
+func TestViewsPortableBaseline_readsTheOtherLocation(t *testing.T) {
+	onHost, uploaded := t.TempDir(), t.TempDir()
+	writeBaselineFixture(t, onHost, "2026-06-10T12-00-00Z", "shop", "orders.parquet")
+	writeBaselineFixture(t, uploaded, "2026-06-10T12-00-00Z", "shop", "invoices.parquet")
+	srv := newTwoLocationServer(t, onHost, uploaded)
+
+	rec, local := doServersReq(t, srv, "GET", "/api/views.sql", "")
+	if rec.Code != 200 {
+		t.Fatalf("default download: code = %d, body = %s", rec.Code, local)
+	}
+	rec, portable := doServersReq(t, srv, "GET", "/api/views.sql?portable_baseline=1", "")
+	if rec.Code != 200 {
+		t.Fatalf("portable download: code = %d, body = %s", rec.Code, portable)
+	}
+
+	// Both directions. Asserting only that the portable file reads the second
+	// location would pass for a build that read it in EVERY file, which breaks
+	// the reader on the host instead of the one off it.
+	if !strings.Contains(string(local), "state_shop_orders") {
+		t.Error("the default download does not read the backup directory on this host")
+	}
+	if strings.Contains(string(local), "state_shop_invoices") {
+		t.Error("the default download reads the uploaded copy, which needs credentials " +
+			"this host may not have")
+	}
+	if !strings.Contains(string(portable), "state_shop_invoices") {
+		t.Error("portable_baseline=1 did not move the state views to the uploaded copy")
+	}
+	if strings.Contains(string(portable), "state_shop_orders") {
+		t.Error("the portable download still reads the backup directory on this host, " +
+			"which is not on the machine it was downloaded to")
+	}
+	if cd := rec.Header().Get("Content-Disposition"); !strings.Contains(cd, `filename="views-portable.sql"`) {
+		t.Errorf("Content-Disposition = %q, want views-portable.sql; saved under the same name "+
+			"as the local file it overwrites it", cd)
+	}
+}
+
+// TestViewsPortableBaseline_refusedWithoutASecondLocation: the parameter names a
+// place, and a server with one backup location has no second place to name.
+//
+// Refused, never quietly ignored. Falling back to the local directory answers a
+// request for a portable file with a 200 and a file whose every state view names
+// a path the reader's machine does not have, which is the exact failure the
+// parameter exists to avoid.
+func TestViewsPortableBaseline_refusedWithoutASecondLocation(t *testing.T) {
+	dir := t.TempDir()
+	writeBaselineFixture(t, dir, "2026-06-10T12-00-00Z", "shop", "orders.parquet")
+	srv := newViewsServer(t, dir, false) // local only, no S3 prefix
+
+	rec, body := doServersReq(t, srv, "GET", "/api/views.sql?portable_baseline=1", "")
+	if rec.Code != 422 {
+		t.Fatalf("code = %d, want 422; body = %s", rec.Code, body)
+	}
+	if !strings.Contains(string(body), "no S3 backup prefix") {
+		t.Errorf("the refusal does not say what is missing: %s", body)
+	}
+}
+
+// TestViewsPortableBaseline_capabilityFollowsTheSecondLocation keeps the control
+// and the route agreeing. The UI renders the box on this flag, so a flag that
+// said yes where the route says 422 would put a box on the card that only fails.
+func TestViewsPortableBaseline_capabilityFollowsTheSecondLocation(t *testing.T) {
+	dir := t.TempDir()
+	writeBaselineFixture(t, dir, "2026-06-10T12-00-00Z", "shop", "orders.parquet")
+
+	for _, tc := range []struct {
+		name string
+		srv  *Server
+		want bool
+	}{
+		{"two locations", newTwoLocationServer(t, dir, "s3://bucket/baselines/"), true},
+		{"local only", newViewsServer(t, dir, false), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec, body := doServersReq(t, tc.srv, "GET", "/api/capabilities", "")
+			if rec.Code != 200 {
+				t.Fatalf("code = %d, body = %s", rec.Code, body)
+			}
+			got := strings.Contains(string(body), `"views_portable_baseline":true`)
+			if got != tc.want {
+				t.Errorf("views_portable_baseline = %v, want %v; body = %s", got, tc.want, body)
+			}
+		})
+	}
+}


### PR DESCRIPTION
closes #1551

Rebased onto `main` now that #1556 has merged.

## Summary

The console emitted whichever backup location its server happened to be configured with. A server with a local backup directory whose snapshots are also uploaded has both, and only ever got the local one, so the person most likely to want the portable file was the one least likely to have a shell on that host.

`portable_baseline=1` on `GET /api/views.sql` reads the state views out of the S3 prefix instead.

## Two corrections to the issue, both of which made it smaller

**The issue's table is half wrong now.** It records the tension as two axes at once: local follows a refresh but does not run off-host, S3 runs off-host but goes stale. #1556 removed the second half, so an `s3://` root follows too. What is left is one axis, where the file will be opened, which is a thing the reader knows and can be asked about plainly.

**The console already had the other location.** The registry stores both per server, and the bundle resolves the S3 prefix into `baselineFallbackSrc` when the local directory wins, for the #766 reconstruct fallback. So the "only offer a location that actually holds the snapshots" constraint needed no new probing: `baselineFallbackSrc != ""` IS that signal, already computed. The choice is read off the bundle rather than the request, so a request cannot name a prefix the snapshots were never written to.

## The three constraints the issue named

- **Only offer a location that holds the snapshots.** The capability and the handler's refusal read the same bundle field, so the box cannot be offered for a server the route then rejects. Asked for with no second location it is a 422, never a quiet fall back to the local directory: answering a request for a portable file with a file full of local paths is the failure the parameter exists to remove, delivered as a success.
- **Follow behaviour per emitted file.** Dissolved by #1556. Both roots follow, and the generated header says which way.
- **Filenames must not collide.** The portable one saves as `views-portable.sql`. A browser writes into one folder and replaces a repeated name without asking.

## On the card

One new checkbox, **Works on another machine**, and only when the capability says this server has two locations. A box that changes nothing for most servers is worse than no box. It is phrased as where the file will be opened, not as which storage it names: the reader taking a file to a laptop knows that much, and need not know where their backups live.

`TestDuckDBCardOffersOneDecision` was rewritten rather than relaxed. It now pins the rule that made it worth having: at most these two, the second gated on the capability, and `include_live` / `pin_snapshot` still absent from this surface.

## Test plan

- [x] `go test ./... -count=1`, `go vet ./...`
- [x] Selection asserted in BOTH directions, with a DIFFERENT table in each location so the assertion is which snapshot was read and not which string appears
- [x] 422 when there is no second location; capability false in the same case
- [x] Four mutations, each failing its guard: selection ignored, refusal removed, capability always true, one filename for both
