### PR TITLE
console: list every backup location, not just the local directory

### DIFF
--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -5581,10 +5581,17 @@ function backupElsewhereNote(b, usable) {
 function backupSQLExportCard(cur, b, sqlSt) {
   if (!capsCache.sql_export || !cur || !cur.id || cur.kind !== "registry") return null;
   if (!b || b.error || !b.configured) return null;
-  // Whichever location the build will read: the server's own directory when it
-  // has one, the bucket otherwise. The comment above is right that an S3-backed
-  // server qualifies; it is a server with BOTH that needed narrowing.
-  const usable = backupSnapshotsFor(b, cur.baseline_dir ? "dir" : "s3");
+  // b.kind, NOT cur.baseline_dir. cur is the RAW registry entry; the export
+  // resolves through withBaselineDefaults (#1010), so an entry that inherits
+  // the daemon-wide backup location has an empty baseline_dir and still builds
+  // from a directory. b.kind comes off the bundle, which applies the same
+  // defaulting and the same dir-over-S3 preference the export does, so it is
+  // exactly "the build will read a directory".
+  //
+  // Borrowing the restore card's gate was the mistake: cur.baseline_dir is
+  // right THERE, because the restore endpoint refuses the shared daemon store
+  // on purpose (the fold would mix servers). This one accepts it, and says so.
+  const usable = backupSnapshotsFor(b, b.kind === "dir" ? "dir" : "s3");
   if (!usable.length) return null;
   const st = sqlSt && sqlSt.sql_export;
   if (st && st.state === "running") return null; // the run region owns it
@@ -5601,7 +5608,7 @@ function backupSQLExportCard(cur, b, sqlSt) {
   msg.hidden = true;
   go.onclick = () => startSQLExport(cur.id, input.value.trim(), go, msg);
   body.append(el("div", { class: "bk-restore-row" }, input, go), msg);
-  if (cur.baseline_dir) {
+  if (b.kind === "dir") {
     const elsewhere = backupElsewhereNote(b, usable);
     if (elsewhere) body.append(elsewhere);
   }

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -4551,7 +4551,16 @@ function baselineContextStrip(b, cur) {
   const snaps = b.snapshots || [];
   // The source path is code, and it gets the width to render as one line —
   // the dark code-ink treatment the recipe reserves for SQL/DSNs/paths.
-  strip.append(item("SOURCE", el("code", { class: "code-ink ctx-source", text: b.source }), "ctx-grow"));
+  // With two locations the strip names them BOTH. Printing only the primary
+  // is what made an S3-backed server look empty: the path on screen was the
+  // local directory, and the bucket holding the snapshots was never mentioned.
+  const srcs = b.sources || [];
+  if (srcs.length > 1) {
+    strip.append(item("SOURCES", el("div", { class: "ctx-srcs" },
+      ...srcs.map((s) => el("code", { class: "code-ink ctx-source", text: s.source }))), "ctx-grow"));
+  } else {
+    strip.append(item("SOURCE", el("code", { class: "code-ink ctx-source", text: b.source }), "ctx-grow"));
+  }
   strip.append(item("BACKUPS", String(snaps.length) + (b.truncated ? "+" : "")));
   if (snaps.length) {
     // One fact, one place: absolute and relative side by side, instead of the
@@ -4813,6 +4822,61 @@ function icebergExportPanel(cur, baselines) {
   return panel;
 }
 
+// backupSourceList renders every location the listing read, which is more than
+// one whenever a server has a local directory AND an S3 destination (#1542).
+// The bucket is the bundle's per-table fallback, so it always held snapshots the
+// page could resolve through Time-travel and never showed.
+function backupSourceList(b) {
+  const srcs = (b && b.sources) || [];
+  if (srcs.length < 2) return el("code", { class: "stg-code", text: (b && b.source) || "" });
+  return el("div", { class: "bk-srcs" }, ...srcs.map((s) => el("div", { class: "bk-src" },
+    el("span", { class: "bk-src-k", text: backupKindWord(s.kind) }),
+    el("code", { class: "stg-code", text: s.source }),
+    s.error
+      ? el("span", { class: "chip chip-mon", text: "unreadable" })
+      : el("span", { class: "bk-src-n", text: s.count + " file(s)" }))));
+}
+
+function backupKindWord(kind) { return kind === "s3" ? "S3" : "disk"; }
+
+// firstLine trims a backend error to its opening line. An S3 listing failure
+// arrives as a DuckDB error carrying the whole generated SQL statement across
+// several lines; pasted into the page it is a wall, and the wall is what a
+// reader skips. The first line is the cause ("HTTP 404", "AccessDenied"); the
+// server keeps the rest.
+function firstLine(msg) {
+  const s = String(msg || "").split("\n")[0].trim();
+  return s.length > 180 ? s.slice(0, 177) + "\u2026" : s;
+}
+
+// backupWhereChip says which of the two locations a snapshot was found in.
+// Rendered only when there IS more than one, since a chip repeating the single
+// configured source on every row is noise, not information.
+function backupWhereChip(b, sn) {
+  const srcs = (b && b.sources) || [];
+  if (srcs.length < 2) return null;
+  const kinds = (sn && sn.kinds) || [];
+  if (!kinds.length) return null;
+  return el("span", { class: "bk-where", text: kinds.map(backupKindWord).join(" + ") });
+}
+
+// backupIncompleteNotice is a HAZARD, not a status line: the list under it is a
+// subset, and the failure this endpoint had was a short list read as the whole
+// set. Named per location, because "one of your sources failed" sends the
+// operator to check both.
+function backupIncompleteNotice(b) {
+  if (!b || !b.incomplete) return null;
+  const bad = ((b.sources) || []).filter((s) => s.error);
+  const box = el("div", { class: "error-box" },
+    el("div", { text: "Some backups are not listed: " + bad.length +
+      " of " + ((b.sources) || []).length + " locations could not be read." }));
+  bad.forEach((s) => box.append(el("div", { class: "bk-src" },
+    el("span", { class: "bk-src-k", text: backupKindWord(s.kind) }),
+    el("code", { class: "stg-code", text: s.source }),
+    el("span", { class: "bk-src-n", text: firstLine(s.error) }))));
+  return box;
+}
+
 function baselinesPanel(b, servers, opts) {
   // Full-width (#1415): this list is the page. The Create-baseline action
   // moved to the context strip — at page level it is a page action; inside
@@ -4848,14 +4912,20 @@ function baselinesPanel(b, servers, opts) {
       el("code", { class: "stg-code", text: "docker compose --profile baseline run --rm baseline" }),
       el("p", { class: "stg-empty-sub", text: "2. " + baselineConfigHint(cur, opts && opts.serversErr) })));
   } else if (!(b.snapshots || []).length) {
+    // A source that failed reaches HERE too, and "no backups found" would be a
+    // flat lie about a bucket nobody could read.
+    const emptyWarn = backupIncompleteNotice(b);
+    if (emptyWarn) list.append(emptyWarn);
     list.append(el("div", { class: "stg-empty" },
       el("p", { class: "stg-empty-lead", text: "Source configured, no backups found." }),
-      el("code", { class: "stg-code", text: b.source }),
+      backupSourceList(b),
       el("p", { class: "stg-empty-sub", text: "Run bintrail dump and bintrail baseline to create your first backup. The path must point at the folder that contains the backups, not a specific file (<timestamp>/<schema>/<table>.parquet)." })));
   } else {
     // Panel headline: the newest-per-table rollup. Older snapshots being past
     // coverage is routine (superseded) — only the headline and the newest
     // row's verdict are actionable, so only those get a chip.
+    const incomplete = backupIncompleteNotice(b);
+    if (incomplete) list.append(incomplete);
     if (b.staleness && b.staleness !== "ok") {
       list.append(el("div", { class: "vfy-summary" },
         el("span", { class: "chip chip-mon", text: b.staleness === "broken"
@@ -4881,6 +4951,8 @@ function baselinesPanel(b, servers, opts) {
         row.append(el("span", { class: "chip chip-mon", text:
           sn.staleness === "broken" ? "⚠ STALE: restore broken" : sn.staleness.toUpperCase() }));
       }
+      const where = backupWhereChip(b, sn);
+      if (where) row.append(where);
       // Click to expand: tables, sizes and how long the backup took. Loaded
       // once per row, on first open.
       const detail = el("div", { class: "bk-detail" });

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -5487,7 +5487,10 @@ function backupRestoreCard(cur, b, restoreSt) {
   // shared store the endpoint refuses (the fold would mix servers).
   if (!cur.baseline_dir) return null;
   if (!b || b.error || !b.configured || b.kind !== "dir") return null;
-  if (!(b.snapshots || []).length) return null;
+  // The LOCAL ones: the card is already gated on the server having its own
+  // baseline_dir, so that is the directory executeRestore will read.
+  const usable = backupSnapshotsFor(b, "dir");
+  if (!usable.length) return null;
   const rst = restoreSt && restoreSt.restore;
   if (rst && rst.state === "running") return null; // the run region owns it
   const details = el("details", { class: "form-advanced bk-restore" },
@@ -5497,12 +5500,14 @@ function backupRestoreCard(cur, b, restoreSt) {
     "Pick a past moment. The console rebuilds every table as it was then, from your backups plus the recorded changes, and saves the result as a new backup in the list below. Your database is not touched." }));
   const input = el("input", { class: "in", type: "text", spellcheck: "false",
     placeholder: "YYYY-MM-DD HH:MM:SS (UTC)" });
-  input.value = (b.snapshots[0] && b.snapshots[0].time) || "";
+  input.value = (usable[0] && usable[0].time) || "";
   const go = el("button", { class: "btn", type: "button", text: "Restore" });
   const msg = el("p", { class: "form-msg err" });
   msg.hidden = true;
   go.onclick = () => startBackupRestore(cur.id, input.value.trim(), go, msg);
   body.append(el("div", { class: "bk-restore-row" }, input, go), msg);
+  const elsewhere = backupElsewhereNote(b, usable);
+  if (elsewhere) body.append(elsewhere);
   if (rst && rst.state === "failed") {
     body.append(el("p", { class: "form-msg err", text:
       "Last restore published nothing: " + backupFoldError(rst.last_error || "unknown error") + " Nothing was overwritten." }));
@@ -5546,10 +5551,41 @@ async function startBackupRestore(id, at, btn, msgEl) {
 // both mean the same thing to the operator: the file is gone, build again.
 // S3-backed backups qualify too (the fold engine reads them directly), which
 // is why this card has no b.kind === "dir" gate.
+// backupSnapshotsFor narrows the listing to the snapshots a JOB can actually
+// fold from (#1542).
+//
+// The Backups list now merges every location, but the restore and .sql-export
+// jobs still read ONE: executeRestore calls SnapshotTablesAt(req.BaselineDir),
+// and the export picks the local directory whenever the server has one. So a
+// card prefilled with the newest row can now name a snapshot that exists only
+// in the bucket, and the job would refuse it while the page above says it is
+// right there. Listing more must not mean offering more than the job can do.
+//
+// The full answer is folding from S3 (#1541); until then the cards offer what
+// works and say what they left out.
+function backupSnapshotsFor(b, kind) {
+  return ((b && b.snapshots) || []).filter((s) => !s.kinds || !s.kinds.length || s.kinds.includes(kind));
+}
+
+// backupElsewhereNote names the snapshots a card had to skip, so a shorter
+// dropdown than the list above it is explained rather than merely odd.
+function backupElsewhereNote(b, usable) {
+  const all = ((b && b.snapshots) || []).length;
+  if (!all || usable.length >= all) return null;
+  const n = all - usable.length;
+  return el("p", { class: "form-hint", text:
+    n + " backup" + (n === 1 ? " is" : "s are") + " kept only in S3. This builds from the local folder, so it cannot start from " +
+    (n === 1 ? "that one" : "those") + " yet." });
+}
+
 function backupSQLExportCard(cur, b, sqlSt) {
   if (!capsCache.sql_export || !cur || !cur.id || cur.kind !== "registry") return null;
   if (!b || b.error || !b.configured) return null;
-  if (!(b.snapshots || []).length) return null;
+  // Whichever location the build will read: the server's own directory when it
+  // has one, the bucket otherwise. The comment above is right that an S3-backed
+  // server qualifies; it is a server with BOTH that needed narrowing.
+  const usable = backupSnapshotsFor(b, cur.baseline_dir ? "dir" : "s3");
+  if (!usable.length) return null;
   const st = sqlSt && sqlSt.sql_export;
   if (st && st.state === "running") return null; // the run region owns it
   const details = el("details", { class: "form-advanced bk-restore" },
@@ -5559,12 +5595,16 @@ function backupSQLExportCard(cur, b, sqlSt) {
     "Pick a past moment. The console takes the backup from just before it, replays the recorded changes up to it, and packages the result as plain SQL files (mydumper format), ready for myloader. Restoring needs nothing from dbtrail. Your database is not touched." }));
   const input = el("input", { class: "in", type: "text", spellcheck: "false",
     placeholder: "YYYY-MM-DD HH:MM:SS (UTC)" });
-  input.value = (b.snapshots[0] && b.snapshots[0].time) || "";
+  input.value = (usable[0] && usable[0].time) || "";
   const go = el("button", { class: "btn", type: "button", text: "Build" });
   const msg = el("p", { class: "form-msg err" });
   msg.hidden = true;
   go.onclick = () => startSQLExport(cur.id, input.value.trim(), go, msg);
   body.append(el("div", { class: "bk-restore-row" }, input, go), msg);
+  if (cur.baseline_dir) {
+    const elsewhere = backupElsewhereNote(b, usable);
+    if (elsewhere) body.append(elsewhere);
+  }
   if (st && st.state === "failed") {
     body.append(el("p", { class: "form-msg err", text:
       "Last build failed: " + backupFoldError(st.last_error || "unknown error") + " Nothing was built." }));

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -2725,3 +2725,11 @@ button { font-family: inherit; }
 .ice-keys { display: flex; flex-wrap: wrap; gap: 6px 18px; margin: -2px 0 12px; }
 .ice-key { display: flex; align-items: center; gap: 6px; font-size: 11.5px; color: var(--ink-4); }
 .ice-eng-l { font-size: 10.5px; color: var(--ink-4); margin-top: 6px; }
+/* Backups: the locations a listing read (#1542). Two of them whenever a server
+   keeps a local directory and an S3 destination. */
+.bk-srcs { display: grid; gap: 4px; margin: 4px 0; }
+.bk-src { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.bk-src-k { font-size: 10.5px; font-weight: 700; letter-spacing: 0.04em; color: var(--ink-4); min-width: 30px; }
+.bk-src-n { font-size: 11.5px; color: var(--ink-4); }
+.bk-where { font-size: 10.5px; color: var(--ink-4); border: 1px solid var(--line-soft); border-radius: 999px; padding: 1px 8px; white-space: nowrap; }
+.ctx-srcs { display: grid; gap: 2px; min-width: 0; }

--- a/internal/console/assets_backup_sources_test.go
+++ b/internal/console/assets_backup_sources_test.go
@@ -1,0 +1,59 @@
+package console
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestBackupsPanelRendersEveryLocation guards the UI half of #1542.
+//
+// The endpoint can report two locations and an incomplete listing perfectly and
+// the page can still show what it always showed: one path, and a list of
+// snapshots with nothing saying it is a subset. That is the same bug one layer
+// up, and it is invisible to every Go test in this package.
+func TestBackupsPanelRendersEveryLocation(t *testing.T) {
+	raw, err := os.ReadFile("assets/app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	js := string(raw)
+	panel := functionBody(t, js, "function baselinesPanel(")
+
+	if !strings.Contains(panel, "backupIncompleteNotice(b)") {
+		t.Error("the panel never renders the incomplete notice, so a listing missing a whole " +
+			"unreadable location renders as if it were the complete set")
+	}
+	// Both branches: a source can fail with snapshots present AND with none, and
+	// the empty branch is the one where "no backups found" is most misleading.
+	if strings.Count(panel, "backupIncompleteNotice(b)") < 2 {
+		t.Error("the incomplete notice is rendered on only one branch; a failed location that " +
+			"leaves the list EMPTY renders as a flat \"no backups found\"")
+	}
+	if !strings.Contains(panel, "backupSourceList(b)") {
+		t.Error("the empty state prints a single source path; with two locations configured it names " +
+			"only one of the places that came back empty")
+	}
+
+	strip := functionBody(t, js, "function baselineContextStrip(")
+	if !strings.Contains(strip, "b.sources") {
+		t.Error("the context strip prints only the primary source; on a server with a local " +
+			"directory and a bucket, the bucket holding the snapshots is never named")
+	}
+
+	notice := functionBody(t, js, "function backupIncompleteNotice(")
+	if !strings.Contains(notice, "s.error") {
+		t.Error("the notice does not print the per-location error, so the operator is told " +
+			"something failed but not what or where")
+	}
+	if !strings.Contains(notice, "error-box") {
+		t.Error("the notice is not rendered as an error; the list under it is a SUBSET and a " +
+			"quiet hint gets read past")
+	}
+
+	where := functionBody(t, js, "function backupWhereChip(")
+	if !strings.Contains(where, "srcs.length < 2") {
+		t.Error("the per-row location chip is not gated on there being more than one location; " +
+			"repeating the single configured source on every row is noise")
+	}
+}

--- a/internal/console/assets_backup_sources_test.go
+++ b/internal/console/assets_backup_sources_test.go
@@ -1,7 +1,10 @@
 package console
 
 import (
+	"encoding/json"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -24,11 +27,25 @@ func TestBackupsPanelRendersEveryLocation(t *testing.T) {
 		t.Error("the panel never renders the incomplete notice, so a listing missing a whole " +
 			"unreadable location renders as if it were the complete set")
 	}
-	// Both branches: a source can fail with snapshots present AND with none, and
-	// the empty branch is the one where "no backups found" is most misleading.
-	if strings.Count(panel, "backupIncompleteNotice(b)") < 2 {
-		t.Error("the incomplete notice is rendered on only one branch; a failed location that " +
-			"leaves the list EMPTY renders as a flat \"no backups found\"")
+	// Both branches, checked by SPLITTING the function rather than counting.
+	// A count of two passes on two calls sitting anywhere, including both on the
+	// same branch — which is the thing it claims to rule out.
+	emptyHalf, populatedHalf, split := strings.Cut(panel, `} else if (!(b.snapshots || []).length) {`)
+	if !split {
+		t.Fatal("baselinesPanel no longer has the empty-list branch this guard reads")
+	}
+	_ = emptyHalf
+	populatedBranch, _, ok := strings.Cut(populatedHalf, "\n  } else {")
+	if !ok {
+		t.Fatal("baselinesPanel no longer has the populated branch this guard reads")
+	}
+	if !strings.Contains(populatedBranch, "backupIncompleteNotice(b)") {
+		t.Error("the empty-list branch does not render the incomplete notice; a failed location " +
+			"that leaves the list EMPTY renders as a flat \"no backups found\"")
+	}
+	if !strings.Contains(strings.TrimPrefix(populatedHalf, populatedBranch), "backupIncompleteNotice(b)") {
+		t.Error("the populated branch does not render the incomplete notice; a shorter list " +
+			"renders as if it were the whole set")
 	}
 	if !strings.Contains(panel, "backupSourceList(b)") {
 		t.Error("the empty state prints a single source path; with two locations configured it names " +
@@ -56,4 +73,131 @@ func TestBackupsPanelRendersEveryLocation(t *testing.T) {
 		t.Error("the per-row location chip is not gated on there being more than one location; " +
 			"repeating the single configured source on every row is noise")
 	}
+}
+
+// TestBackupJobCardsOfferOnlyWhatTheirJobCanRead pins the gate that decides a
+// card's default (#1542).
+//
+// The listing merges every location; the restore and .sql-export jobs each read
+// ONE. A card defaulting to the merged newest can therefore name a snapshot its
+// own job will refuse, while the page above says it is right there — the very
+// failure the merge was supposed to end, one layer down.
+//
+// The field matters and it is easy to get wrong: `cur` is the RAW registry
+// entry, while both jobs resolve through withBaselineDefaults, so a server that
+// inherits the daemon-wide backup location has an empty cur.baseline_dir and
+// still builds from a directory. b.kind comes off the bundle, which applies the
+// same defaulting and the same dir-over-S3 preference the export does.
+//
+// The restore card is the exception and stays on cur.baseline_dir on purpose:
+// its endpoint REFUSES the shared daemon store, because that fold would mix
+// servers. Same field, opposite meanings.
+func TestBackupJobCardsOfferOnlyWhatTheirJobCanRead(t *testing.T) {
+	raw, err := os.ReadFile("assets/app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	js := string(raw)
+
+	// Comments stripped first. This function's own comment explains why
+	// cur.baseline_dir is the wrong field here, and a raw substring check reads
+	// that explanation as the mistake it warns about.
+	exportCard := stripJSLineComments(functionBody(t, js, "function backupSQLExportCard("))
+	if strings.Contains(exportCard, "cur.baseline_dir") {
+		t.Error("the .sql-export card gates on cur.baseline_dir, which is the RAW registry entry. " +
+			"A server inheriting the daemon-wide backup location has none, so the card either " +
+			"vanishes or defaults to a snapshot the build cannot read")
+	}
+	if !strings.Contains(exportCard, `backupSnapshotsFor(b, b.kind === "dir" ? "dir" : "s3")`) {
+		t.Error("the .sql-export card does not choose its default from the location the build " +
+			"will actually read")
+	}
+
+	restoreCard := stripJSLineComments(functionBody(t, js, "function backupRestoreCard("))
+	if !strings.Contains(restoreCard, "!cur.baseline_dir") {
+		t.Error("the restore card no longer requires the server's OWN directory; its endpoint " +
+			"refuses the shared daemon store, so the card must not offer it")
+	}
+	if !strings.Contains(restoreCard, `backupSnapshotsFor(b, "dir")`) {
+		t.Error("the restore card does not narrow to the snapshots its fold can read")
+	}
+
+	for _, fn := range []string{"function backupSQLExportCard(", "function backupRestoreCard("} {
+		if strings.Contains(stripJSLineComments(functionBody(t, js, fn)), "b.snapshots[0]") {
+			t.Errorf("%s still defaults to the merged newest snapshot, which its job may not be "+
+				"able to read", fn)
+		}
+	}
+}
+
+// backupSnapshotsFor is pure, so it is EXECUTED rather than matched: the three
+// server shapes are where the gate went wrong, and a source assertion cannot
+// tell which snapshot each one lands on.
+func TestBackupSnapshotsFor_perServerShape(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		if os.Getenv(requireNodeEnv) != "" {
+			t.Fatalf("%s is set and node is not on PATH", requireNodeEnv)
+		}
+		t.Skip("node is not installed")
+	}
+	raw, err := os.ReadFile("assets/app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := functionBody(t, string(raw), "function backupSnapshotsFor(") + `
+const snaps = [
+  {time: "2026-06-10", kinds: ["s3"]},
+  {time: "2026-06-03", kinds: ["dir", "s3"]},
+  {time: "2026-05-27", kinds: ["dir"]},
+];
+const pick = (kind) => { const u = backupSnapshotsFor({snapshots: snaps}, kind); return u.length ? u[0].time : null; };
+console.log(JSON.stringify({dir: pick("dir"), s3: pick("s3"),
+  none: backupSnapshotsFor({snapshots: [{time: "x"}]}, "dir").length}));
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gate.js")
+	if err := os.WriteFile(path, []byte(script), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := exec.Command(node, path).Output()
+	if err != nil {
+		t.Fatalf("node: %v", err)
+	}
+	var got struct {
+		Dir  string `json:"dir"`
+		S3   string `json:"s3"`
+		None int    `json:"none"`
+	}
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("decode %q: %v", out, err)
+	}
+	// The newest LOCAL one, not the newest overall: the newest is S3-only and a
+	// dir-reading job would refuse it.
+	if got.Dir != "2026-06-03" {
+		t.Errorf("a dir-reading job defaults to %q, want 2026-06-03 (the newest one on disk)", got.Dir)
+	}
+	if got.S3 != "2026-06-10" {
+		t.Errorf("an S3-reading job defaults to %q, want 2026-06-10", got.S3)
+	}
+	// A snapshot with no kinds is usable for anything: that is the pre-merge
+	// behaviour, and the conservative default for a response shape that predates
+	// the field.
+	if got.None != 1 {
+		t.Errorf("a snapshot carrying no kinds was filtered out (%d left); it must stay usable", got.None)
+	}
+}
+
+// stripJSLineComments drops // lines so a guard reads CODE, not the comment
+// explaining the trap it checks for.
+func stripJSLineComments(body string) string {
+	var b strings.Builder
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "//") {
+			continue
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	return b.String()
 }

--- a/internal/console/backup_schedule_test.go
+++ b/internal/console/backup_schedule_test.go
@@ -383,8 +383,6 @@ func TestChooseBackupMethod_unreadableDirIsNotNoBackup(t *testing.T) {
 	}
 }
 
-
-
 // Same verdict for a path that is a FILE (ENOTDIR): this one runs as root
 // too, where a mode-000 directory reads fine and the test above skips.
 func TestChooseBackupMethod_fileAsDirIsNotNoBackup(t *testing.T) {

--- a/internal/console/baselines_api.go
+++ b/internal/console/baselines_api.go
@@ -34,6 +34,11 @@ type baselineSnapshotDTO struct {
 	// ok | aging | broken | unknown. "unknown" when the coverage floor could
 	// not be read — never reported as ok.
 	Staleness string `json:"staleness,omitempty"`
+	// Kinds names every location this snapshot was found in, sorted: "dir",
+	// "s3", or both (#1542). The union over the snapshot's files, which is
+	// exactly what it claims and no more — a snapshot listing both was seen in
+	// both places, not necessarily with every table in each.
+	Kinds []string `json:"kinds,omitempty"`
 }
 
 type baselinesResponse struct {
@@ -41,9 +46,20 @@ type baselinesResponse struct {
 	// all (dir or s3). Reconstruct additionally requires archives enabled and
 	// no RBAC profile (the bundle's gate) — a server can list baselines that
 	// Time-travel still refuses to use.
-	Configured  bool                  `json:"configured"`
-	Source      string                `json:"source,omitempty"`
-	Kind        string                `json:"kind,omitempty"` // "dir" | "s3"
+	Configured bool   `json:"configured"`
+	Source     string `json:"source,omitempty"`
+	Kind       string `json:"kind,omitempty"` // "dir" | "s3"
+	// Sources reports EVERY location that was read, in consult order, with a
+	// per-location count and error (#1542). Source/Kind above still name the
+	// primary; they were the whole answer when the listing only ever read one
+	// place, and a server with a local directory and an S3 destination has two.
+	Sources []baselineSourceDTO `json:"sources,omitempty"`
+	// Incomplete says at least one configured location could not be read, so
+	// the snapshots below are a SUBSET. The listing is still served, because a
+	// briefly unreachable bucket must not blank a page whose local half works,
+	// but a shorter list rendered as if it were the whole set is the exact bug
+	// this endpoint had.
+	Incomplete  bool                  `json:"incomplete,omitempty"`
 	Reconstruct bool                  `json:"reconstruct"`
 	Snapshots   []baselineSnapshotDTO `json:"snapshots"`
 	Truncated   bool                  `json:"truncated,omitempty"`
@@ -125,14 +141,26 @@ func (s *Server) handleBaselines(w http.ResponseWriter, r *http.Request) {
 		resp.Kind = "s3"
 	}
 
-	files, err := reconstruct.ListBaselines(r.Context(), b.baselineSrc)
-	if err != nil {
-		// The source is configured but unreadable (missing dir, unreachable
-		// bucket) — an upstream fault from the console's point of view, and an
-		// actionable message for the operator.
-		writeJSONError(w, http.StatusBadGateway, "list baselines: "+err.Error())
+	// Every configured location, not just the primary (#1542). A server with a
+	// local directory AND an S3 destination keeps the bucket as the bundle's
+	// per-table fallback, which findBaseline consults and this listing did not:
+	// once retention pruned the local copies, the page showed nothing while the
+	// bucket held dozens, and Time-travel resolved tables from a bucket the page
+	// behind it did not list.
+	merged := listBaselinesMerged(r.Context(), baselineSourcesOf(b), reconstruct.ListBaselines)
+	resp.Sources = merged.Sources
+	if merged.Listed == 0 {
+		// Nothing could be read anywhere. Still a hard failure, and the message
+		// names every location so the operator is not left guessing which one.
+		var parts []string
+		for _, src := range merged.Sources {
+			parts = append(parts, src.Source+": "+src.Error)
+		}
+		writeJSONError(w, http.StatusBadGateway, "list baselines: "+strings.Join(parts, "; "))
 		return
 	}
+	resp.Incomplete = merged.Listed < len(merged.Sources)
+	files := merged.Files
 
 	now := time.Now().UTC()
 	// Staleness floor (#1193): best-effort but never silent and never a
@@ -161,7 +189,12 @@ func (s *Server) handleBaselines(w http.ResponseWriter, r *http.Request) {
 				AgeHours: now.Sub(f.SnapshotTime).Hours(),
 			}
 			dto.Staleness = string(floor.Grade(f.SnapshotTime, now))
-			if resp.Kind == "dir" {
+			dto.Kinds = merged.Kinds[f.SnapshotTime.UnixNano()]
+			// Keyed on the file's OWN path, not on the primary source's kind:
+			// with two locations merged, the primary being S3 says nothing about
+			// whether THIS snapshot came off local disk, and the reverse would
+			// try to open an s3:// URL as a file.
+			if baselineKindOf(f.Path) == "dir" {
 				if meta, err := baseline.ReadParquetMetadata(f.Path); err == nil {
 					dto.BinlogFile = meta.BinlogFile
 					dto.BinlogPos = meta.BinlogPos

--- a/internal/console/baselines_detail.go
+++ b/internal/console/baselines_detail.go
@@ -223,22 +223,43 @@ func (s *Server) resolveSnapshotRequest(w http.ResponseWriter, r *http.Request, 
 			"at must be a snapshot time as the listing returned it (YYYY-MM-DD HH:MM:SS, UTC)")
 		return nil, "", nil
 	}
-	ss, err := openSnapshotSource(r.Context(), b.baselineSrc)
-	if err != nil {
-		writeJSONError(w, http.StatusBadGateway, "open backup storage: "+err.Error())
-		return nil, "", nil
-	}
 	dirName := reconstruct.SnapshotDirName(ts)
-	files, err := ss.files(r.Context(), dirName)
-	if errors.Is(err, fs.ErrNotExist) {
-		writeJSONError(w, http.StatusNotFound, "no backup found at "+ts.Format(consoleTSFormat))
+	// Every configured location, in the same order the listing consults them
+	// (#1542). Before the listing merged them this could only ever be asked
+	// about a snapshot the primary held, because no other row existed. Now that
+	// an S3-only snapshot has a row, opening the primary alone would answer
+	// "no backup found" for a row the same page just said is there — and the
+	// download button, which is built inside the success path, would never
+	// appear for exactly the snapshots #1542 exists to reveal.
+	//
+	// The same fallback bundle.findBaseline already performs, for the same
+	// reason: local retention prunes while the durable copy remains.
+	var firstErr error
+	for _, src := range baselineSourcesOf(b) {
+		ss, err := openSnapshotSource(r.Context(), src)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("open backup storage: %w", err)
+			}
+			continue
+		}
+		files, err := ss.files(r.Context(), dirName)
+		if err == nil {
+			return ss, dirName, files
+		}
+		// Not-found is not an error yet: a later location may hold it. Anything
+		// else IS reported, but only after every location has been tried, so an
+		// unreachable bucket cannot hide a snapshot sitting on local disk.
+		if !errors.Is(err, fs.ErrNotExist) && firstErr == nil {
+			firstErr = fmt.Errorf("list backup files: %w", err)
+		}
+	}
+	if firstErr != nil {
+		writeJSONError(w, http.StatusBadGateway, firstErr.Error())
 		return nil, "", nil
 	}
-	if err != nil {
-		writeJSONError(w, http.StatusBadGateway, "list backup files: "+err.Error())
-		return nil, "", nil
-	}
-	return ss, dirName, files
+	writeJSONError(w, http.StatusNotFound, "no backup found at "+ts.Format(consoleTSFormat))
+	return nil, "", nil
 }
 
 // handleBaselineFiles serves GET /api/baselines/files?at=…: one snapshot's

--- a/internal/console/baselines_detail.go
+++ b/internal/console/baselines_detail.go
@@ -236,14 +236,24 @@ func (s *Server) resolveSnapshotRequest(w http.ResponseWriter, r *http.Request, 
 	// reason: local retention prunes while the durable copy remains.
 	var firstErr error
 	for _, src := range baselineSourcesOf(b) {
-		ss, err := openSnapshotSource(r.Context(), src)
+		// Bounded, for the reason the listing is: an s3:// source builds an
+		// object store (which HEADs the bucket) and then lists it, inside the
+		// process that is also capturing, and the server sets no WriteTimeout
+		// on purpose. Before this loop the detail tier only ever opened the
+		// primary, so on a dir+S3 server it never touched the bucket at all;
+		// extending it without a deadline would have traded a 404 for a handler
+		// pinned indefinitely.
+		srcCtx, cancel := context.WithTimeout(r.Context(), baselineListTimeout)
+		ss, err := openSnapshotSource(srcCtx, src)
 		if err != nil {
+			cancel()
 			if firstErr == nil {
 				firstErr = fmt.Errorf("open backup storage: %w", err)
 			}
 			continue
 		}
-		files, err := ss.files(r.Context(), dirName)
+		files, err := ss.files(srcCtx, dirName)
+		cancel()
 		if err == nil {
 			return ss, dirName, files
 		}

--- a/internal/console/baselines_sources.go
+++ b/internal/console/baselines_sources.go
@@ -1,0 +1,170 @@
+package console
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/dbtrail/dbtrail/internal/reconstruct"
+)
+
+// baselineSourceDTO is one location the listing read, and what came of reading
+// it. Present for every configured location, including one that failed: a
+// listing that quietly drops an unreadable bucket is the same lie as one that
+// never looked at it (#1542).
+type baselineSourceDTO struct {
+	Source string `json:"source"`
+	Kind   string `json:"kind"` // "dir" | "s3"
+	// Count is how many baseline files this location held. Zero with no Error
+	// is a real answer: the location is readable and empty.
+	Count int `json:"count"`
+	// Error is the reason this location contributed nothing. When it is set the
+	// listing beside it is INCOMPLETE, and the page has to say so rather than
+	// render a shorter list as if it were the whole set.
+	Error string `json:"error,omitempty"`
+}
+
+// baselineKindOf classifies a source the way the rest of the console does.
+func baselineKindOf(source string) string {
+	if strings.HasPrefix(source, "s3://") {
+		return "s3"
+	}
+	return "dir"
+}
+
+// baselineFileKey identifies the same snapshot file across locations. Time is
+// carried as UnixNano so the key stays comparable; two locations holding the
+// same snapshot agree on its directory timestamp, which is where both listers
+// derive SnapshotTime from.
+type baselineFileKey struct {
+	unixNano int64
+	schema   string
+	table    string
+}
+
+func keyOf(f reconstruct.BaselineFile) baselineFileKey {
+	return baselineFileKey{unixNano: f.SnapshotTime.UnixNano(), schema: f.Schema, table: f.Table}
+}
+
+// mergedBaselines is the union of every configured baseline location.
+type mergedBaselines struct {
+	// Files is the deduplicated union, newest snapshot first, then by
+	// schema.table — the order a single lister already returns, preserved so
+	// the grouping loop downstream is unchanged.
+	Files []reconstruct.BaselineFile
+	// Kinds maps a snapshot's timestamp to the sorted set of locations any of
+	// its files were found in.
+	Kinds map[int64][]string
+	// Sources reports every location that was consulted, in consult order.
+	Sources []baselineSourceDTO
+	// Listed counts the locations that answered. Zero means nothing could be
+	// read, which is the only case that is still a hard failure.
+	Listed int
+}
+
+// listBaselinesMerged lists every configured location and returns their union.
+//
+// Merged rather than "fall back when the primary is empty", because the empty
+// case is not the only one that hides snapshots and not even the common one.
+// Local retention prunes old snapshots while the durable S3 copies remain
+// (#616/#766), so as soon as ONE local snapshot survives, a fallback-on-empty
+// rule reports that single snapshot and hides every older one in the bucket.
+// The union is the set the operator actually has.
+//
+// A location that fails does NOT fail the request when another answered. The
+// bug this fixes is a listing that looks complete and is not; replacing it with
+// a page that shows nothing because a bucket was briefly unreachable would be
+// the same failure with worse manners. It is recorded on the source instead,
+// and every caller has to render it.
+// baselineLister is reconstruct.ListBaselines, taken as a parameter rather than
+// called directly so a test can drive the merge across BOTH kinds. An s3://
+// source cannot be listed from a unit test, and the three things most likely to
+// break here — dedup across locations, the union of kinds, and preferring the
+// local path for the footer read — are exactly the ones that only appear when
+// the two locations are of different kinds.
+type baselineLister func(ctx context.Context, source string) ([]reconstruct.BaselineFile, error)
+
+func listBaselinesMerged(ctx context.Context, sources []string, list baselineLister) mergedBaselines {
+	out := mergedBaselines{Kinds: map[int64][]string{}}
+	seen := map[baselineFileKey]int{}
+	kindSeen := map[int64]map[string]bool{}
+
+	for _, src := range sources {
+		if src == "" {
+			continue
+		}
+		kind := baselineKindOf(src)
+		report := baselineSourceDTO{Source: src, Kind: kind}
+		files, err := list(ctx, src)
+		if err != nil {
+			report.Error = err.Error()
+			out.Sources = append(out.Sources, report)
+			continue
+		}
+		out.Listed++
+		report.Count = len(files)
+		out.Sources = append(out.Sources, report)
+
+		for _, f := range files {
+			ts := f.SnapshotTime.UnixNano()
+			if kindSeen[ts] == nil {
+				kindSeen[ts] = map[string]bool{}
+			}
+			kindSeen[ts][kind] = true
+
+			k := keyOf(f)
+			if idx, dup := seen[k]; dup {
+				// Keep the LOCAL path when the same file exists in both. The
+				// footer read downstream opens Path directly, and doing that
+				// over S3 is the latency this listing deliberately avoids.
+				if kind == "dir" && baselineKindOf(out.Files[idx].Path) == "s3" {
+					out.Files[idx].Path = f.Path
+				}
+				continue
+			}
+			seen[k] = len(out.Files)
+			out.Files = append(out.Files, f)
+		}
+	}
+
+	for ts, kinds := range kindSeen {
+		list := make([]string, 0, len(kinds))
+		for k := range kinds {
+			list = append(list, k)
+		}
+		sort.Strings(list)
+		out.Kinds[ts] = list
+	}
+
+	// One lister returns newest-first already; two concatenated do not. Sorted
+	// here rather than left to the caller because the grouping loop downstream
+	// starts a new snapshot every time the timestamp CHANGES, so an interleaved
+	// order would emit the same snapshot twice.
+	sort.SliceStable(out.Files, func(i, j int) bool {
+		a, b := out.Files[i], out.Files[j]
+		if !a.SnapshotTime.Equal(b.SnapshotTime) {
+			return a.SnapshotTime.After(b.SnapshotTime)
+		}
+		if a.Schema != b.Schema {
+			return a.Schema < b.Schema
+		}
+		return a.Table < b.Table
+	})
+	return out
+}
+
+// baselineSourcesOf lists the locations a bundle can read, primary first.
+//
+// Both come off the bundle rather than off the registry entry, because the
+// bundle is where the local-wins-over-S3 resolution already happened and a
+// second opinion about it here is how the listing and findBaseline would come
+// to disagree about which files exist.
+func baselineSourcesOf(b *bundle) []string {
+	if b == nil || b.baselineSrc == "" {
+		return nil
+	}
+	if b.baselineFallbackSrc == "" {
+		return []string{b.baselineSrc}
+	}
+	return []string{b.baselineSrc, b.baselineFallbackSrc}
+}

--- a/internal/console/baselines_sources.go
+++ b/internal/console/baselines_sources.go
@@ -2,11 +2,26 @@ package console
 
 import (
 	"context"
+	"log/slog"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/dbtrail/dbtrail/internal/reconstruct"
 )
+
+// baselineListTimeout bounds ONE location's listing.
+//
+// A local directory answers off the filesystem; an S3 one opens DuckDB, loads
+// httpfs and globs a bucket, and this runs inside `bintrail-console watch`,
+// which is also the capture process. The Backups page polls every ~10s while a
+// run is in flight and the server sets no WriteTimeout, so an endpoint that
+// accepts and never answers would hold a request open indefinitely.
+//
+// Generous rather than tight: a slow bucket that eventually answers must not be
+// reported as unreadable, which would be this endpoint claiming an incomplete
+// listing on a healthy configuration.
+const baselineListTimeout = 15 * time.Second
 
 // baselineSourceDTO is one location the listing read, and what came of reading
 // it. Present for every configured location, including one that failed: a
@@ -95,10 +110,21 @@ func listBaselinesMerged(ctx context.Context, sources []string, list baselineLis
 		}
 		kind := baselineKindOf(src)
 		report := baselineSourceDTO{Source: src, Kind: kind}
-		files, err := list(ctx, src)
+		srcCtx, cancel := context.WithTimeout(ctx, baselineListTimeout)
+		files, err := list(srcCtx, src)
+		cancel()
 		if err != nil {
 			report.Error = err.Error()
 			out.Sources = append(out.Sources, report)
+			// Logged as well as returned. The response body is the ONLY other
+			// copy, so without this a bucket that has been failing since a
+			// credential expiry is visible to whoever has the tab open and to
+			// nobody else — not cron, not alerting, not the journal. The
+			// coverage endpoint already warns on the identical failure from the
+			// identical call, and this handler already warns about the far
+			// smaller failure of one unreadable Parquet footer.
+			slog.Warn("console: a backup location could not be listed; the listing beside it is incomplete",
+				"source", src, "kind", kind, "error", err)
 			continue
 		}
 		out.Listed++

--- a/internal/console/baselines_sources_test.go
+++ b/internal/console/baselines_sources_test.go
@@ -1,0 +1,217 @@
+package console
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/reconstruct"
+)
+
+func bf(ts string, schema, table, path string) reconstruct.BaselineFile {
+	t, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		panic(err)
+	}
+	return reconstruct.BaselineFile{SnapshotTime: t, Schema: schema, Table: table, Path: path}
+}
+
+// fakeLister answers per source, so a test can put a local directory and a
+// bucket side by side without either existing.
+func fakeLister(bySource map[string][]reconstruct.BaselineFile, fail map[string]error) baselineLister {
+	return func(_ context.Context, src string) ([]reconstruct.BaselineFile, error) {
+		if err, bad := fail[src]; bad {
+			return nil, err
+		}
+		return bySource[src], nil
+	}
+}
+
+// TestMergedBaselines_unionsTheLocationsRatherThanFallingBack is the bug in
+// #1542, stated as the case that distinguishes the two candidate fixes.
+//
+// The local directory is NOT empty: retention pruned it down to the newest
+// snapshot while the durable S3 copies stayed (#616/#766). A
+// "fall back when the primary is empty" rule answers with that one snapshot and
+// hides every older one in the bucket, and it passes any test whose local
+// directory happens to be empty. So this fixture has one snapshot on disk and
+// two older ones only in S3.
+func TestMergedBaselines_unionsTheLocationsRatherThanFallingBack(t *testing.T) {
+	const dir, s3 = "/data/baselines", "s3://bucket/baselines"
+	got := listBaselinesMerged(context.Background(), []string{dir, s3}, fakeLister(
+		map[string][]reconstruct.BaselineFile{
+			dir: {bf("2026-06-10T12:00:00Z", "shop", "orders", dir+"/2026-06-10T12-00-00Z/shop/orders.parquet")},
+			s3: {
+				bf("2026-06-10T12:00:00Z", "shop", "orders", s3+"/2026-06-10T12-00-00Z/shop/orders.parquet"),
+				bf("2026-06-03T12:00:00Z", "shop", "orders", s3+"/2026-06-03T12-00-00Z/shop/orders.parquet"),
+				bf("2026-05-27T12:00:00Z", "shop", "orders", s3+"/2026-05-27T12-00-00Z/shop/orders.parquet"),
+			},
+		}, nil))
+
+	if len(got.Files) != 3 {
+		t.Fatalf("merged %d file(s), want 3 (one on disk, two more only in the bucket): %+v", len(got.Files), got.Files)
+	}
+	want := []string{"2026-06-10T12:00:00Z", "2026-06-03T12:00:00Z", "2026-05-27T12:00:00Z"}
+	for i, w := range want {
+		if got.Files[i].SnapshotTime.Format(time.RFC3339) != w {
+			t.Errorf("file[%d] = %s, want %s (newest first, across BOTH locations)",
+				i, got.Files[i].SnapshotTime.Format(time.RFC3339), w)
+		}
+	}
+
+	// The snapshot held in both is listed ONCE, and says so.
+	newest := got.Files[0].SnapshotTime.UnixNano()
+	if k := got.Kinds[newest]; len(k) != 2 || k[0] != "dir" || k[1] != "s3" {
+		t.Errorf("newest snapshot kinds = %v, want [dir s3]: it is in both places", k)
+	}
+	if k := got.Kinds[got.Files[1].SnapshotTime.UnixNano()]; len(k) != 1 || k[0] != "s3" {
+		t.Errorf("pruned snapshot kinds = %v, want [s3] only", k)
+	}
+
+	// And the surviving row keeps the LOCAL path: the footer read downstream
+	// opens it directly, which is the latency this listing avoids over S3.
+	if got.Files[0].Path != dir+"/2026-06-10T12-00-00Z/shop/orders.parquet" {
+		t.Errorf("deduped file kept %q; the local copy has to win so the footer is read off disk", got.Files[0].Path)
+	}
+
+	if got.Listed != 2 || len(got.Sources) != 2 {
+		t.Fatalf("listed %d of %d sources, want 2 of 2", got.Listed, len(got.Sources))
+	}
+	if got.Sources[0].Kind != "dir" || got.Sources[0].Count != 1 {
+		t.Errorf("source[0] = %+v, want the local dir with 1 file", got.Sources[0])
+	}
+	if got.Sources[1].Kind != "s3" || got.Sources[1].Count != 3 {
+		t.Errorf("source[1] = %+v, want the bucket with 3 files", got.Sources[1])
+	}
+}
+
+// A location that fails must not blank a page whose other half works, and must
+// not be silent about it either.
+func TestMergedBaselines_oneLocationFailsAndSaysSo(t *testing.T) {
+	const dir, s3 = "/data/baselines", "s3://bucket/baselines"
+	got := listBaselinesMerged(context.Background(), []string{dir, s3}, fakeLister(
+		map[string][]reconstruct.BaselineFile{
+			dir: {bf("2026-06-10T12:00:00Z", "shop", "orders", dir+"/x.parquet")},
+		},
+		map[string]error{s3: errors.New("AccessDenied")}))
+
+	if len(got.Files) != 1 {
+		t.Fatalf("merged %d file(s), want the 1 readable one", len(got.Files))
+	}
+	if got.Listed != 1 || len(got.Sources) != 2 {
+		t.Fatalf("listed %d of %d, want 1 of 2", got.Listed, len(got.Sources))
+	}
+	if got.Sources[1].Error == "" {
+		t.Error("the failing location is reported with no error; the listing beside it is a SUBSET and nothing would say so")
+	}
+	if got.Sources[1].Count != 0 {
+		t.Errorf("a failing location reported %d file(s); it contributed none", got.Sources[1].Count)
+	}
+}
+
+func TestBaselineSourcesOf(t *testing.T) {
+	if got := baselineSourcesOf(nil); got != nil {
+		t.Errorf("nil bundle = %v, want nil", got)
+	}
+	if got := baselineSourcesOf(&bundle{}); got != nil {
+		t.Errorf("unconfigured bundle = %v, want nil", got)
+	}
+	if got := baselineSourcesOf(&bundle{baselineSrc: "/d"}); len(got) != 1 || got[0] != "/d" {
+		t.Errorf("dir only = %v, want [/d]", got)
+	}
+	got := baselineSourcesOf(&bundle{baselineSrc: "/d", baselineFallbackSrc: "s3://b/p"})
+	if len(got) != 2 || got[0] != "/d" || got[1] != "s3://b/p" {
+		t.Errorf("dir + bucket = %v, want [/d s3://b/p] in consult order", got)
+	}
+}
+
+// newBaselineServerWithFallback is newBaselineServer for a server that keeps
+// BOTH a local directory and an S3 destination — the shape the endpoint used to
+// list only half of.
+func newBaselineServerWithFallback(t *testing.T, src, fallback string) *Server {
+	t.Helper()
+	s := &Server{token: "t", cm: newConnManager(nil, false)}
+	s.cm.boot = &bundle{baselineSrc: src, baselineFallbackSrc: fallback, baselineConfigured: true}
+	s.mux = s.buildHandler()
+	return s
+}
+
+// TestBaselinesAPI_listsBothLocations drives the real endpoint over two local
+// directories. It cannot exercise the s3 KIND (there is no bucket here), which
+// is what the merge unit test above is for; what it covers is that the handler
+// consults the fallback at all and reports both locations.
+func TestBaselinesAPI_listsBothLocations(t *testing.T) {
+	primary, fallback := t.TempDir(), t.TempDir()
+	writeBaselineFixture(t, primary, "2026-06-10T12-00-00Z", "shop", "orders.parquet")
+	writeBaselineFixture(t, fallback, "2026-06-03T12-00-00Z", "shop", "orders.parquet")
+	writeBaselineFixture(t, fallback, "2026-05-27T12-00-00Z", "shop", "orders.parquet")
+
+	srv := newBaselineServerWithFallback(t, primary, fallback)
+	rec, body := doServersReq(t, srv, "GET", "/api/baselines", "")
+	if rec.Code != 200 {
+		t.Fatalf("code = %d, body = %s", rec.Code, body)
+	}
+	var got baselinesResponse
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Snapshots) != 3 {
+		t.Fatalf("snapshots = %d, want 3 across both locations: %+v", len(got.Snapshots), got.Snapshots)
+	}
+	if got.Snapshots[0].Time != "2026-06-10 12:00:00" || got.Snapshots[2].Time != "2026-05-27 12:00:00" {
+		t.Errorf("order = %v, want newest first across locations",
+			[]string{got.Snapshots[0].Time, got.Snapshots[1].Time, got.Snapshots[2].Time})
+	}
+	if len(got.Sources) != 2 {
+		t.Fatalf("sources = %+v, want both locations named", got.Sources)
+	}
+	if got.Incomplete {
+		t.Error("both locations were readable; the listing must not claim to be a subset")
+	}
+	// Source/Kind still name the primary: they were the whole answer when there
+	// was one location, and an existing client reading them must not start
+	// getting a different location's path.
+	if got.Source != primary || got.Kind != "dir" {
+		t.Errorf("source/kind = %q/%q, want the primary %q/dir", got.Source, got.Kind, primary)
+	}
+}
+
+func TestBaselinesAPI_servesWhatItCanWhenOneLocationFails(t *testing.T) {
+	primary := t.TempDir()
+	writeBaselineFixture(t, primary, "2026-06-10T12-00-00Z", "shop", "orders.parquet")
+
+	srv := newBaselineServerWithFallback(t, primary, "/definitely/not/a/directory/1542")
+	rec, body := doServersReq(t, srv, "GET", "/api/baselines", "")
+	if rec.Code != 200 {
+		t.Fatalf("code = %d, body = %s — an unreadable second location must not blank a page whose first location works", rec.Code, body)
+	}
+	var got baselinesResponse
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Snapshots) != 1 {
+		t.Fatalf("snapshots = %d, want the 1 readable one", len(got.Snapshots))
+	}
+	if !got.Incomplete {
+		t.Error("the response does not flag itself incomplete; a short list rendered as the whole set is the bug this endpoint had")
+	}
+	if len(got.Sources) != 2 || got.Sources[1].Error == "" {
+		t.Errorf("sources = %+v, want the failing location named with its error", got.Sources)
+	}
+}
+
+func TestBaselinesAPI_failsOnlyWhenNoLocationAnswers(t *testing.T) {
+	srv := newBaselineServerWithFallback(t, "/nope/a/1542", "/nope/b/1542")
+	rec, body := doServersReq(t, srv, "GET", "/api/baselines", "")
+	if rec.Code != 502 {
+		t.Fatalf("code = %d, want 502 when nothing could be read: %s", rec.Code, body)
+	}
+	for _, want := range []string{"/nope/a/1542", "/nope/b/1542"} {
+		if !strings.Contains(string(body), want) {
+			t.Errorf("the failure does not name %s; the operator is left guessing which location broke:\n%s", want, body)
+		}
+	}
+}

--- a/internal/console/baselines_sources_test.go
+++ b/internal/console/baselines_sources_test.go
@@ -1,9 +1,11 @@
 package console
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"strings"
 	"testing"
 	"time"
@@ -213,5 +215,64 @@ func TestBaselinesAPI_failsOnlyWhenNoLocationAnswers(t *testing.T) {
 		if !strings.Contains(string(body), want) {
 			t.Errorf("the failure does not name %s; the operator is left guessing which location broke:\n%s", want, body)
 		}
+	}
+}
+
+// TestBaselineFilesAPI_reachesASnapshotOnlyInTheFallback is the half of #1542
+// that the listing fix created.
+//
+// Before the merge this could not be asked: a snapshot held only in the second
+// location had no row, so nothing linked to it. Now it has one, and opening the
+// primary alone answers "no backup found" for a row the same page just said is
+// there — and the Download button, which the frontend builds inside the success
+// path, never appears for exactly the snapshots this feature exists to reveal.
+func TestBaselineFilesAPI_reachesASnapshotOnlyInTheFallback(t *testing.T) {
+	primary, fallback := t.TempDir(), t.TempDir()
+	writeBaselineFixture(t, primary, "2026-06-10T12-00-00Z", "shop", "orders.parquet")
+	writeBaselineFixture(t, fallback, "2026-06-03T12-00-00Z", "shop", "orders.parquet")
+
+	srv := newBaselineServerWithFallback(t, primary, fallback)
+	rec, body := doServersReq(t, srv, "GET",
+		"/api/baselines/files?at=2026-06-03T12:00:00Z", "")
+	if rec.Code != 200 {
+		t.Fatalf("code = %d, body = %s — the listing shows this snapshot; its detail must not deny it", rec.Code, body)
+	}
+	var got baselineFilesResponse
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Tables) != 1 || got.Tables[0].Table != "orders" {
+		t.Errorf("tables = %+v, want the one table of the fallback-only snapshot", got.Tables)
+	}
+
+	// And the primary still wins for a snapshot it holds, so the fallback is a
+	// fallback and not a replacement.
+	rec, body = doServersReq(t, srv, "GET", "/api/baselines/files?at=2026-06-10T12:00:00Z", "")
+	if rec.Code != 200 {
+		t.Fatalf("code = %d for the primary's own snapshot: %s", rec.Code, body)
+	}
+}
+
+// A location that cannot be read has to reach the log, not only the response
+// body. The body is seen by whoever has the tab open and by nobody else — not
+// cron, not alerting, not the journal — and a bucket that has been failing since
+// a credential expiry is exactly the case that outlives a browser tab.
+func TestMergedBaselines_logsAFailedLocation(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	const dir, s3 = "/data/baselines", "s3://bucket/baselines"
+	listBaselinesMerged(context.Background(), []string{dir, s3}, fakeLister(
+		map[string][]reconstruct.BaselineFile{dir: {bf("2026-06-10T12:00:00Z", "shop", "orders", dir+"/x.parquet")}},
+		map[string]error{s3: errors.New("AccessDenied")}))
+
+	out := buf.String()
+	if !strings.Contains(out, s3) || !strings.Contains(out, "AccessDenied") {
+		t.Errorf("the failing location was not logged with its source and error:\n%s", out)
+	}
+	if strings.Contains(out, dir) {
+		t.Errorf("the location that WORKED was logged as a failure:\n%s", out)
 	}
 }


### PR DESCRIPTION
closes #1542

## The bug

A server that keeps a local directory **and** an S3 destination resolves the
bucket as the bundle's per-table fallback. `findBaseline` consults it; the
Backups listing did not.

So once retention pruned the local copies, the page showed nothing while the
bucket held dozens — and Time-travel could resolve a table from a bucket the
page behind it did not list.

## Why merged and not "fall back when the primary is empty"

Empty is not the only case that hides snapshots, and it is not even the common
one. As soon as **one** local snapshot survives retention, a fallback-on-empty
rule reports that single snapshot and hides every older one in the bucket.

`TestMergedBaselines_unionsTheLocationsRatherThanFallingBack` is built on
exactly that shape — one snapshot on disk, two older ones only in S3 — so the
cheaper fix fails it rather than passing by accident on an empty directory.

## Partial failure

A location that fails does not fail the request when another answered. The bug
here is a listing that looks complete and is not; replacing it with a blank page
whenever a bucket is briefly unreachable would be the same failure with worse
manners.

- `sources[]` reports every location consulted, with its file count and its
  error.
- `incomplete` says the list below is a subset.
- The page renders that as an error box naming the location, on **both** the
  populated branch and the empty one — "no backups found" over an unreadable
  bucket is the most misleading form of this bug.
- Only when nothing anywhere can be read is it still a 502, and the message now
  names every location instead of one.

Verified against a real (nonexistent) bucket:

```
incomplete: True
sources: [{"source":"/tmp/dbtrail/backups","kind":"dir","count":8},
          {"source":"s3://dbtrail-nope-1542/baselines","kind":"s3","count":0,
           "error":"list S3 baseline markers: HTTP Error: ... (HTTP 404 Not Found)"}]
```

The console trims that to its first line for display: the DuckDB error carries
the whole generated SQL across several lines, and a wall is what a reader skips.

## Smaller things

- Per snapshot, `kinds` says where it was found; the row shows it only when
  there is more than one location to distinguish, since a chip repeating the
  single configured source on every row is noise.
- `source`/`kind` keep naming the **primary**. They were the whole answer when
  there was one location, and a client reading them must not start getting a
  different path.
- The footer read is keyed on the file's own path rather than on the primary
  source's kind. With two locations merged, the primary being S3 says nothing
  about whether a given snapshot came off local disk, and the reverse would try
  to open an `s3://` URL as a file.
- `listBaselinesMerged` takes the lister as a parameter rather than calling
  `reconstruct.ListBaselines` directly. An `s3://` source cannot be listed from
  a unit test, and dedup across locations, the union of kinds, and preferring
  the local path only appear when the two locations are of different kinds.

## Out of scope, same shape

`/api/coverage` and the views download still read `baselineSrc` alone: filed as
#1571. The restore path, which the issue mentions, is #1541.

## Test plan

- [x] `go test ./... -count=1`
- [x] Rendered in a real browser against a live console with both locations
      configured and the bucket unreachable
- [x] Mutations, each red: `baselineSourcesOf` back to primary-only, and the
      merge changed into fallback-on-empty (caught by the pruned-local fixture)
- [x] UI mutation red: the incomplete notice dropped from the empty branch
- [x] The existing single-source tests are unchanged and still pass
