### PR TITLE
views: say when the state views resolve on only one machine

### DIFF
--- a/internal/views/localpath_note_test.go
+++ b/internal/views/localpath_note_test.go
@@ -1,0 +1,38 @@
+package views
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestHeader_localBaselineRootSaysWhereItResolves pins the note in BOTH
+// directions, which is the whole point of it.
+//
+// A views file travels: the console serves it to a browser, and a generated file
+// gets copied to whichever machine will run it. A local baseline root resolves on
+// exactly one of them, at exactly one path, and without the note the mismatch
+// arrives as DuckDB's "No files found", which reads as a missing or corrupt
+// backup rather than as the right file on the wrong host.
+//
+// The negative half matters as much: an s3:// root resolves anywhere, so the
+// same line there would be false, and a warning that fires on the shape that
+// does NOT have the problem teaches the reader to ignore it.
+func TestHeader_localBaselineRootSaysWhereItResolves(t *testing.T) {
+	const note = "resolve only where it is mounted"
+
+	local := goldenInput()
+	local.BaselineSource = "/data/baselines"
+	for i := range local.Baselines {
+		local.Baselines[i].Path = "/data/baselines/2026-04-30T03-00-00Z/shop/t.parquet"
+	}
+	if got := Generate(local); !strings.Contains(got, note) {
+		t.Error("a file over a local baseline directory does not say its state views resolve " +
+			"only on the machine that holds it")
+	}
+
+	// goldenInput's baseline root is already s3://.
+	if got := Generate(goldenInput()); strings.Contains(got, note) {
+		t.Error("a file over an s3:// baseline root carries the host-bound note; an S3 root is " +
+			"readable from anywhere, so the note is false there")
+	}
+}

--- a/internal/views/testdata/views.follow.golden.sql
+++ b/internal/views/testdata/views.follow.golden.sql
@@ -40,6 +40,8 @@
 -- Baseline snapshot:
 --   /data/baselines at 2026-04-30T03:00:00Z (4 table(s))
 --   read through /data/baselines/current, which is that snapshot right now
+--   a directory, so the state views resolve only where it is mounted,
+--   at exactly this path
 
 -- S3 setup, mirroring what bintrail's own DuckDB sessions configure.
 INSTALL httpfs; LOAD httpfs;

--- a/internal/views/views.go
+++ b/internal/views/views.go
@@ -693,6 +693,16 @@ func writeHeader(b *strings.Builder, in Input) {
 			// open. What they open is decided per read.
 			b.WriteString("--   read through the newest `_SUCCESS` snapshot, which is that one right now\n")
 		}
+		// A local root resolves on ONE machine, and this file travels: the
+		// console serves it to a browser, and a generated file is meant to be
+		// copied around. Said here, beside the path, because without it the
+		// mismatch surfaces as DuckDB's "No files found", which reads as a
+		// missing or corrupt backup rather than as the right file on the wrong
+		// host. An s3:// root needs no such line; that is what it is for.
+		if !isS3(in.BaselineSource) {
+			b.WriteString("--   a directory, so the state views resolve only where it is mounted,\n")
+			b.WriteString("--   at exactly this path\n")
+		}
 	}
 	b.WriteString("\n")
 }


### PR DESCRIPTION
## Summary

A views file travels. The console serves it to a browser, and a generated file gets copied to whichever machine will run it. State views over a **local** baseline directory resolve on exactly one host, at exactly one path, and the file said nothing about it: it printed the directory and left the reader to find out.

The way they found out was DuckDB's `No files found that match the pattern`, which reads as a missing or corrupt backup rather than as the right file on the wrong machine.

On the shipped compose stack the gap is wider than it first looks. `BINTRAIL_CONSOLE_BASELINE_DIR` is `/var/lib/bintrail/baselines`, a **container** path into the `bintrail-state` volume, so the downloaded file resolves neither on a laptop nor in a shell on the host running the stack. It resolves only inside a container that mounts that volume at the same path, which is what the `flashback` profile already does (`bintrail-state:/var/lib/bintrail:ro`).

## Not on S3

An `s3://` root is readable from anywhere, so the same sentence there would be false. A warning that fires on the shape that does NOT have the problem teaches its reader to skip it, so the guard pins both directions.

## Test plan

- [x] `go test ./... -count=1`, `go vet ./...`
- [x] Guard asserts the note appears for a local root and is ABSENT for an `s3://` one
- [x] Two mutations, each failing it: note always emitted, note never emitted
- [x] Goldens regenerated; `views.follow.golden.sql` (local) gains the line, `views.newest.golden.sql` (S3) does not
