### PR TITLE
console: draw the Iceberg panel instead of explaining it

### DIFF
--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -4644,6 +4644,84 @@ function icebergComposeNote(cur) {
     ", set INDEX_DSN and BASELINE_DIR or BASELINE_S3 in the stack's .env file.";
 }
 
+// ICEBERG_ENGINES is the payoff, drawn as the names an analyst already knows
+// rather than claimed in a sentence. Prose, not derived from anything: the
+// export writes standard Iceberg, so this is which readers we say it out loud
+// for, and it is edited by hand when that answer changes.
+const ICEBERG_ENGINES = ["Spark", "Trino", "Athena", "Snowflake", "DuckDB"];
+
+// ICEBERG_PLACEHOLDERS labels the two blanks in the command instead of
+// describing them in a paragraph under it.
+//
+// Each key must appear VERBATIM in what icebergExportCommand builds, and a
+// test asserts exactly that: a legend pointing at text that is not on the line
+// above it is worse than no legend, because the reader hunts for it. This is
+// the "a drawing can lie in a way prose cannot" discipline that claudeAskMock
+// carries against the bundle manifest.
+//
+// Filtered by what the rendered command actually holds, because the password
+// blank is absent for an index that needs none, and a legend for a blank that
+// is not there describes somebody else's command.
+const ICEBERG_PLACEHOLDERS = [
+  ["***", "your index password"],
+  ["/path/to/warehouse", "a folder you pick"],
+];
+
+// icebergFlow draws what the export makes and who reads it: three stages, left
+// to right. It replaces the opening paragraph, which said the same thing in
+// three sentences that a reader skimming a settings page does not read.
+function icebergFlow() {
+  const stage = (title, sub) => el("div", { class: "ice-stage" },
+    el("div", { class: "ice-stage-t", text: title }),
+    el("div", { class: "ice-stage-s", text: sub }));
+  const arrow = () => el("div", { class: "ice-arrow", text: "\u2192" });
+  const engines = el("div", { class: "ice-stage" },
+    el("div", { class: "ice-stage-t", text: "Read directly by" }),
+    el("div", { class: "ice-eng" },
+      ...ICEBERG_ENGINES.map((n) => el("span", { class: "ice-eng-n", text: n }))));
+  return el("div", { class: "ice-flow" },
+    stage("This server's history", "a snapshot, plus every change since"),
+    arrow(),
+    stage("Iceberg tables", "in a folder you pick"),
+    arrow(),
+    engines);
+}
+
+// icebergRuns draws the incremental behaviour as two bars, because the shape
+// IS the message: the first run is the expensive one and every run after it is
+// small. That is what makes "as fresh as you schedule it" believable, and it
+// was the clause of the old paragraph most likely to be skipped.
+function icebergRuns() {
+  const row = (label, barClass, note) => [
+    el("span", { class: "ice-run-l", text: label }),
+    el("span", { class: "ice-run-b" },
+      el("span", { class: "ice-bar " + barClass }),
+      el("span", { class: "ice-run-n", text: note })),
+  ];
+  return el("div", { class: "ice-runs" },
+    ...row("First run", "ice-bar-full", "loads the whole snapshot"),
+    ...row("Every run after", "ice-bar-delta", "adds only what changed"));
+}
+
+// icebergKeys labels the blanks in the command that was just printed.
+function icebergKeys(cmd) {
+  const keys = ICEBERG_PLACEHOLDERS.filter(([k]) => cmd.includes(k));
+  if (!keys.length) return null;
+  return el("div", { class: "ice-keys" },
+    ...keys.map(([k, what]) => el("span", { class: "ice-key" },
+      el("code", { class: "stg-code", text: k }),
+      el("span", { text: what }))));
+}
+
+// icebergExportPanel: a drawing, the command, and one warning.
+//
+// It used to open with four paragraphs before the command and keep two more
+// after it. Everything that was an EXPLANATION is now either drawn (what it
+// makes, who reads it, what a run costs) or moved into "How to run it", where
+// a reader who is actually about to run it will look. Only one paragraph stays
+// in the open, and it is the only one that is a HAZARD rather than a
+// description: the Docker route can export a different dataset than the one
+// this panel just described, and succeed while doing it.
 function icebergExportPanel(cur, baselines) {
   const cmd = icebergExportCommand(cur, baselines);
   if (!cmd) return null;
@@ -4652,28 +4730,29 @@ function icebergExportPanel(cur, baselines) {
     el("h2", { class: "ov-panel-title", text: "Keep it current with Iceberg" })));
   const body = el("div", { class: "cn-sql-body" });
   panel.append(body);
