### PR TITLE
console: show the view names the DuckDB card just wrote

### DIFF
--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -4203,6 +4203,50 @@ function duckdbShape() {
   return { el: el("div", { class: "dk-shape" }, state, events), events };
 }
 
+// duckdbViewNames pulls the view names out of a generated views.sql.
+//
+// Read off the file the user just downloaded, rather than asked for separately.
+// The names are sanitized and collision-suffixed by the generator, so a second
+// source for them is a second opinion that can drift; these ARE the names in the
+// file, or there is no file. It also costs nothing: the bytes are already here,
+// where asking the server would have re-listed storage to answer.
+//
+// The generator writes every one as CREATE OR REPLACE VIEW "<name>". A name can
+// hold no quote of its own to confuse the match, because the generator builds it
+// through sanitizeIdent, which keeps only [a-z0-9_] and folds everything else to
+// an underscore. assets_duckdbcard_test.go pins BOTH halves of that against
+// views.Generate, so neither the statement shape nor the character set can
+// quietly stop matching.
+function duckdbViewNames(sql) {
+  const out = [];
+  const re = /^CREATE OR REPLACE VIEW "([^"]+)"/gm;
+  let m;
+  while ((m = re.exec(sql)) !== null) out.push(m[1]);
+  return out;
+}
+
+// duckdbNameList renders what the reader can now query, by name.
+//
+// After the download, not before: on first visit the names are noise, and the
+// card has a text budget it keeps by drawing rather than explaining. At this
+// moment they are the one thing the reader needs and cannot guess, since the
+// only documented way to recover them is SHOW TABLES, the query that took 63
+// seconds on the surface this card replaced.
+function duckdbNameList(names, file) {
+  const box = el("div", { class: "dk-names" });
+  box.append(el("div", { class: "dk-names-head" },
+    el("code", { text: ".read " + file }),
+    el("span", { class: "dk-names-count", text: names.length + " views" })));
+  const list = el("div", { class: "dk-names-list" });
+  for (const n of names) {
+    const row = el("button", { class: "dk-name", type: "button", text: n, title: "Copy" });
+    row.onclick = () => copyText(n, "view name");
+    list.append(row);
+  }
+  box.append(list);
+  return box;
+}
+
 // duckdbPanel offers the generated DuckDB schema for this server's Parquet.
 //
 // It is NOT the console SQL page, which #1549 removed: nothing here executes.
@@ -4272,7 +4316,16 @@ function duckdbPanel() {
       const name = portable && portable.checked ? "views-portable.sql" : "views.sql";
       const sql = await apiText("/api/views.sql" + (q.length ? "?" + q.join("&") : ""));
       downloadBlob(name, sql, "text/plain");
-      toast(name + " downloaded. In DuckDB run .read " + name + ", once per session.");
+      // The instruction used to be a toast, which is the wrong container for the
+      // only handoff in this flow: it names a command for a session the reader
+      // has not opened yet, and then disappears. This stays on the card.
+      const older = body.querySelector(".dk-names");
+      if (older) older.remove();
+      // Above the button, not appended after it. The button is the action and
+      // stays at the foot of the card; a list that lands below it pushes the
+      // action into the middle of its own result.
+      body.insertBefore(duckdbNameList(duckdbViewNames(sql), name),
+        body.querySelector(".stg-cardfoot"));
     } catch (err) {
       toastError("could not generate views: " + ((err && err.message) || err));
     } finally {

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -2672,3 +2672,18 @@ button { font-family: inherit; }
    its idiom), accent (white label on a warm fill — orange text there would
    be invisible). */
 .btn:hover:not(.btn-primary):not(.btn-ghost):not(.btn-accent) { border-color: color-mix(in srgb, var(--brand-warm-b) 45%, var(--line)); color: var(--orange-2); }
+
+/* The view names, shown on the card after a views.sql download. Fixed height
+   with its own scroll: a server with fifty tables must not push the button off
+   screen, and the list is a lookup rather than something anyone reads through. */
+.dk-names { margin: 12px 14px 0; border-top: 1px solid var(--line); padding-top: 10px; }
+.dk-names-head { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; margin-bottom: 8px; }
+.dk-names-head code { font-size: 12px; color: var(--ink-2); }
+.dk-names-count { font-size: 11px; color: var(--ink-4); flex: none; }
+.dk-names-list { display: flex; flex-wrap: wrap; gap: 4px; max-height: 132px; overflow-y: auto; }
+.dk-name {
+  font: inherit; font-size: 11px; font-family: var(--mono, ui-monospace, monospace);
+  padding: 3px 7px; border: 1px solid var(--line); border-radius: 5px;
+  background: var(--surface-1); color: var(--ink-2); cursor: pointer;
+}
+.dk-name:hover { border-color: var(--accent); color: var(--ink-1); }

--- a/internal/console/assets_duckdbcard_test.go
+++ b/internal/console/assets_duckdbcard_test.go
@@ -2,9 +2,13 @@ package console
 
 import (
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/views"
 )
 
 // The Download a DuckDB schema card is the only caller of GET /api/views.sql,
@@ -172,4 +176,76 @@ func functionBody(t *testing.T, js, decl string) string {
 		}
 	}
 	return rest
