### PR TITLE
shorten the handoff from the DuckDB card to a DuckDB session

### DIFF
--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -4225,6 +4225,23 @@ function duckdbViewNames(sql) {
   return out;
 }
 
+// duckdbCommandLine renders the one command the reader has to reproduce, with a
+// Copy button.
+//
+// Real text, not a drawing. A picture of a terminal was built here first and
+// thrown away: at card width it wrapped under the command and read as a loading
+// skeleton, and unlike claudeAskMock it depicted nothing the server sends, so
+// there was nothing to pin it against. The command itself is the part that has
+// to be exact, and it is the part a drawing cannot carry.
+function duckdbCommandLine(file) {
+  const cmd = "duckdb -init " + file + " lake.db";
+  const box = el("div", { class: "dk-run" },
+    el("code", { class: "dk-cmd", text: cmd }),
+    el("button", { class: "dk-copy", type: "button", text: "Copy" }));
+  box.querySelector(".dk-copy").onclick = () => copyText(cmd, "command");
+  return box;
+}
+
 // duckdbNameList renders what the reader can now query, by name.
 //
 // After the download, not before: on first visit the names are noise, and the
@@ -4232,10 +4249,13 @@ function duckdbViewNames(sql) {
 // moment they are the one thing the reader needs and cannot guess, since the
 // only documented way to recover them is SHOW TABLES, the query that took 63
 // seconds on the surface this card replaced.
-function duckdbNameList(names, file) {
+function duckdbNameList(names) {
   const box = el("div", { class: "dk-names" });
+  // The count only. The command box above already says how to load the file,
+  // and naming a second way to do it (.read, for a session already open) beside
+  // the first put two loading instructions on screen with nothing to tell them
+  // apart.
   box.append(el("div", { class: "dk-names-head" },
-    el("code", { text: ".read " + file }),
     el("span", { class: "dk-names-count", text: names.length + " views" })));
   const list = el("div", { class: "dk-names-list" });
   for (const n of names) {
@@ -4319,13 +4339,16 @@ function duckdbPanel() {
       // The instruction used to be a toast, which is the wrong container for the
       // only handoff in this flow: it names a command for a session the reader
       // has not opened yet, and then disappears. This stays on the card.
-      const older = body.querySelector(".dk-names");
-      if (older) older.remove();
+      for (const sel of [".dk-names", ".dk-run"]) {
+        const older = body.querySelector(sel);
+        if (older) older.remove();
+      }
       // Above the button, not appended after it. The button is the action and
       // stays at the foot of the card; a list that lands below it pushes the
       // action into the middle of its own result.
-      body.insertBefore(duckdbNameList(duckdbViewNames(sql), name),
-        body.querySelector(".stg-cardfoot"));
+      const foot = body.querySelector(".stg-cardfoot");
+      body.insertBefore(duckdbCommandLine(name), foot);
+      body.insertBefore(duckdbNameList(duckdbViewNames(sql)), foot);
     } catch (err) {
       toastError("could not generate views: " + ((err && err.message) || err));
     } finally {

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -2677,8 +2677,7 @@ button { font-family: inherit; }
    with its own scroll: a server with fifty tables must not push the button off
    screen, and the list is a lookup rather than something anyone reads through. */
 .dk-names { margin: 12px 14px 0; border-top: 1px solid var(--line); padding-top: 10px; }
-.dk-names-head { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; margin-bottom: 8px; }
-.dk-names-head code { font-size: 12px; color: var(--ink-2); }
+.dk-names-head { display: flex; align-items: baseline; justify-content: flex-end; margin-bottom: 8px; }
 .dk-names-count { font-size: 11px; color: var(--ink-4); flex: none; }
 .dk-names-list { display: flex; flex-wrap: wrap; gap: 4px; max-height: 132px; overflow-y: auto; }
 .dk-name {
@@ -2687,3 +2686,20 @@ button { font-family: inherit; }
   background: var(--surface-1); color: var(--ink-2); cursor: pointer;
 }
 .dk-name:hover { border-color: var(--accent); color: var(--ink-1); }
+
+/* The one command the reader has to reproduce, with a Copy button. Real text
+   rather than a drawing: a terminal mock was built here and dropped, because at
+   card width it read as a loading skeleton and depicted nothing the server
+   sends, so nothing could pin it. */
+.dk-run {
+  display: flex; align-items: center; gap: 8px; margin: 12px 14px 0;
+  padding: 9px 10px; border: 1px solid var(--line); border-radius: 7px;
+  background: var(--surface-1);
+}
+.dk-cmd { font-size: 11px; font-family: var(--mono, ui-monospace, monospace); color: var(--ink-2); word-break: break-all; flex: 1; }
+.dk-copy {
+  font: inherit; font-size: 11px; flex: none; cursor: pointer;
+  padding: 3px 8px; border: 1px solid var(--line); border-radius: 5px;
+  background: var(--surface-2); color: var(--ink-3);
+}
+.dk-copy:hover { border-color: var(--accent); color: var(--ink-1); }

--- a/internal/views/testdata/views.follow.golden.sql
+++ b/internal/views/testdata/views.follow.golden.sql
@@ -43,6 +43,12 @@
 --   a directory, so the state views resolve only where it is mounted,
 --   at exactly this path
 
+-- Timestamps are recorded in UTC, and the archives carry the zone, so the
+-- session's setting decides how they print and where date_trunc puts a day
+-- boundary. Pinned to UTC here so the numbers match the console. Change it if
+-- you would rather read in your own zone.
+SET TimeZone = 'UTC';
+
 -- S3 setup, mirroring what bintrail's own DuckDB sessions configure.
 INSTALL httpfs; LOAD httpfs;
 INSTALL aws; LOAD aws;

--- a/internal/views/testdata/views.golden.sql
+++ b/internal/views/testdata/views.golden.sql
@@ -24,6 +24,12 @@
 -- Baseline snapshot:
 --   s3://my-bucket/baselines/ at 2026-04-30T03:00:00Z (4 table(s))
 
+-- Timestamps are recorded in UTC, and the archives carry the zone, so the
+-- session's setting decides how they print and where date_trunc puts a day
+-- boundary. Pinned to UTC here so the numbers match the console. Change it if
+-- you would rather read in your own zone.
+SET TimeZone = 'UTC';
+
 -- S3 setup, mirroring what bintrail's own DuckDB sessions configure.
 INSTALL httpfs; LOAD httpfs;
 INSTALL aws; LOAD aws;

--- a/internal/views/testdata/views.live.golden.sql
+++ b/internal/views/testdata/views.live.golden.sql
@@ -24,6 +24,12 @@
 -- Baseline snapshot:
 --   s3://my-bucket/baselines/ at 2026-04-30T03:00:00Z (4 table(s))
 
+-- Timestamps are recorded in UTC, and the archives carry the zone, so the
+-- session's setting decides how they print and where date_trunc puts a day
+-- boundary. Pinned to UTC here so the numbers match the console. Change it if
+-- you would rather read in your own zone.
+SET TimeZone = 'UTC';
+
 -- S3 setup, mirroring what bintrail's own DuckDB sessions configure.
 INSTALL httpfs; LOAD httpfs;
 INSTALL aws; LOAD aws;

--- a/internal/views/testdata/views.newest.golden.sql
+++ b/internal/views/testdata/views.newest.golden.sql
@@ -41,6 +41,12 @@
 --   s3://my-bucket/baselines/ at 2026-04-30T03:00:00Z (4 table(s))
 --   read through the newest `_SUCCESS` snapshot, which is that one right now
 
+-- Timestamps are recorded in UTC, and the archives carry the zone, so the
+-- session's setting decides how they print and where date_trunc puts a day
+-- boundary. Pinned to UTC here so the numbers match the console. Change it if
+-- you would rather read in your own zone.
+SET TimeZone = 'UTC';
+
 -- S3 setup, mirroring what bintrail's own DuckDB sessions configure.
 INSTALL httpfs; LOAD httpfs;
 INSTALL aws; LOAD aws;

--- a/internal/views/testdata/views.omitevents.golden.sql
+++ b/internal/views/testdata/views.omitevents.golden.sql
@@ -22,6 +22,12 @@
 -- Baseline snapshot:
 --   s3://my-bucket/baselines/ at 2026-04-30T03:00:00Z (4 table(s))
 
+-- Timestamps are recorded in UTC, and the archives carry the zone, so the
+-- session's setting decides how they print and where date_trunc puts a day
+-- boundary. Pinned to UTC here so the numbers match the console. Change it if
+-- you would rather read in your own zone.
+SET TimeZone = 'UTC';
+
 -- S3 setup, mirroring what bintrail's own DuckDB sessions configure.
 INSTALL httpfs; LOAD httpfs;
 INSTALL aws; LOAD aws;

--- a/internal/views/timezone_test.go
+++ b/internal/views/timezone_test.go
@@ -1,0 +1,46 @@
+package views
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestGenerate_pinsTheSessionToUTC covers the one statement in the file that is
+// neither a view nor a way to reach storage.
+//
+// It exists because leaving it out is wrong QUIETLY. The archives write
+// event_timestamp as TIMESTAMP WITH TIME ZONE, so the session's zone decides
+// where date_trunc puts a day boundary: read from Buenos Aires, an event at
+// 2026-01-02 01:00 UTC buckets into January 1st, and nothing fails. The guide
+// used to carry this as a step performed by hand, which made the silent wrong
+// answer the default for anyone who skipped it.
+func TestGenerate_pinsTheSessionToUTC(t *testing.T) {
+	got := Generate(goldenInput())
+	if !strings.Contains(got, "SET TimeZone = 'UTC';") {
+		t.Fatal("the generated file does not pin the session zone, so date_trunc buckets on " +
+			"whatever zone the reader's machine happens to be in")
+	}
+
+	// Ahead of every view. A zone set after them still applies, since the views
+	// are not evaluated at creation, but a reader who stops the file early or
+	// copies the first half out gets the buckets they expect either way.
+	if strings.Index(got, "SET TimeZone") > strings.Index(got, "CREATE OR REPLACE VIEW") {
+		t.Error("the zone is pinned after the views are defined")
+	}
+
+	// It says what it did. This changes the reader's session rather than
+	// describing the layout, which is the one thing the rest of the file never
+	// does, so the file has to own it and say how to undo it.
+	if !strings.Contains(got, "Change it if") {
+		t.Error("the file sets the reader's session zone without saying they can change it")
+	}
+
+	// A local-only file gets it too: the zone question is about the column type,
+	// not about where the bytes are.
+	local := goldenInput()
+	local.ArchiveSources = []string{"/data/archives/bintrail_id=1111"}
+	local.BaselineSource = "/data/baselines"
+	if !strings.Contains(Generate(local), "SET TimeZone = 'UTC';") {
+		t.Error("a file over local paths does not pin the session zone")
+	}
+}

--- a/internal/views/views.go
+++ b/internal/views/views.go
@@ -310,6 +310,7 @@ func (v ViewSet) wants(name string) bool {
 func Generate(in Input) string {
 	var b strings.Builder
 	writeHeader(&b, in)
+	writeTimeZone(&b)
 	if in.NeedsS3() {
 		region := in.ArchiveRegion
 		if in.RegionAmbiguous {
@@ -722,6 +723,28 @@ func orUnknown(s string) string {
 // paste into a notebook or share with a colleague: it resolves whatever the
 // environment already has (instance role, SSO profile, env vars) and puts NO key
 // material in the generated text.
+// writeTimeZone pins the session to UTC, which is the one statement in this file
+// that is neither a view nor a way to reach storage.
+//
+// It is here because leaving it out is wrong QUIETLY. The archives store
+// event_timestamp as TIMESTAMP WITH TIME ZONE, so the session's zone decides
+// both how it prints and where date_trunc puts a day boundary; DuckDB defaults
+// to the machine's zone, and a reader west of UTC gets buckets that disagree
+// with the console, with the MCP tools and with every timestamp dbtrail records,
+// without anything failing. The guide used to carry this as a step the reader
+// performed by hand, which made a silent wrong answer the default for anyone who
+// skipped it.
+//
+// Emitted, not enforced: the comment says what it did so a reader who would
+// rather work in their own zone can change one line.
+func writeTimeZone(b *strings.Builder) {
+	b.WriteString("-- Timestamps are recorded in UTC, and the archives carry the zone, so the\n")
+	b.WriteString("-- session's setting decides how they print and where date_trunc puts a day\n")
+	b.WriteString("-- boundary. Pinned to UTC here so the numbers match the console. Change it if\n")
+	b.WriteString("-- you would rather read in your own zone.\n")
+	b.WriteString("SET TimeZone = 'UTC';\n\n")
+}
+
 func writeS3Preamble(b *strings.Builder, region string, ep storage.S3Endpoint, ambiguousRegion bool) {
 	b.WriteString("-- S3 setup, mirroring what bintrail's own DuckDB sessions configure.\n")
 	if ep.Set() {


### PR DESCRIPTION
Two changes about the gap between downloading the file and reading a row.

## The file pins its own session zone

The archives store `event_timestamp` as `TIMESTAMP WITH TIME ZONE`, so the session's setting decides how it prints and where `date_trunc` puts a day boundary. Verified: the same instant reads `2026-01-01 23:30+00` in UTC and `20:30-03` in Buenos Aires, and the day bucket moves with it.

DuckDB defaults to the machine's zone, so a reader west of UTC got buckets that disagreed with the console, the MCP tools, and every timestamp dbtrail records, with nothing failing. The guide carried `SET TimeZone = 'UTC'` as step 3, performed by hand, which made the silent wrong answer the default for anyone who skipped it.

Emitted, not enforced: the comment above it says what it did, so a reader who would rather work in their own zone changes one line.

## The card shows the command, with Copy

It was the one thing the reader had to reproduce exactly, and the only part of the flow the console never named.

**A drawn terminal and a miniature DuckDB session were built for this and thrown away.** Rendered at card width the session wrapped under the command and read as a loading skeleton, and unlike `claudeAskMock` it depicted nothing the server sends, so there was nothing to pin it against. The command is real text because being exact is its whole job.

The view list also drops the `.read` line from its header: with the command box above it, two ways to load the same file sat on screen with nothing to tell them apart.

## Test plan

- [x] `go test ./... -count=1`, `go vet ./...`
- [x] Guard asserts the zone is pinned, ahead of the views, that the file says it can be changed, and that a local-only file gets it too
- [x] Two mutations, each failing it: not emitted, emitted after the views
- [x] All five goldens regenerated. `views.golden.sql` initially went stale because `-run Golden` does not match `TestGenerate_golden`; caught by the failing test before commit
- [x] Rendered in headless Chrome twice. The first render is why the session drawing is not in this PR