-  body.append(el("p", { class: "cn-sql-row", text:
-    "Write these backups, and every change recorded since, as Apache Iceberg tables. Spark, Trino, Athena, " +
-    "Snowflake and DuckDB read them directly. The first run loads the newest backup; every run after that " +
-    "adds only what changed, so a report can be as fresh as you schedule it." }));
-  body.append(el("p", { class: "cn-sql-row", text:
-    "It is a command and not a button because the export writes a new copy of your data, and it is kept out " +
-    "of the process that captures changes so a long export can never slow capture down." }));
+  body.append(icebergFlow());
+  body.append(icebergRuns());
   body.append(el("div", { class: "cn-urlrow" },
     el("code", { class: "stg-code cn-url", text: cmd }),
     el("button", { class: "btn btn-sm", type: "button", text: "Copy",
       onclick: () => copyText(cmd, "Export command") })));
-  body.append(el("p", { class: "cn-sql-row", text:
-    "Put the index password in place of *** and choose a folder in place of /path/to/warehouse. " +
-    "Nothing is sent anywhere: the tables are written where you point it." }));
-  body.append(el("p", { class: "cn-sql-row", text:
-    "The line carries the index host, port, database and user, and nothing else about the connection. " +
-    "If your index needs settings this console was given, such as TLS or a timeout, add them yourself." }));
+  const keys = icebergKeys(cmd);
+  if (keys) body.append(keys);
   // In the visible body, not inside the collapsed block: for a server that is
   // not the stack's own, the Docker route exports a DIFFERENT dataset and
   // succeeds while doing it, which is the one failure here nobody would see.
   body.append(el("p", { class: "cn-sql-row", text: icebergComposeNote(cur) }));
   body.append(cnFine("How to run it",
+    // Moved down from the open body. Both are answers to questions a reader
+    // has only once they are about to run the line, and one of them ("why is
+    // this not a button") is a justification, which is the first thing to go
+    // when the page is too dense to read.
+    el("p", { class: "form-hint", text:
+      "It is a command and not a button because the export writes a new copy of your data, and it is kept out " +
+      "of the process that captures changes so a long export can never slow capture down." }),
+    el("p", { class: "form-hint", text:
+      "The line carries the index host, port, database and user, and nothing else about the connection. " +
+      "If your index needs settings this console was given, such as TLS or a timeout, add them yourself." }),
     // The address and the path are as THIS process sees them, and in the
     // bundled stack both are container-scoped (index-mysql:3306,
     // /var/lib/bintrail/baselines): pasted into a host shell they resolve to

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -4680,9 +4680,18 @@ function icebergFlow() {
     el("div", { class: "ice-eng" },
       ...ICEBERG_ENGINES.map((n) => el("span", { class: "ice-eng-n", text: n }))));
   return el("div", { class: "ice-flow" },
-    stage("This server's history", "a snapshot, plus every change since"),
+    // "newest backup", not "the whole snapshot": the old paragraph said WHICH
+    // backup the first run consumes, and a reader looking at a list of them on
+    // this very page cannot work that out from "snapshot". One word for one
+    // object, too — the fold below and the rest of this page say "backup".
+    stage("This server's history", "the newest backup, plus every change since"),
     arrow(),
-    stage("Iceberg tables", "in a folder you pick"),
+    // The egress answer, kept in the open. It was a sentence under the command
+    // ("Nothing is sent anywhere: the tables are written where you point it")
+    // and drawing the panel dropped it. For an EXPORT feature it is the one
+    // thing a cautious operator asks while standing here, so it belongs in the
+    // picture rather than in the docs it also appears in.
+    stage("Iceberg tables", "written where you point it, nowhere else"),
     arrow(),
     engines);
 }
@@ -4691,6 +4700,14 @@ function icebergFlow() {
 // IS the message: the first run is the expensive one and every run after it is
 // small. That is what makes "as fresh as you schedule it" believable, and it
 // was the clause of the old paragraph most likely to be skipped.
+//
+// The two widths are SCHEMATIC. Nothing measures them and nothing should: the
+// ratio between a first run and an incremental one is a property of the
+// operator's data, not of this page, and a drawn ratio that looked derived
+// would be the drawing lying in the way this panel's own comments warn about.
+// They are painted in one neutral ink for the same reason — the widths carry
+// the whole comparison, and style.css's brand rule is explicit that the warm
+// palette never encodes data.
 function icebergRuns() {
   const row = (label, barClass, note) => [
     el("span", { class: "ice-run-l", text: label }),
@@ -4699,7 +4716,7 @@ function icebergRuns() {
       el("span", { class: "ice-run-n", text: note })),
   ];
   return el("div", { class: "ice-runs" },
-    ...row("First run", "ice-bar-full", "loads the whole snapshot"),
+    ...row("First run", "ice-bar-full", "loads the newest backup"),
     ...row("Every run after", "ice-bar-delta", "adds only what changed"));
 }
 

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -4644,11 +4644,19 @@ function icebergComposeNote(cur) {
     ", set INDEX_DSN and BASELINE_DIR or BASELINE_S3 in the stack's .env file.";
 }
 
-// ICEBERG_ENGINES is the payoff, drawn as the names an analyst already knows
-// rather than claimed in a sentence. Prose, not derived from anything: the
-// export writes standard Iceberg, so this is which readers we say it out loud
-// for, and it is edited by hand when that answer changes.
-const ICEBERG_ENGINES = ["Spark", "Trino", "Athena", "Snowflake", "DuckDB"];
+// The payoff, drawn as the names an analyst already knows rather than claimed
+// in a sentence — and SPLIT, because "read them directly" is true of two of the
+// five. docs/iceberg-export.md says it plainly: "DuckDB and Spark read such a
+// directory directly. Trino, Athena and Snowflake read Iceberg through a
+// catalog, so with them you register the table's current metadata file ...
+// rather than pointing at the path."
+//
+// The old prose said all five read them directly and got away with it as a
+// hedgeable sentence. Rendered as five chips under a heading that IS the claim,
+// it stops being hedgeable. A guard ties both lists to that doc paragraph, so
+// the drawing cannot drift away from what we tell people elsewhere.
+const ICEBERG_ENGINES_DIRECT = ["DuckDB", "Spark"];
+const ICEBERG_ENGINES_CATALOG = ["Trino", "Athena", "Snowflake"];
 
 // ICEBERG_PLACEHOLDERS labels the two blanks in the command instead of
 // describing them in a paragraph under it.
@@ -4675,10 +4683,14 @@ function icebergFlow() {
     el("div", { class: "ice-stage-t", text: title }),
     el("div", { class: "ice-stage-s", text: sub }));
   const arrow = () => el("div", { class: "ice-arrow", text: "\u2192" });
+  const chips = (names) => el("div", { class: "ice-eng" },
+    ...names.map((n) => el("span", { class: "ice-eng-n", text: n })));
   const engines = el("div", { class: "ice-stage" },
-    el("div", { class: "ice-stage-t", text: "Read directly by" }),
-    el("div", { class: "ice-eng" },
-      ...ICEBERG_ENGINES.map((n) => el("span", { class: "ice-eng-n", text: n }))));
+    el("div", { class: "ice-stage-t", text: "Read by" }),
+    el("div", { class: "ice-eng-l", text: "straight off the folder" }),
+    chips(ICEBERG_ENGINES_DIRECT),
+    el("div", { class: "ice-eng-l", text: "through a catalog" }),
+    chips(ICEBERG_ENGINES_CATALOG));
   return el("div", { class: "ice-flow" },
     // "newest backup", not "the whole snapshot": the old paragraph said WHICH
     // backup the first run consumes, and a reader looking at a list of them on
@@ -4732,8 +4744,9 @@ function icebergKeys(cmd) {
 
 // icebergExportPanel: a drawing, the command, and one warning.
 //
-// It used to open with four paragraphs before the command and keep two more
-// after it. Everything that was an EXPLANATION is now either drawn (what it
+// It used to open with two paragraphs before the command and keep three after
+// it, the last of them the compose note. Everything that was an EXPLANATION is
+// now either drawn (what it
 // makes, who reads it, what a run costs) or moved into "How to run it", where
 // a reader who is actually about to run it will look. Only one paragraph stays
 // in the open, and it is the only one that is a HAZARD rather than a

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -2703,3 +2703,24 @@ button { font-family: inherit; }
   background: var(--surface-2); color: var(--ink-3);
 }
 .dk-copy:hover { border-color: var(--accent); color: var(--ink-1); }
+
+/* Iceberg export panel (#1467). The drawing that replaced four paragraphs:
+   three stages left to right, then two bars for what a run costs. Sized so the
+   whole thing is shorter than the prose it stands in for; if it ever grows past
+   that it has stopped being a drawing. */
+.ice-flow { display: flex; align-items: stretch; gap: 10px; flex-wrap: wrap; margin: 2px 0 12px; }
+.ice-stage { flex: 1 1 150px; min-width: 132px; border: 1px solid var(--line); border-radius: 10px; background: var(--surface-2); padding: 9px 11px; }
+.ice-stage-t { font-size: 12.5px; font-weight: 600; color: var(--ink-2); }
+.ice-stage-s { font-size: 11.5px; color: var(--ink-4); margin-top: 3px; }
+.ice-arrow { align-self: center; flex: none; color: var(--ink-4); font-size: 15px; }
+.ice-eng { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 6px; }
+.ice-eng-n { font-size: 11px; color: var(--ink-3); border: 1px solid var(--line-soft); border-radius: 999px; padding: 1px 7px; background: var(--surface); }
+.ice-runs { display: grid; grid-template-columns: auto 1fr; gap: 5px 12px; align-items: center; margin: 0 0 12px; }
+.ice-run-l { font-size: 11.5px; color: var(--ink-3); white-space: nowrap; }
+.ice-run-b { display: flex; align-items: center; gap: 9px; }
+.ice-bar { height: 7px; border-radius: 4px; flex: none; }
+.ice-bar-full { width: 148px; background: linear-gradient(90deg, oklch(0.53 0.2 3), oklch(0.54 0.14 51)); }
+.ice-bar-delta { width: 26px; background: oklch(0.54 0.14 51); }
+.ice-run-n { font-size: 11.5px; color: var(--ink-4); }
+.ice-keys { display: flex; flex-wrap: wrap; gap: 6px 18px; margin: -2px 0 12px; }
+.ice-key { display: flex; align-items: center; gap: 6px; font-size: 11.5px; color: var(--ink-4); }

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -2719,8 +2719,8 @@ button { font-family: inherit; }
 .ice-run-l { font-size: 11.5px; color: var(--ink-3); white-space: nowrap; }
 .ice-run-b { display: flex; align-items: center; gap: 9px; }
 .ice-bar { height: 7px; border-radius: 4px; flex: none; }
-.ice-bar-full { width: 148px; background: linear-gradient(90deg, oklch(0.53 0.2 3), oklch(0.54 0.14 51)); }
-.ice-bar-delta { width: 26px; background: oklch(0.54 0.14 51); }
+.ice-bar-full { width: 148px; background: var(--ink-4); }
+.ice-bar-delta { width: 26px; background: var(--ink-4); }
 .ice-run-n { font-size: 11.5px; color: var(--ink-4); }
 .ice-keys { display: flex; flex-wrap: wrap; gap: 6px 18px; margin: -2px 0 12px; }
 .ice-key { display: flex; align-items: center; gap: 6px; font-size: 11.5px; color: var(--ink-4); }

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -2705,9 +2705,9 @@ button { font-family: inherit; }
 .dk-copy:hover { border-color: var(--accent); color: var(--ink-1); }
 
 /* Iceberg export panel (#1467). The drawing that replaced four paragraphs:
-   three stages left to right, then two bars for what a run costs. Sized so the
-   whole thing is shorter than the prose it stands in for; if it ever grows past
-   that it has stopped being a drawing. */
+   three stages left to right, then two bars for what a run costs. The intent is
+   that it stays shorter than the prose it replaced; nothing measures that, so
+   read it as the reason these sizes are small rather than as a rule. */
 .ice-flow { display: flex; align-items: stretch; gap: 10px; flex-wrap: wrap; margin: 2px 0 12px; }
 .ice-stage { flex: 1 1 150px; min-width: 132px; border: 1px solid var(--line); border-radius: 10px; background: var(--surface-2); padding: 9px 11px; }
 .ice-stage-t { font-size: 12.5px; font-weight: 600; color: var(--ink-2); }
@@ -2724,3 +2724,4 @@ button { font-family: inherit; }
 .ice-run-n { font-size: 11.5px; color: var(--ink-4); }
 .ice-keys { display: flex; flex-wrap: wrap; gap: 6px 18px; margin: -2px 0 12px; }
 .ice-key { display: flex; align-items: center; gap: 6px; font-size: 11.5px; color: var(--ink-4); }
+.ice-eng-l { font-size: 10.5px; color: var(--ink-4); margin-top: 6px; }

--- a/internal/console/assets_iceberg_panel_test.go
+++ b/internal/console/assets_iceberg_panel_test.go
@@ -358,3 +358,103 @@ func TestCIRequiresNodeForTheRenderedCommand(t *testing.T) {
 			"and leave icebergExportCommand with no executing coverage", path, requireNodeEnv)
 	}
 }