+}
+
+// TestDuckDBCardNamesMatchTheFileItParses is the anti-lying guard for the view
+// list the card shows after a download (#1551 follow-up).
+//
+// The card reads the names out of the file's own bytes rather than asking for
+// them, so a second source cannot drift from the first. What CAN drift is the
+// shape it greps for. This drives views.Generate and extracts with a port of the
+// JavaScript regex, so a change to how the generator writes a CREATE statement
+// fails here instead of silently rendering an empty list.
+func TestDuckDBCardNamesMatchTheFileItParses(t *testing.T) {
+	in := views.Input{
+		GeneratedAt:      time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
+		BaselineSource:   "/data/baselines",
+		BaselineSnapshot: time.Date(2026, 4, 30, 3, 0, 0, 0, time.UTC),
+		Baselines: []views.BaselineTable{
+			{Schema: "shop", Table: "orders", Path: "/data/baselines/s/shop/orders.parquet"},
+			// Sanitizes to the same name as shop.order_items, so the generator
+			// suffixes it. A hand-derived list would get this pair wrong, which
+			// is half the reason the card does not derive one.
+			{Schema: "shop", Table: "order_items", Path: "/data/baselines/s/shop/order_items.parquet"},
+			{Schema: "shop_order", Table: "items", Path: "/data/baselines/s/shop_order/items.parquet"},
+			// Neither a hyphen nor a space is legal bare in an identifier.
+			{Schema: "Legacy-DB", Table: "Audit Log", Path: "/data/baselines/s/Legacy-DB/Audit Log.parquet"},
+		},
+	}
+	sqlText := views.Generate(in)
+	want := in.DefinedViews()
+	if len(want) == 0 {
+		t.Fatal("the fixture defines no view, so this asserts nothing")
+	}
+
+	// The same expression app.js uses. Kept as a literal rather than read out of
+	// the asset: the point is that these two agree, and reading one to test
+	// itself would agree with anything.
+	re := regexp.MustCompile(`(?m)^CREATE OR REPLACE VIEW "([^"]+)"`)
+	var got []string
+	for _, m := range re.FindAllStringSubmatch(sqlText, -1) {
+		got = append(got, m[1])
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("the card would list %v; the file defines %v", got, want)
+	}
+
+	// The character set the simple pattern above relies on. sanitizeIdent folds
+	// everything outside [a-z0-9_], so a name can carry no quote of its own; if
+	// that ever changes, the pattern needs the quote-doubling case back and this
+	// says so before the list starts truncating names.
+	safe := regexp.MustCompile(`^[a-z0-9_]+$`)
+	for _, n := range want {
+		if !safe.MatchString(n) {
+			t.Errorf("view name %q is outside [a-z0-9_]; the card's pattern assumes it is not", n)
+		}
+	}
+
+	// And the asset really does carry that expression.
+	body := functionBody(t, readAsset(t, "app.js"), "function duckdbViewNames(")
+	if !strings.Contains(body, `/^CREATE OR REPLACE VIEW "([^"]+)"/gm`) {
+		t.Error("app.js no longer greps for the statement shape this test pinned")
+	}
+
+	// Placement, which fails OPEN if it breaks: insertBefore appends when its
+	// reference node is null, so moving the foot off `body` would put the list
+	// below the button with nothing raised and nothing to see in a diff.
+	panel := functionBody(t, readAsset(t, "app.js"), "function duckdbPanel(")
+	if !strings.Contains(panel, "body.insertBefore(duckdbNameList") {
+		t.Error("the view list is no longer placed relative to the card foot")
+	}
+	if !strings.Contains(panel, `body.append(el("div", { class: "stg-cardfoot" }`) {
+		t.Error("the card foot is not appended to `body`, so insertBefore's reference is null " +
+			"and the list silently lands below the button instead of above it")
+	}
 }


### PR DESCRIPTION
closes #1559

## Summary

The card wrote a file naming up to fifty views and showed none of them. The names are not guessable (`sanitizeIdent` folds anything outside `[a-z0-9_]`, collisions get a numeric suffix), and the documented way to recover them was `SHOW TABLES`, the query that measured 63s and timed out on the SQL page this card replaced. The console held the answer and pointed the reader at the query that failed.

## Two decisions worth reviewing

**Read from the downloaded bytes, not a new endpoint.** They are already in the page. A second source for a generated name can drift from the file it describes; these ARE the names in the file or there is no file. A names route would also have re-listed storage to answer and carried the per-route tax (`apiRoutePerms` + mirror + `rbace2e` row).

**Shown after the download, above the button.** On first visit the names are noise and the card keeps its 300-character budget by drawing rather than explaining. When the file lands they are the one thing the reader needs and cannot work out. This replaces the toast, which named a dot-command for a session the reader had not opened yet and then disappeared.

Nothing runs and nothing is read from storage, so this is not the SQL surface returning.

## Test plan

- [x] `go test ./... -count=1`, `go vet ./...`
- [x] The guard drives `views.Generate` over a fixture carrying a name collision and a schema with a hyphen and a space, extracts with a port of the card's own expression, and compares to `DefinedViews()`
- [x] It also pins the character set the simple pattern relies on, and the placement, which fails OPEN because `insertBefore` appends when its reference node is null
- [x] Four mutations, each failing the guard: statement shape changed, sanitize keeps uppercase, asset regex drifted, card foot moved off `body`
- [x] Rendered in headless Chrome against the real stylesheet before committing. That is what caught the placement bug: `append` would have put the list below the button