+
+// TestIcebergLegendMatchesTheCommandItLabels pins the drawing to its source.
+//
+// The legend under the command is FILTERED by what the command holds
+// (`cmd.includes(k)`), which is right — the password blank is absent for an
+// index that needs none — and which fails OPEN in exactly one way: change the
+// placeholder in icebergExportCommand and every label quietly stops rendering.
+// Nothing on screen looks broken, the panel just goes back to printing an
+// unexplained line, and no assertion in this file would notice.
+//
+// So the guard is not "the keys are consistent with themselves" but "a command
+// that should show BOTH of them does". This is the claudeAskMock discipline:
+// a drawing can be wrong in a way prose cannot, so it is tied to the thing it
+// depicts.
+func TestIcebergLegendMatchesTheCommandItLabels(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		if os.Getenv(requireNodeEnv) != "" {
+			t.Fatalf("%s is set and node is not on PATH: the legend would go unchecked", requireNodeEnv)
+		}
+		t.Skip("node is not installed; the legend is not covered on this machine")
+	}
+	raw, err := os.ReadFile("assets/app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	js := string(raw)
+
+	keys := icebergPlaceholderKeys(t, js)
+	if len(keys) < 2 {
+		t.Fatalf("ICEBERG_PLACEHOLDERS holds %d key(s); the legend exists to label the "+
+			"password and the warehouse path, so this guard covers nothing", len(keys))
+	}
+
+	script := functionBody(t, js, "function shellWord(") + "\n" +
+		functionBody(t, js, "function icebergExportCommand(") + `
+console.log(icebergExportCommand(
+  {host: "db.internal", port: "3307", user: "reader", dbname: "idx", has_password: true},
+  {source: "/data/baselines", kind: "dir"}));
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "legend.js")
+	if err := os.WriteFile(path, []byte(script), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := exec.Command(node, path).Output()
+	if err != nil {
+		t.Fatalf("node: %v", err)
+	}
+	cmd := strings.TrimSpace(string(out))
+
+	for _, k := range keys {
+		if !strings.Contains(cmd, k) {
+			t.Errorf("the legend labels %q, which the command does not contain:\n  %s\n"+
+				"the label is filtered out by cmd.includes(), so it silently stops rendering", k, cmd)
+		}
+	}
+
+	// And the legend is actually reached. Every check above passes on a panel
+	// that never calls it.
+	panel := functionBody(t, js, "function icebergExportPanel(")
+	if !strings.Contains(panel, "icebergKeys(cmd)") {
+		t.Error("the panel never builds the legend, so the command's blanks go unlabelled")
+	}
+	if !strings.Contains(panel, "icebergFlow()") || !strings.Contains(panel, "icebergRuns()") {
+		t.Error("the panel does not draw the flow and the run shapes; without them it is " +
+			"a bare command with no statement of what it produces")
+	}
+}
+
+// icebergPlaceholderKeys reads the first element of each ICEBERG_PLACEHOLDERS
+// pair straight out of app.js, so the test cannot drift from the constant by
+// carrying its own copy.
+func icebergPlaceholderKeys(t *testing.T, js string) []string {
+	t.Helper()
+	const marker = "const ICEBERG_PLACEHOLDERS = ["
+	i := strings.Index(js, marker)
+	if i < 0 {
+		t.Fatal("ICEBERG_PLACEHOLDERS is gone from app.js; the legend has no source to check")
+	}
+	block := js[i+len(marker):]
+	end := strings.Index(block, "];")
+	if end < 0 {
+		t.Fatal("ICEBERG_PLACEHOLDERS is not closed; cannot read its keys")
+	}
+	var keys []string
+	for _, line := range strings.Split(block[:end], "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, `["`) {
+			continue
+		}
+		rest := line[2:]
+		j := strings.Index(rest, `"`)
+		if j < 0 {
+			t.Fatalf("cannot read the key out of %q", line)
+		}
+		keys = append(keys, rest[:j])
+	}
+	return keys
+}

--- a/internal/console/assets_iceberg_panel_test.go
+++ b/internal/console/assets_iceberg_panel_test.go
@@ -444,8 +444,19 @@ func icebergPlaceholderKeys(t *testing.T, js string) []string {
 		t.Fatal("ICEBERG_PLACEHOLDERS is not closed; cannot read its keys")
 	}
 	var keys []string
+	var candidates int
 	for _, line := range strings.Split(block[:end], "\n") {
 		line = strings.TrimSpace(line)
+		// Every entry of the literal opens with a bracket. Counted separately
+		// from the ones this scanner can READ, because a floor ("at least two
+		// keys survived") passes on a THIRD entry written in a shape the
+		// scanner skips — a constant reference, two entries on one line, one
+		// wrapped across two — and that third label would then be exactly the
+		// unguarded fail-open this test exists to close, one entry later.
+		if !strings.HasPrefix(line, "[") {
+			continue
+		}
+		candidates++
 		if !strings.HasPrefix(line, `["`) {
 			continue
 		}
@@ -456,5 +467,65 @@ func icebergPlaceholderKeys(t *testing.T, js string) []string {
 		}
 		keys = append(keys, rest[:j])
 	}
+	if len(keys) != candidates {
+		t.Fatalf("ICEBERG_PLACEHOLDERS holds %d entries but this test could only read %d of them; "+
+			"the ones it skipped go unchecked, which is the silent failure it exists to prevent. "+
+			"Write every entry as [\"key\", \"label\"] on its own line, or teach this scanner the new shape.",
+			candidates, len(keys))
+	}
 	return keys
+}
+
+// TestAppendedPanelCSSPaintsNoBrandWarmth covers a range the brand guard cannot.
+//
+// assets_brandpaint_test.go scans only the marker-delimited #1385 block, so any
+// rule appended at the END of style.css is structurally invisible to it. The
+// rule those tests enforce is stated in style.css itself: the warm palette is
+// worn across the chrome and "never encode[s] data ... pink never lands on a
+// surface that carries a row".
+//
+// The Iceberg run bars are exactly the shape that rule is about: two widths
+// standing for two magnitudes. They are painted in one neutral ink instead, and
+// this keeps them that way.
+func TestAppendedPanelCSSPaintsNoBrandWarmth(t *testing.T) {
+	raw, err := os.ReadFile("assets/style.css")
+	if err != nil {
+		t.Fatal(err)
+	}
+	css := string(raw)
+	const marker = "/* Iceberg export panel (#1467)."
+	i := strings.Index(css, marker)
+	if i < 0 {
+		t.Fatal("the Iceberg panel CSS block is gone from style.css; this guard covers nothing")
+	}
+	block := css[i:]
+	if j := strings.Index(block[len(marker):], "\n/* "); j >= 0 {
+		block = block[:len(marker)+j]
+	}
+	if !strings.Contains(block, ".ice-bar-full") {
+		t.Fatal("the run bars are not in the block this guard reads")
+	}
+	// Declarations only. The block's own comments carry issue numbers, and a
+	// bare "#" scan would match those and fail on prose.
+	var decls strings.Builder
+	for _, line := range strings.Split(block, "\n") {
+		if t := strings.TrimSpace(line); strings.HasPrefix(t, "/*") || strings.HasPrefix(t, "*") ||
+			strings.HasPrefix(t, "//") || t == "" {
+			continue
+		}
+		decls.WriteString(line)
+		decls.WriteString("\n")
+	}
+	body := decls.String()
+	// A raw colour literal is the tell. Every legitimate value here is a token
+	// the console already defines, so a rule that spells a colour out is either
+	// brand warmth or a value that will not follow the palette.
+	for _, lit := range []string{"oklch(", "rgb(", "hsl(", "#0", "#1", "#2", "#3", "#4",
+		"#5", "#6", "#7", "#8", "#9", "#a", "#b", "#c", "#d", "#e", "#f"} {
+		if strings.Contains(strings.ToLower(body), lit) {
+			t.Errorf("the Iceberg panel CSS spells a colour literally (%q). Its run bars encode a "+
+				"magnitude with their WIDTHS, and style.css's own rule is that the warm palette "+
+				"never encodes data; use a var(--ink-*) / var(--line*) / var(--surface*) token.", lit)
+		}
+	}
 }

--- a/internal/console/assets_iceberg_panel_test.go
+++ b/internal/console/assets_iceberg_panel_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -457,6 +458,12 @@ func icebergPlaceholderKeys(t *testing.T, js string) []string {
 			continue
 		}
 		candidates++
+		// More than one entry on a line is the shape a per-line scanner reads
+		// as ONE. Counted here rather than parsed, because the fix is to write
+		// them one per line, not to teach this more grammar.
+		if n := strings.Count(line, `["`); n > 1 {
+			candidates += n - 1
+		}
 		if !strings.HasPrefix(line, `["`) {
 			continue
 		}
@@ -478,8 +485,11 @@ func icebergPlaceholderKeys(t *testing.T, js string) []string {
 
 // TestAppendedPanelCSSPaintsNoBrandWarmth covers a range the brand guard cannot.
 //
-// assets_brandpaint_test.go scans only the marker-delimited #1385 block, so any
-// rule appended at the END of style.css is structurally invisible to it. The
+// The brand-COLOUR guards in assets_brandpaint_test.go read only the
+// marker-delimited #1385 block (brandSection), so a rule appended at the END of
+// style.css is structurally invisible to them. Not every test in that file is
+// so scoped — TestTransparentInkStaysBehindABackgroundClipSupportsTest reads the
+// whole file — but the ones enforcing this rule are. The
 // rule those tests enforce is stated in style.css itself: the warm palette is
 // worn across the chrome and "never encode[s] data ... pink never lands on a
 // surface that carries a row".
@@ -505,21 +515,39 @@ func TestAppendedPanelCSSPaintsNoBrandWarmth(t *testing.T) {
 	if !strings.Contains(block, ".ice-bar-full") {
 		t.Fatal("the run bars are not in the block this guard reads")
 	}
-	// Declarations only. The block's own comments carry issue numbers, and a
-	// bare "#" scan would match those and fail on prose.
+	// Declarations only: the block's own comments carry issue numbers, and a bare
+	// "#" scan would match those and fail on prose. Tracked as a STATE rather
+	// than per-line prefixes, because a /* */ comment's continuation lines start
+	// with ordinary words and a prefix filter keeps them — which is the failure
+	// this filter exists to avoid, one line down.
 	var decls strings.Builder
+	inComment := false
 	for _, line := range strings.Split(block, "\n") {
-		if t := strings.TrimSpace(line); strings.HasPrefix(t, "/*") || strings.HasPrefix(t, "*") ||
-			strings.HasPrefix(t, "//") || t == "" {
+		trimmed := strings.TrimSpace(line)
+		if inComment {
+			if strings.Contains(line, "*/") {
+				inComment = false
+			}
+			continue
+		}
+		if strings.HasPrefix(trimmed, "//") || trimmed == "" {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "/*") {
+			if !strings.Contains(line, "*/") {
+				inComment = true
+			}
 			continue
 		}
 		decls.WriteString(line)
 		decls.WriteString("\n")
 	}
 	body := decls.String()
-	// A raw colour literal is the tell. Every legitimate value here is a token
-	// the console already defines, so a rule that spells a colour out is either
-	// brand warmth or a value that will not follow the palette.
+	// Two checks, because brand warmth reaches a rule two ways and a denylist of
+	// colour LITERALS only closes one of them. style.css:137 defines
+	// --brand-warm as the very pink-to-peach gradient that was removed from the
+	// run bars, so `background: var(--brand-warm)` restores the exact visual
+	// while spelling no colour at all.
 	for _, lit := range []string{"oklch(", "rgb(", "hsl(", "#0", "#1", "#2", "#3", "#4",
 		"#5", "#6", "#7", "#8", "#9", "#a", "#b", "#c", "#d", "#e", "#f"} {
 		if strings.Contains(strings.ToLower(body), lit) {
@@ -528,4 +556,101 @@ func TestAppendedPanelCSSPaintsNoBrandWarmth(t *testing.T) {
 				"never encodes data; use a var(--ink-*) / var(--line*) / var(--surface*) token.", lit)
 		}
 	}
+	// An ALLOWLIST for the tokens, which is what the message above already
+	// tells the author. A denylist of brand names would need updating every
+	// time the palette grows a colour.
+	for _, m := range regexp.MustCompile(`var\(\s*(--[a-z0-9-]+)`).FindAllStringSubmatch(body, -1) {
+		name := m[1]
+		if strings.HasPrefix(name, "--ink") || strings.HasPrefix(name, "--line") ||
+			strings.HasPrefix(name, "--surface") {
+			continue
+		}
+		t.Errorf("the Iceberg panel CSS uses %s. Its run bars encode a magnitude with their "+
+			"WIDTHS, and style.css's own rule is that the warm palette never encodes data; "+
+			"only --ink-* / --line* / --surface* belong here.", name)
+	}
+}
+
+// TestIcebergFlowStatesWhatTheExportActuallyProduces pins the two claims the
+// drawing pass dropped and 3c5a6f2 put back, plus the engine split.
+//
+// Nothing pinned them before: the legend guard checks only that icebergFlow is
+// CALLED, never what it renders, so the same edit that lost them once could
+// lose them again with the suite green. The compose note next door is guarded
+// down to body-vs-fold placement; these are the panel's other two load-bearing
+// claims and they had nothing.
+func TestIcebergFlowStatesWhatTheExportActuallyProduces(t *testing.T) {
+	raw, err := os.ReadFile("assets/app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	js := string(raw)
+	flow := functionBody(t, js, "function icebergFlow(")
+	runs := functionBody(t, js, "function icebergRuns(")
+
+	if !strings.Contains(flow, "newest backup") || !strings.Contains(runs, "newest backup") {
+		t.Error("the panel no longer says WHICH backup the first run loads; a reader looking at " +
+			"a list of them on this very page cannot work that out from \"the whole snapshot\"")
+	}
+	if !strings.Contains(flow, "nowhere else") {
+		t.Error("the panel no longer answers where the tables go. For an EXPORT feature that is " +
+			"the one thing a cautious operator asks while standing here")
+	}
+
+	// The engine split against the paragraph it paraphrases. A drawing can be
+	// wrong in a way prose cannot, and "read them directly" is true of two of
+	// the five.
+	docs, err := os.ReadFile("../../docs/iceberg-export.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := string(docs)
+	direct, catalog := "read such a directory directly", "read Iceberg through a catalog"
+	di, ci := strings.Index(d, direct), strings.Index(d, catalog)
+	if di < 0 || ci < 0 || di >= ci {
+		t.Fatalf("docs/iceberg-export.md no longer carries the two sentences this guard reads "+
+			"(direct at %d, catalog at %d); the engine split has no source to check against", di, ci)
+	}
+	// Windowed, not searched. These names appear all over the document, so a
+	// plain Index finds an unrelated earlier mention and grades every engine
+	// against the wrong sentence.
+	dEnd := di + len(direct)
+	dStart := strings.LastIndex(d[:di], ".") + 1
+	directSentence, catalogSentence := d[dStart:dEnd], d[dEnd:ci+len(catalog)]
+	for _, name := range icebergEngineNames(t, js, "ICEBERG_ENGINES_DIRECT") {
+		if !strings.Contains(directSentence, name) {
+			t.Errorf("the panel says %s reads the folder straight off, but the docs sentence that "+
+				"says so does not name it:\n  %s", name, strings.TrimSpace(directSentence))
+		}
+	}
+	for _, name := range icebergEngineNames(t, js, "ICEBERG_ENGINES_CATALOG") {
+		if !strings.Contains(catalogSentence, name) {
+			t.Errorf("the panel says %s reads through a catalog, but the docs sentence that says "+
+				"so does not name it:\n  %s", name, strings.TrimSpace(catalogSentence))
+		}
+	}
+}
+
+func icebergEngineNames(t *testing.T, js, constName string) []string {
+	t.Helper()
+	marker := "const " + constName + " = ["
+	i := strings.Index(js, marker)
+	if i < 0 {
+		t.Fatalf("%s is gone from app.js; the engine split has nothing to check", constName)
+	}
+	rest := js[i+len(marker):]
+	end := strings.Index(rest, "]")
+	if end < 0 {
+		t.Fatalf("%s is not closed", constName)
+	}
+	var out []string
+	for _, part := range strings.Split(rest[:end], ",") {
+		if v := strings.Trim(strings.TrimSpace(part), `"`); v != "" {
+			out = append(out, v)
+		}
+	}
+	if len(out) == 0 {
+		t.Fatalf("%s is empty; this guard covers nothing", constName)
+	}
+	return out
 }


### PR DESCRIPTION
## Before

Four paragraphs before the command, two more after it. Six blocks of prose on a
settings page is a wall, and a wall gets skipped, so the reader arrives at the
command having read none of it.

## After

Everything that was a **description** is drawn:

- What the export makes and who reads it: three stages left to right, ending in
  the engine names an analyst already recognises.
- The incremental behaviour: two bars. The shape is the message — the first run
  is the expensive one, every run after it is small, which is what makes "as
  fresh as you schedule it" believable rather than asserted.
- The two blanks in the command: labelled under it, next to the line they refer
  to, instead of described in a sentence below.

Everything that was a **justification** moved into "How to run it", where a
reader who is about to run the line will look: why this is a command and not a
button, and which connection settings the line does not carry.

One paragraph stays in the open, and it is the only one that is a **hazard**
rather than a description: for a server that is not the stack's own, the Docker
route exports a different dataset and succeeds while doing it.

## The guard

The legend renders only the placeholders the rendered command actually holds.
That is right — the password blank is absent for an index that needs none — and
it fails open in exactly one way: change the placeholder in
`icebergExportCommand` and every label quietly stops rendering, with nothing on
screen looking broken and no existing assertion noticing.

So `TestIcebergLegendMatchesTheCommandItLabels` executes the real renderer and
asserts that a command which should show BOTH labels does. It reads the keys out
of `ICEBERG_PLACEHOLDERS` in `app.js` rather than carrying its own copy. Same
discipline `claudeAskMock` carries against the bundle manifest: a drawing can be
wrong in a way prose cannot.

## Test plan

- [x] `go test ./internal/console/`
- [x] Rendered in a real browser and looked at, not just built
- [x] Mutations, each red: the command's placeholder changed (labels would
      silently vanish), and the panel no longer drawing the flow
- [x] The existing panel guards still hold, including that the compose note
      stays OUT of the collapsed block
