### PR TITLE
baseline: say how each table got into a snapshot

### DIFF
--- a/internal/baseline/baseline.go
+++ b/internal/baseline/baseline.go
@@ -189,11 +189,14 @@ func Run(ctx context.Context, cfg Config) (Stats, error) {
 			}
 
 			md := map[string]string{
-				"bintrail.snapshot_timestamp": tsStr,
-				"bintrail.source_database":    tf.Database,
-				"bintrail.source_table":       tf.Table,
-				"bintrail.mydumper_format":    tf.Format,
-				"bintrail.bintrail_version":   Version,
+				MetaKeySnapshotTimestamp:    tsStr,
+				"bintrail.source_database":  tf.Database,
+				"bintrail.source_table":     tf.Table,
+				MetaKeyMydumperFormat:       tf.Format,
+				"bintrail.bintrail_version": Version,
+				// #1545: say so, rather than leaving every reader to infer a
+				// dump from the ABSENCE of the fold's keys.
+				MetaKeySnapshotProducer: ProducerDump,
 			}
 			if meta.BinlogFile != "" {
 				md[MetaKeyBinlogFile] = meta.BinlogFile

--- a/internal/baseline/metadata.go
+++ b/internal/baseline/metadata.go
@@ -111,6 +111,23 @@ type DumpMetadata struct {
 	RowCount       int64  // rows ingested into this table's baseline; valid only when ContentDigest != ""
 	LSN            uint64 // PostgreSQL WAL LSN delta-replay floor, inclusive (MetaKeyLSN, see its doc comment / #771); 0 = absent (MySQL baseline, or pre-#593 PG baseline)
 	RenderGUCs     string // pinned rendering-GUC stamp (MetaKeyRenderGUCs, #593 slice D); "" = pre-pin PG baseline or MySQL baseline
+	// Producer is MetaKeySnapshotProducer: which code path wrote these bytes
+	// ("dump" | "reconstruct"). Empty on any snapshot written before #1545
+	// stamped it on the dump path; see ProvenanceOf, which does not guess.
+	Producer string
+	// DerivedFrom / DerivedFromPath are the ancestor a FOLD was built from
+	// (MetaKeyDerivedFrom / MetaKeyDerivedFromPath). Zero on a dump.
+	DerivedFrom     time.Time
+	DerivedFromPath string
+	// SnapshotTimestamp is MetaKeySnapshotTimestamp, the instant the writing
+	// run stamped. NOT which snapshot the file belongs to — the directory name
+	// is that (internal/snapshotdir) — and the disagreement between the two is
+	// how a carried-forward table is recognised. See ProvenanceOf.
+	SnapshotTimestamp time.Time
+	// MydumperFormat is MetaKeyMydumperFormat, written only by the mydumper
+	// dump path. Carried here as the one positive signal that dates a
+	// pre-#1545 MySQL dump.
+	MydumperFormat string
 	// CaptureGap is MetaKeyCaptureGap: non-empty means this snapshot is KNOWINGLY
 	// incomplete — it was folded across a permanent capture gap under
 	// --allow-gaps, or inherited that state from the snapshot it was derived
@@ -293,6 +310,7 @@ func ReadParquetMetadata(path string) (DumpMetadata, error) {
 	if v, ok := pf.Lookup(MetaKeyCaptureGap); ok {
 		m.CaptureGap = v
 	}
+	readProvenance(path, &m, func(k string) (string, bool) { return pf.Lookup(k) })
 	if v, ok := pf.Lookup(MetaKeyRowCount); ok {
 		n, parseErr := strconv.ParseInt(v, 10, 64)
 		if parseErr != nil {
@@ -389,6 +407,16 @@ func ReadParquetMetadataAny(ctx context.Context, path string) (DumpMetadata, err
 			m.RenderGUCs = val
 		case MetaKeyCaptureGap:
 			m.CaptureGap = val
+		case MetaKeySnapshotProducer:
+			m.Producer = val
+		case MetaKeyDerivedFromPath:
+			m.DerivedFromPath = val
+		case MetaKeyMydumperFormat:
+			m.MydumperFormat = val
+		case MetaKeyDerivedFrom:
+			m.DerivedFrom = parseFooterTime(path, MetaKeyDerivedFrom, val)
+		case MetaKeySnapshotTimestamp:
+			m.SnapshotTimestamp = parseFooterTime(path, MetaKeySnapshotTimestamp, val)
 		case MetaKeyRowCount:
 			if n, parseErr := strconv.ParseInt(val, 10, 64); parseErr == nil {
 				m.RowCount = n

--- a/internal/baseline/provenance.go
+++ b/internal/baseline/provenance.go
@@ -58,10 +58,13 @@ const (
 	// the window, so its previous file was reused verbatim (#1471) — usually as
 	// a HARD LINK, meaning these are literally the older snapshot's bytes.
 	ProducedByCarriedForward = "carried_forward"
-	// ProducedByUnknown: a snapshot old enough to carry none of the signals
-	// below. Never guessed as one of the others — the whole point is that an
-	// operator can tell which they have, and a confident wrong answer is worse
-	// than none.
+	// ProducedByUnknown: none of the signals below are present. Several causes
+	// reach it and this verdict does NOT distinguish them: a snapshot written
+	// before any of them existed, a producer value a newer build wrote that this
+	// one does not know, and a corrupt LSN or mydumper format that parsed away.
+	// Anything reporting it must not name a cause it cannot see. Never guessed
+	// as one of the others — the whole point is that an operator can tell which
+	// they have, and a confident wrong answer is worse than none.
 	ProducedByUnknown = "unknown"
 )
 
@@ -75,7 +78,12 @@ type TableProvenance struct {
 	// the ancestor that was folded (ProducedByFold) or the snapshot whose file
 	// was reused (ProducedByCarriedForward). Zero for a dump.
 	From time.Time
-	// FromPath is that ancestor's file, when the footer recorded one.
+	// FromPath is From's own file, when the footer recorded one. EMPTY on a
+	// carried table, and deliberately: derived_from_path in a carried file is
+	// the footer of the snapshot the bytes came from, which for a folded
+	// ancestor names ITS source — one link further back than From. Returning
+	// the pair would hand an operator two timestamps that do not describe the
+	// same snapshot. The footer simply does not record the carried-from file.
 	FromPath string
 }
 
@@ -102,10 +110,11 @@ type TableProvenance struct {
 func ProvenanceOf(snapshotTime time.Time, md DumpMetadata) TableProvenance {
 	if !md.SnapshotTimestamp.IsZero() && !snapshotTime.IsZero() &&
 		!md.SnapshotTimestamp.Equal(snapshotTime.UTC()) {
+		// No FromPath: see the field's doc. md.DerivedFromPath here belongs to
+		// whoever wrote these bytes, not to the snapshot they were written for.
 		return TableProvenance{
 			ProducedBy: ProducedByCarriedForward,
 			From:       md.SnapshotTimestamp,
-			FromPath:   md.DerivedFromPath,
 		}
 	}
 	switch md.Producer {

--- a/internal/baseline/provenance.go
+++ b/internal/baseline/provenance.go
@@ -123,6 +123,15 @@ func ProvenanceOf(snapshotTime time.Time, md DumpMetadata) TableProvenance {
 	case ProducerDump:
 		return TableProvenance{ProducedBy: ProducedByDump}
 	}
+	// A producer this build does not recognise is UNKNOWN, and it must not reach
+	// the legacy sniff below. That block dates a file that carries no producer
+	// key at all; a value a newer version stamped is a positive statement this
+	// build cannot read, and grading it `dump` because the file also happens to
+	// carry a mydumper format would be a confident answer about an operation
+	// nobody here knows the name of.
+	if md.Producer != "" {
+		return TableProvenance{ProducedBy: ProducedByUnknown}
+	}
 	// No producer key: written before #1545 stamped one. Two positive signals
 	// still date it as a dump, and both are keys the fold never writes —
 	// mydumper's format for MySQL, the WAL floor for PostgreSQL. Guessing from

--- a/internal/baseline/provenance.go
+++ b/internal/baseline/provenance.go
@@ -1,0 +1,159 @@
+package baseline
+
+import (
+	"log/slog"
+	"time"
+)
+
+// Provenance keys and values (#1545).
+//
+// The fold has stamped MetaKeySnapshotProducer / MetaKeyDerivedFrom /
+// MetaKeyDerivedFromPath since #1169, but they lived in internal/reconstruct
+// and NOTHING read them: the data was on disk and no surface could answer
+// "where did this snapshot come from". They move here, where the rest of the
+// footer vocabulary lives and where both writers and every reader can reach
+// them without an import cycle.
+//
+// The string VALUES are unchanged, deliberately. Every snapshot already written
+// carries them, and renaming a key would silently drop provenance on exactly
+// the historical files this exists to explain.
+const (
+	// MetaKeySnapshotProducer names the code path that WROTE these bytes.
+	MetaKeySnapshotProducer = "bintrail.snapshot_producer"
+	// MetaKeyDerivedFrom is the RFC3339 snapshot time this one was folded from;
+	// absent on a dump, which is derived from nothing.
+	MetaKeyDerivedFrom = "bintrail.derived_from_snapshot"
+	// MetaKeyDerivedFromPath is that ancestor's file path, for a human tracing
+	// a chain by hand.
+	MetaKeyDerivedFromPath = "bintrail.derived_from_path"
+	// MetaKeySnapshotTimestamp is the instant the WRITING run stamped. It is
+	// NOT authoritative for which snapshot a file belongs to — the directory
+	// name is (see internal/snapshotdir) — and the gap between the two is what
+	// identifies a carried-forward table. See TableProvenance.
+	MetaKeySnapshotTimestamp = "bintrail.snapshot_timestamp"
+	// MetaKeyMydumperFormat is written only by the mydumper dump path. Kept as
+	// a named constant because it is the one POSITIVE signal that dates a
+	// pre-#1545 MySQL dump, which carries no producer key at all.
+	MetaKeyMydumperFormat = "bintrail.mydumper_format"
+)
+
+// Producer values for MetaKeySnapshotProducer.
+const (
+	// ProducerDump is a real read of the source: mydumper for MySQL,
+	// pgbaseline for PostgreSQL.
+	ProducerDump = "dump"
+	// ProducerReconstruct is the fold — the previous snapshot replayed forward
+	// over the index. Its value predates this file and must not change.
+	ProducerReconstruct = "reconstruct"
+)
+
+// How a table's rows got into a snapshot.
+const (
+	// ProducedByDump: read from the source. Independent evidence.
+	ProducedByDump = "dump"
+	// ProducedByFold: the previous snapshot replayed forward over the index.
+	// Only as correct as the index window it folded; the source was never read.
+	ProducedByFold = "fold"
+	// ProducedByCarriedForward: not written at all. The table saw no changes in
+	// the window, so its previous file was reused verbatim (#1471) — usually as
+	// a HARD LINK, meaning these are literally the older snapshot's bytes.
+	ProducedByCarriedForward = "carried_forward"
+	// ProducedByUnknown: a snapshot old enough to carry none of the signals
+	// below. Never guessed as one of the others — the whole point is that an
+	// operator can tell which they have, and a confident wrong answer is worse
+	// than none.
+	ProducedByUnknown = "unknown"
+)
+
+// TableProvenance answers, for ONE table of ONE snapshot, how its rows got
+// there. Per table rather than per snapshot because carry-forward makes a
+// single snapshot a mix: some tables folded, some reused whole.
+type TableProvenance struct {
+	// ProducedBy is one of the ProducedBy* values.
+	ProducedBy string
+	// From is the snapshot these rows came out of, for the two derived cases:
+	// the ancestor that was folded (ProducedByFold) or the snapshot whose file
+	// was reused (ProducedByCarriedForward). Zero for a dump.
+	From time.Time
+	// FromPath is that ancestor's file, when the footer recorded one.
+	FromPath string
+}
+
+// ProvenanceOf derives a table's provenance from its footer and the snapshot
+// DIRECTORY time it was found under.
+//
+// The directory time is a parameter and not something read out of the file
+// because it is the authoritative one (internal/snapshotdir says so, and every
+// discovery path already works that way), and because the DISAGREEMENT between
+// the two is the whole signal for carry-forward.
+//
+// A carried table is usually a hard link to the previous snapshot's file, so
+// its footer is that snapshot's footer, unchanged and unchangeable: rewriting
+// it would edit the older snapshot through the same inode. That closes off
+// stamping a carried file at write time and leaves exactly one honest way to
+// recognise one — its footer says it was written at a different instant than
+// the snapshot it now sits in. Which is not a workaround: it is the same fact,
+// read where it actually exists.
+//
+// Order matters. The carried check comes FIRST, because a carried file's
+// producer key is its ancestor's and reporting that would name the wrong
+// operation for this snapshot. Everything after it is describing bytes that
+// really were written into this snapshot.
+func ProvenanceOf(snapshotTime time.Time, md DumpMetadata) TableProvenance {
+	if !md.SnapshotTimestamp.IsZero() && !snapshotTime.IsZero() &&
+		!md.SnapshotTimestamp.Equal(snapshotTime.UTC()) {
+		return TableProvenance{
+			ProducedBy: ProducedByCarriedForward,
+			From:       md.SnapshotTimestamp,
+			FromPath:   md.DerivedFromPath,
+		}
+	}
+	switch md.Producer {
+	case ProducerReconstruct:
+		return TableProvenance{ProducedBy: ProducedByFold, From: md.DerivedFrom, FromPath: md.DerivedFromPath}
+	case ProducerDump:
+		return TableProvenance{ProducedBy: ProducedByDump}
+	}
+	// No producer key: written before #1545 stamped one. Two positive signals
+	// still date it as a dump, and both are keys the fold never writes —
+	// mydumper's format for MySQL, the WAL floor for PostgreSQL. Guessing from
+	// their ABSENCE is what is refused: an old fold carries neither either.
+	if md.MydumperFormat != "" || md.LSN != 0 {
+		return TableProvenance{ProducedBy: ProducedByDump}
+	}
+	return TableProvenance{ProducedBy: ProducedByUnknown}
+}
+
+// readProvenance fills the provenance half of a DumpMetadata from a footer
+// lookup. Shared by the local and S3 readers so the two cannot come to hold
+// different opinions about which keys exist.
+func readProvenance(path string, m *DumpMetadata, lookup func(string) (string, bool)) {
+	if v, ok := lookup(MetaKeySnapshotProducer); ok {
+		m.Producer = v
+	}
+	if v, ok := lookup(MetaKeyDerivedFromPath); ok {
+		m.DerivedFromPath = v
+	}
+	if v, ok := lookup(MetaKeyMydumperFormat); ok {
+		m.MydumperFormat = v
+	}
+	if v, ok := lookup(MetaKeyDerivedFrom); ok {
+		m.DerivedFrom = parseFooterTime(path, MetaKeyDerivedFrom, v)
+	}
+	if v, ok := lookup(MetaKeySnapshotTimestamp); ok {
+		m.SnapshotTimestamp = parseFooterTime(path, MetaKeySnapshotTimestamp, v)
+	}
+}
+
+// parseFooterTime reads an RFC3339 footer value, warning rather than failing on
+// a corrupt one: provenance is a description, and losing it must never take a
+// baseline READ down with it.
+func parseFooterTime(path, key, val string) time.Time {
+	t, err := time.Parse(time.RFC3339, val)
+	if err != nil {
+		slog.Warn("corrupt timestamp in baseline Parquet metadata",
+			"path", path, "key", key, "raw_value", val, "error", err)
+		return time.Time{}
+	}
+	return t.UTC()
+}

--- a/internal/baseline/provenance_test.go
+++ b/internal/baseline/provenance_test.go
@@ -1,0 +1,134 @@
+package baseline
+
+import (
+	"testing"
+	"time"
+)
+
+func ts(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return t.UTC()
+}
+
+func TestProvenanceOf(t *testing.T) {
+	const snap = "2026-06-10T12:00:00Z"
+	older := ts("2026-06-03T12:00:00Z")
+
+	cases := []struct {
+		name string
+		dir  time.Time
+		md   DumpMetadata
+		want string
+		from time.Time
+	}{
+		{
+			name: "dump stamps itself",
+			dir:  ts(snap),
+			md:   DumpMetadata{Producer: ProducerDump, SnapshotTimestamp: ts(snap), MydumperFormat: "csv"},
+			want: ProducedByDump,
+		},
+		{
+			name: "fold stamps itself and names its ancestor",
+			dir:  ts(snap),
+			md: DumpMetadata{Producer: ProducerReconstruct, SnapshotTimestamp: ts(snap),
+				DerivedFrom: older, DerivedFromPath: "/b/2026-06-03T12-00-00Z/shop/orders.parquet"},
+			want: ProducedByFold,
+			from: older,
+		},
+		{
+			// The case the footer CANNOT be stamped for: carry-forward hard
+			// links the previous file, so its footer is the ancestor's, and
+			// rewriting it would edit the older snapshot through the same
+			// inode. The disagreement between the footer's instant and the
+			// directory it now sits in is the only honest signal.
+			name: "a file whose footer predates its directory was carried forward",
+			dir:  ts(snap),
+			md: DumpMetadata{Producer: ProducerReconstruct, SnapshotTimestamp: older,
+				DerivedFromPath: "/b/2026-05-27T12-00-00Z/shop/orders.parquet"},
+			want: ProducedByCarriedForward,
+			from: older,
+		},
+		{
+			// And it wins over the producer key, which for a carried file is
+			// the ancestor's and would name the wrong operation for THIS
+			// snapshot. A carried dump is the same story.
+			name: "a carried DUMP is still carried, not a dump",
+			dir:  ts(snap),
+			md:   DumpMetadata{Producer: ProducerDump, SnapshotTimestamp: older, MydumperFormat: "csv"},
+			want: ProducedByCarriedForward,
+			from: older,
+		},
+		{
+			name: "a legacy mysql dump is dated by its mydumper format",
+			dir:  ts(snap),
+			md:   DumpMetadata{SnapshotTimestamp: ts(snap), MydumperFormat: "csv"},
+			want: ProducedByDump,
+		},
+		{
+			name: "a legacy postgres dump is dated by its WAL floor",
+			dir:  ts(snap),
+			md:   DumpMetadata{SnapshotTimestamp: ts(snap), LSN: 42},
+			want: ProducedByDump,
+		},
+		{
+			// Refused rather than guessed. An old fold carries no producer key
+			// either, so absence names nothing.
+			name: "a snapshot with no signal at all is unknown",
+			dir:  ts(snap),
+			md:   DumpMetadata{SnapshotTimestamp: ts(snap)},
+			want: ProducedByUnknown,
+		},
+		{
+			// A footer with no timestamp cannot be compared, so the carried
+			// check must not fire on the zero value and call every such file
+			// carried from year zero.
+			name: "a footer with no timestamp falls through to the producer",
+			dir:  ts(snap),
+			md:   DumpMetadata{Producer: ProducerReconstruct},
+			want: ProducedByFold,
+		},
+		{
+			// Same, from the other side: a caller that does not know the
+			// snapshot's directory time must not have every file called
+			// carried.
+			name: "an unknown directory time falls through to the producer",
+			md:   DumpMetadata{Producer: ProducerDump, SnapshotTimestamp: ts(snap)},
+			want: ProducedByDump,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ProvenanceOf(tc.dir, tc.md)
+			if got.ProducedBy != tc.want {
+				t.Errorf("ProducedBy = %q, want %q", got.ProducedBy, tc.want)
+			}
+			if !tc.from.IsZero() && !got.From.Equal(tc.from) {
+				t.Errorf("From = %v, want %v — the ancestor is what makes the verdict actionable", got.From, tc.from)
+			}
+			if tc.want == ProducedByDump && !got.From.IsZero() {
+				t.Errorf("From = %v on a dump, which is derived from nothing", got.From)
+			}
+		})
+	}
+}
+
+// The values are load-bearing on disk. Every snapshot already written carries
+// them, and a rename silently drops provenance on exactly the historical files
+// this feature exists to explain.
+func TestProvenanceKeysAndValuesAreFrozen(t *testing.T) {
+	for k, want := range map[string]string{
+		MetaKeySnapshotProducer:  "bintrail.snapshot_producer",
+		MetaKeyDerivedFrom:       "bintrail.derived_from_snapshot",
+		MetaKeyDerivedFromPath:   "bintrail.derived_from_path",
+		MetaKeySnapshotTimestamp: "bintrail.snapshot_timestamp",
+		MetaKeyMydumperFormat:    "bintrail.mydumper_format",
+		ProducerReconstruct:      "reconstruct",
+	} {
+		if k != want {
+			t.Errorf("a footer key/value moved: got %q, want %q — files already on disk carry the old spelling", k, want)
+		}
+	}
+}

--- a/internal/baseline/provenance_test.go
+++ b/internal/baseline/provenance_test.go
@@ -18,11 +18,12 @@ func TestProvenanceOf(t *testing.T) {
 	older := ts("2026-06-03T12:00:00Z")
 
 	cases := []struct {
-		name string
-		dir  time.Time
-		md   DumpMetadata
-		want string
-		from time.Time
+		name     string
+		dir      time.Time
+		md       DumpMetadata
+		want     string
+		from     time.Time
+		fromPath string
 	}{
 		{
 			name: "dump stamps itself",
@@ -35,8 +36,12 @@ func TestProvenanceOf(t *testing.T) {
 			dir:  ts(snap),
 			md: DumpMetadata{Producer: ProducerReconstruct, SnapshotTimestamp: ts(snap),
 				DerivedFrom: older, DerivedFromPath: "/b/2026-06-03T12-00-00Z/shop/orders.parquet"},
-			want: ProducedByFold,
-			from: older,
+			// A fold DOES name its ancestor's file, and it is the same snapshot
+			// From names. That pairing is what makes the carried case below a
+			// real assertion rather than "nothing is ever set".
+			want:     ProducedByFold,
+			from:     older,
+			fromPath: "/b/2026-06-03T12-00-00Z/shop/orders.parquet",
 		},
 		{
 			// The case the footer CANNOT be stamped for: carry-forward hard
@@ -111,6 +116,14 @@ func TestProvenanceOf(t *testing.T) {
 			if tc.want == ProducedByDump && !got.From.IsZero() {
 				t.Errorf("From = %v on a dump, which is derived from nothing", got.From)
 			}
+			// FromPath must name FROM's file or nothing. On a carried table the
+			// footer's derived_from_path belongs to whoever wrote the bytes,
+			// which for a folded ancestor is one link FURTHER back than From —
+			// so returning it would hand an operator a timestamp and a path that
+			// describe two different snapshots.
+			if got.FromPath != tc.fromPath {
+				t.Errorf("FromPath = %q, want %q", got.FromPath, tc.fromPath)
+			}
 		})
 	}
 }
@@ -130,5 +143,11 @@ func TestProvenanceKeysAndValuesAreFrozen(t *testing.T) {
 		if k != want {
 			t.Errorf("a footer key/value moved: got %q, want %q — files already on disk carry the old spelling", k, want)
 		}
+	}
+	// Separately, because ProducedByDump shares its spelling and Go rejects a
+	// duplicate constant map key. Once shipped this value is on disk like the
+	// rest of them.
+	if ProducerDump != "dump" {
+		t.Errorf("ProducerDump = %q, want \"dump\" — it is stamped into every new snapshot", ProducerDump)
 	}
 }

--- a/internal/baseline/provenance_test.go
+++ b/internal/baseline/provenance_test.go
@@ -110,11 +110,13 @@ func TestProvenanceOf(t *testing.T) {
 			if got.ProducedBy != tc.want {
 				t.Errorf("ProducedBy = %q, want %q", got.ProducedBy, tc.want)
 			}
-			if !tc.from.IsZero() && !got.From.Equal(tc.from) {
+			// Unconditional, like FromPath below. A guard that only fires when a
+			// non-zero From is EXPECTED cannot see a verdict that grew one it
+			// must not have: `unknown` says the file records nothing, and
+			// rendering an ancestor date beside that is the confident wrong
+			// answer this whole type exists to refuse.
+			if !got.From.Equal(tc.from) {
 				t.Errorf("From = %v, want %v — the ancestor is what makes the verdict actionable", got.From, tc.from)
-			}
-			if tc.want == ProducedByDump && !got.From.IsZero() {
-				t.Errorf("From = %v on a dump, which is derived from nothing", got.From)
 			}
 			// FromPath must name FROM's file or nothing. On a carried table the
 			// footer's derived_from_path belongs to whoever wrote the bytes,
@@ -144,10 +146,59 @@ func TestProvenanceKeysAndValuesAreFrozen(t *testing.T) {
 			t.Errorf("a footer key/value moved: got %q, want %q — files already on disk carry the old spelling", k, want)
 		}
 	}
-	// Separately, because ProducedByDump shares its spelling and Go rejects a
-	// duplicate constant map key. Once shipped this value is on disk like the
-	// rest of them.
-	if ProducerDump != "dump" {
-		t.Errorf("ProducerDump = %q, want \"dump\" — it is stamped into every new snapshot", ProducerDump)
+	// Pairs, not a map. ProducerDump and ProducedByDump share the spelling
+	// "dump" and Go rejects a duplicate constant key in a map literal, so the
+	// map above structurally cannot hold all of them — which is how the four
+	// ProducedBy values ended up unpinned.
+	//
+	// Those four are WIRE values: app.js keys MADE_BY by the literals and looks
+	// up MADE_BY[t.produced_by]. Rename one and every Go assertion still passes
+	// (they all compare constant to constant) while the backup row renders
+	// nothing at all.
+	for _, p := range []struct{ got, want string }{
+		{ProducerDump, "dump"},
+		{ProducedByDump, "dump"},
+		{ProducedByFold, "fold"},
+		{ProducedByCarriedForward, "carried_forward"},
+		{ProducedByUnknown, "unknown"},
+	} {
+		if p.got != p.want {
+			t.Errorf("a value moved: got %q, want %q — the console keys its labels by these "+
+				"literals, so a rename renders an empty cell with every test green", p.got, p.want)
+		}
+	}
+}
+
+// TestProvenanceOf_unrecognisedProducerIsUnknown covers the forward-compat
+// region the table above leaves open: a value a NEWER build stamped.
+//
+// The switch has two cases and falls through to the legacy sniff, so a future
+// "refresh" or "carry" producer would grade a confident `dump` on any file that
+// also carries a mydumper format or an LSN. Unknown is the answer: this build
+// genuinely does not know.
+func TestProvenanceOf_unrecognisedProducerIsUnknown(t *testing.T) {
+	at := ts("2026-06-10T12:00:00Z")
+	for _, md := range []DumpMetadata{
+		{Producer: "refresh", SnapshotTimestamp: at, MydumperFormat: "csv"},
+		{Producer: "refresh", SnapshotTimestamp: at, LSN: 42},
+	} {
+		if got := ProvenanceOf(at, md); got.ProducedBy != ProducedByUnknown {
+			t.Errorf("producer %q with %+v graded %q; a value this build does not know is not "+
+				"evidence of a dump", md.Producer, md, got.ProducedBy)
+		}
+	}
+}
+
+// TestParseFooterTime_corruptIsZeroNotNow pins the failure mode of a damaged
+// stamp.
+//
+// The carried check is direction-blind (a footer disagreeing with its directory
+// is carried, either way), so a corrupt stamp resolving to "now" would grade an
+// ordinary file carried_forward with a present-day ancestor. Zero is what makes
+// the guard above skip it and fall through to the producer.
+func TestParseFooterTime_corruptIsZeroNotNow(t *testing.T) {
+	if got := parseFooterTime("/b/x.parquet", MetaKeySnapshotTimestamp, "not-a-time"); !got.IsZero() {
+		t.Errorf("a corrupt stamp parsed to %v; anything but the zero time makes the carried "+
+			"check fire on a file whose stamp was merely damaged", got)
 	}
 }

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -5052,7 +5052,11 @@ const MADE_BY = {
   dump: ["read from source", "A full copy taken from the database itself."],
   fold: ["built from changes", "The previous copy brought forward over the recorded changes. The source was not read."],
   carried_forward: ["reused unchanged", "Nothing changed in this table, so the previous copy was reused as is."],
-  unknown: ["not recorded", "Taken before backups recorded how they were made."],
+  // No cause named. This verdict is reached by a backup old enough to predate
+  // the record, by a newer version writing a value this build does not know,
+  // and by a footer field that would not parse. Picking one of them for the
+  // tooltip would be the reader told something nobody checked.
+  unknown: ["not recorded", "This backup does not say how it was made."],
 };
 
 function madeByCell(t) {

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -5040,6 +5040,31 @@ const BACKUP_KIND_LABEL = { dump: "full copy of the source", refresh: "automatic
 // loadBackupDetail fills a row's expansion: tables with sizes, total weight,
 // and duration. The recorded run (this daemon performed it) gives the exact
 // duration; otherwise the file timestamps bound it, labeled as such.
+// MADE_BY says, in the operator's terms, how a table's rows got into a backup
+// (#1545). The three routes have different trust, which is the whole reason to
+// show it: a full copy is independent evidence read from the source; the other
+// two never touched it.
+//
+// Plain words rather than the wire values. "fold" and "carried_forward" are
+// this codebase's names for its own mechanics, and nobody reading a backup page
+// knows them.
+const MADE_BY = {
+  dump: ["read from source", "A full copy taken from the database itself."],
+  fold: ["built from changes", "The previous copy brought forward over the recorded changes. The source was not read."],
+  carried_forward: ["reused unchanged", "Nothing changed in this table, so the previous copy was reused as is."],
+  unknown: ["not recorded", "Taken before backups recorded how they were made."],
+};
+
+function madeByCell(t) {
+  const entry = MADE_BY[t.produced_by];
+  if (!entry) return el("span", { class: "bk-made-none", text: "—" });
+  const cell = el("span", { class: "bk-made", title: entry[1], text: entry[0] });
+  // The ancestor is what makes the two derived verdicts actionable: it answers
+  // "how far back is the last copy that actually read the source".
+  if (t.from) cell.append(el("span", { class: "bk-made-from", text: " · " + t.from }));
+  return cell;
+}
+
 async function loadBackupDetail(at, box) {
   box.textContent = "Loading…";
   let d;
@@ -5069,11 +5094,22 @@ async function loadBackupDetail(at, box) {
   box.append(facts);
   if (d.incomplete) box.append(el("p", { class: "form-msg err", text: "This backup is marked incomplete (a failed or unfinished run); it cannot be downloaded or restored from." }));
   const tbl = el("table", { class: "bk-table" });
-  tbl.append(el("thead", {}, el("tr", {}, el("th", { text: "Table" }), el("th", { text: "Size" }))));
+  // The "Made by" column is only rendered when a row actually carries a verdict
+  // (#1545). An S3 source does not look it up, and a header over a column of
+  // dashes reads as "we checked and there is nothing", which is a different
+  // answer from "we did not check".
+  const anyProv = (d.tables || []).some((t) => t.produced_by);
+  const head = el("tr", {}, el("th", { text: "Table" }), el("th", { text: "Size" }));
+  if (anyProv) head.append(el("th", { text: "Made by" }));
+  tbl.append(el("thead", {}, head));
   const tb = el("tbody");
-  (d.tables || []).forEach((t) => tb.append(el("tr", {},
-    el("td", { class: "mono", text: t.schema + "." + t.table }),
-    el("td", { text: humanBytes(t.size_bytes || 0) }))));
+  (d.tables || []).forEach((t) => {
+    const row = el("tr", {},
+      el("td", { class: "mono", text: t.schema + "." + t.table }),
+      el("td", { text: humanBytes(t.size_bytes || 0) }));
+    if (anyProv) row.append(el("td", {}, madeByCell(t)));
+    tb.append(row);
+  });
   tbl.append(tb);
   box.append(tbl);
 }

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -2733,3 +2733,7 @@ button { font-family: inherit; }
 .bk-src-n { font-size: 11.5px; color: var(--ink-4); }
 .bk-where { font-size: 10.5px; color: var(--ink-4); border: 1px solid var(--line-soft); border-radius: 999px; padding: 1px 8px; white-space: nowrap; }
 .ctx-srcs { display: grid; gap: 2px; min-width: 0; }
+/* Backup detail: how each table's rows got into the snapshot (#1545). */
+.bk-made { font-size: 11.5px; color: var(--ink-3); }
+.bk-made-from { color: var(--ink-4); }
+.bk-made-none { color: var(--ink-4); }

--- a/internal/console/baselines_detail.go
+++ b/internal/console/baselines_detail.go
@@ -38,6 +38,14 @@ type baselineTableSizeDTO struct {
 	Schema    string `json:"schema"`
 	Table     string `json:"table"`
 	SizeBytes int64  `json:"size_bytes"`
+	// ProducedBy is how THIS table's rows got into THIS snapshot (#1545):
+	// dump | fold | carried_forward | unknown. Per table, not per snapshot,
+	// because carry-forward makes one snapshot a mix. Empty on an S3 source,
+	// where it would cost one object read per table; the field being absent is
+	// "not looked up", never "unknown".
+	ProducedBy string `json:"produced_by,omitempty"`
+	// From is the snapshot these rows came out of, for the two derived cases.
+	From string `json:"from,omitempty"`
 }
 
 type baselineFilesResponse struct {
@@ -279,7 +287,7 @@ func (s *Server) resolveSnapshotRequest(w http.ResponseWriter, r *http.Request, 
 // Deliberately NOT audited: like the listing, this is metadata (names, sizes,
 // timestamps) — no row data leaves the store. The download below is audited.
 func (s *Server) handleBaselineFiles(w http.ResponseWriter, r *http.Request) {
-	_, _, files := s.resolveSnapshotRequest(w, r, "baseline-files")
+	src, _, files := s.resolveSnapshotRequest(w, r, "baseline-files")
 	if files == nil {
 		return
 	}
@@ -307,8 +315,15 @@ func (s *Server) handleBaselineFiles(w http.ResponseWriter, r *http.Request) {
 		if len(parts) != 3 || !strings.HasSuffix(parts[2], ".parquet") {
 			continue
 		}
-		resp.Tables = append(resp.Tables, baselineTableSizeDTO{
-			Schema: parts[1], Table: strings.TrimSuffix(parts[2], ".parquet"), SizeBytes: f.Size})
+		row := baselineTableSizeDTO{
+			Schema: parts[1], Table: strings.TrimSuffix(parts[2], ".parquet"), SizeBytes: f.Size}
+		// Local only. Over S3 this is one object read per table, which is the
+		// same latency the listing already declines to spend on footers, and a
+		// row with no verdict reads as "not looked up" rather than as unknown.
+		if src != nil && src.localRoot != "" {
+			row.ProducedBy, row.From = tableProvenance(filepath.Join(src.localRoot, filepath.FromSlash(f.RelPath)), ts)
+		}
+		resp.Tables = append(resp.Tables, row)
 	}
 	sort.Slice(resp.Tables, func(i, j int) bool {
 		if resp.Tables[i].Schema != resp.Tables[j].Schema {
@@ -430,4 +445,27 @@ func (s *Server) handleBaselineDownload(w http.ResponseWriter, r *http.Request) 
 		abort("backup download: gzip finalize failed", "", err)
 	}
 	completed = true
+}
+
+// tableProvenance reads one table's footer and derives how its rows reached
+// this snapshot (#1545).
+//
+// Best-effort, and quiet about it: a footer that will not open leaves the row
+// with NO verdict rather than "unknown". The two are different answers — one is
+// "we did not find out", the other is "the file carries no signal" — and a
+// listing that turned an unreadable file into a confident verdict would be the
+// same class of mistake the audit reader was fixed for (ee#115).
+func tableProvenance(path string, snapshotAt time.Time) (string, string) {
+	md, err := baseline.ReadParquetMetadata(path)
+	if err != nil {
+		slog.Warn("console: could not read a backup table's footer for provenance",
+			"path", path, "error", err)
+		return "", ""
+	}
+	p := baseline.ProvenanceOf(snapshotAt, md)
+	from := ""
+	if !p.From.IsZero() {
+		from = p.From.UTC().Format(consoleTSFormat)
+	}
+	return p.ProducedBy, from
 }

--- a/internal/console/baselines_detail.go
+++ b/internal/console/baselines_detail.go
@@ -460,6 +460,10 @@ func tableProvenance(path string, snapshotAt time.Time) (string, string) {
 	if err != nil {
 		slog.Warn("console: could not read a backup table's footer for provenance",
 			"path", path, "error", err)
+		// NOT ProducedByUnknown. "we could not find out" and "the file records
+		// nothing" are different answers, and collapsing them is the ee#115
+		// class this comment cites: the reader is handed a verdict nobody
+		// checked. An empty verdict renders as a dash.
 		return "", ""
 	}
 	p := baseline.ProvenanceOf(snapshotAt, md)

--- a/internal/console/baselines_provenance_test.go
+++ b/internal/console/baselines_provenance_test.go
@@ -103,3 +103,54 @@ func TestBaselineFilesAPI_reportsHowEachTableWasMade(t *testing.T) {
 		}
 	}
 }
+
+// TestBaselineFilesAPI_unreadableFooterIsNotAVerdict keeps "we could not find
+// out" distinct from "the file records nothing" (#1545).
+//
+// Collapsing them hands the operator a verdict nobody checked, which is the
+// ee#115 class this endpoint's comment cites by name. An empty produced_by
+// renders as a dash; `unknown` renders as a claim about the file.
+func TestBaselineFilesAPI_unreadableFooterIsNotAVerdict(t *testing.T) {
+	root := t.TempDir()
+	const snap = "2026-06-10T12-00-00Z"
+	writeProvenanceTable(t, root, snap, "shop", "orders", baseline.ProducerDump, "2026-06-10T12:00:00Z")
+	// Not Parquet at all: the reader will refuse it.
+	if err := os.WriteFile(filepath.Join(root, snap, "shop", "broken.parquet"),
+		[]byte("this is not a parquet file"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, snap, baseline.SuccessMarker), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := newBaselineServer(t, root, true)
+	rec, body := doServersReq(t, srv, "GET", "/api/baselines/files?at=2026-06-10T12:00:00Z", "")
+	if rec.Code != 200 {
+		t.Fatalf("code = %d, body = %s — one unreadable file must not take the listing down", rec.Code, body)
+	}
+	var got baselineFilesResponse
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatal(err)
+	}
+	var seen int
+	for _, row := range got.Tables {
+		switch row.Table {
+		case "broken":
+			seen++
+			if row.ProducedBy != "" {
+				t.Errorf("an unreadable footer reported %q; nothing was found out about that file, "+
+					"and a verdict here is a claim nobody checked", row.ProducedBy)
+			}
+		case "orders":
+			seen++
+			// The readable one beside it still answers, so "empty" above is not
+			// the whole endpoint having given up.
+			if row.ProducedBy != baseline.ProducedByDump {
+				t.Errorf("the readable table reported %q, want %q", row.ProducedBy, baseline.ProducedByDump)
+			}
+		}
+	}
+	if seen != 2 {
+		t.Fatalf("tables = %+v, want both the readable and the unreadable one", got.Tables)
+	}
+}

--- a/internal/console/baselines_provenance_test.go
+++ b/internal/console/baselines_provenance_test.go
@@ -1,0 +1,105 @@
+package console
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
+)
+
+// writeProvenanceTable writes one real baseline Parquet whose footer carries the
+// producer and the snapshot instant a run of that kind would leave.
+func writeProvenanceTable(t *testing.T, root, snapshot, schema, table, producer, stampedAt string) {
+	t.Helper()
+	const createSQL = "CREATE TABLE `t` (\n  `id` int NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB;\n"
+	cols, err := baseline.ParseSchemaText(createSQL)
+	if err != nil {
+		t.Fatalf("ParseSchemaText: %v", err)
+	}
+	dir := filepath.Join(root, snapshot, schema)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	w, err := baseline.NewWriter(filepath.Join(dir, table+".parquet"), cols, baseline.WriterConfig{
+		Compression:  "none",
+		RowGroupSize: 100,
+		Metadata: map[string]string{
+			baseline.MetaKeyCreateTableSQL:    createSQL,
+			baseline.MetaKeySnapshotProducer:  producer,
+			baseline.MetaKeySnapshotTimestamp: stampedAt,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	if err := w.WriteRow([]string{"1"}, []bool{false}); err != nil {
+		t.Fatalf("WriteRow: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+// TestBaselineFilesAPI_reportsHowEachTableWasMade covers the per-table half of
+// #1545 through the real endpoint.
+//
+// Per TABLE and not per snapshot, because carry-forward makes one snapshot a
+// mix: this fixture is one snapshot holding a folded table and a carried one,
+// which is the shape a snapshot-level answer cannot describe at all.
+func TestBaselineFilesAPI_reportsHowEachTableWasMade(t *testing.T) {
+	root := t.TempDir()
+	const snap = "2026-06-10T12-00-00Z"
+	const snapAt = "2026-06-10T12:00:00Z"
+	const olderAt = "2026-06-03T12:00:00Z"
+
+	writeProvenanceTable(t, root, snap, "shop", "orders", baseline.ProducerReconstruct, snapAt)
+	// Carried: the previous file, hard linked, so its footer keeps the OLDER
+	// instant. Written directly here rather than linked, because what is under
+	// test is the READING rule; the link itself is pinned in reconstruct.
+	writeProvenanceTable(t, root, snap, "shop", "cold", baseline.ProducerReconstruct, olderAt)
+	writeProvenanceTable(t, root, snap, "shop", "fresh", baseline.ProducerDump, snapAt)
+	if err := os.WriteFile(filepath.Join(root, snap, baseline.SuccessMarker), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := newBaselineServer(t, root, true)
+	at, err := time.Parse(time.RFC3339, snapAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec, body := doServersReq(t, srv, "GET",
+		"/api/baselines/files?at="+at.Format(time.RFC3339), "")
+	if rec.Code != 200 {
+		t.Fatalf("code = %d, body = %s", rec.Code, body)
+	}
+	var got baselineFilesResponse
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatal(err)
+	}
+
+	want := map[string]string{
+		"cold":   baseline.ProducedByCarriedForward,
+		"fresh":  baseline.ProducedByDump,
+		"orders": baseline.ProducedByFold,
+	}
+	if len(got.Tables) != len(want) {
+		t.Fatalf("tables = %+v, want %d", got.Tables, len(want))
+	}
+	for _, row := range got.Tables {
+		if row.ProducedBy != want[row.Table] {
+			t.Errorf("%s.%s made by %q, want %q", row.Schema, row.Table, row.ProducedBy, want[row.Table])
+		}
+	}
+	for _, row := range got.Tables {
+		if row.Table == "cold" && row.From == "" {
+			t.Error("the carried table does not name the snapshot its bytes came from, " +
+				"which is what answers how far back the last real read of the source is")
+		}
+		if row.Table == "fresh" && row.From != "" {
+			t.Errorf("a table read from the source reports from = %q; it is derived from nothing", row.From)
+		}
+	}
+}

--- a/internal/pgbaseline/pgbaseline.go
+++ b/internal/pgbaseline/pgbaseline.go
@@ -414,10 +414,14 @@ func processTable(ctx context.Context, conn *pgx.Conn, t tableInfo, outputDir, t
 	outPath := filepath.Join(outputDir, tsDir, t.Schema, t.Table+".parquet")
 
 	md := map[string]string{
-		"bintrail.snapshot_timestamp": tsStr,
-		"bintrail.source_database":    t.Schema,
-		"bintrail.source_table":       t.Table,
-		"bintrail.bintrail_version":   baseline.Version,
+		baseline.MetaKeySnapshotTimestamp: tsStr,
+		"bintrail.source_database":        t.Schema,
+		"bintrail.source_table":           t.Table,
+		"bintrail.bintrail_version":       baseline.Version,
+		// #1545: a PostgreSQL baseline is a real read of the source, same as
+		// mydumper's. Without this it carries no producer key and only its LSN
+		// dates it.
+		baseline.MetaKeySnapshotProducer: baseline.ProducerDump,
 		// The LSN delta-replay floor (#593 slice A, corrected by #771): deltas
 		// for this table replay from AT OR AFTER this point — the slot's own
 		// confirmed_flush_lsn/restart_lsn (pgcapture.SlotFloorLSN), NOT the

--- a/internal/reconstruct/carryforward_provenance_test.go
+++ b/internal/reconstruct/carryforward_provenance_test.go
@@ -2,7 +2,9 @@ package reconstruct
 
 import (
 	"context"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -34,9 +36,16 @@ func writeProvenanceSnapshot(t *testing.T, root, stamp, producer string) string 
 	w, werr := baseline.NewWriter(path, cols, baseline.WriterConfig{
 		Compression:  "none",
 		RowGroupSize: 10,
+		// Every provenance key, not just the two the verdict turns on. Three of
+		// them reached ProvenanceOf only as hand-set struct fields, so a reader
+		// that stopped looking one of them up off a REAL file changed nothing
+		// any test could see.
 		Metadata: map[string]string{
 			baseline.MetaKeySnapshotTimestamp: at.Format(time.RFC3339),
 			baseline.MetaKeySnapshotProducer:  producer,
+			baseline.MetaKeyDerivedFrom:       at.Add(-7 * 24 * time.Hour).Format(time.RFC3339),
+			baseline.MetaKeyDerivedFromPath:   "/b/ancestor/demo/orders.parquet",
+			baseline.MetaKeyMydumperFormat:    "csv",
 		},
 	})
 	if werr != nil {
@@ -82,6 +91,21 @@ func TestCarryForward_readsBackAsCarriedNotAsItsAncestor(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read the carried file's footer: %v", err)
 	}
+	// The reader, off a REAL file, not off a struct a test filled in. Three of
+	// these keys are handled in two places (a closure over pf.Lookup locally, a
+	// switch for S3) and reached ProvenanceOf only as hand-set fields, so a
+	// reader that quietly stopped looking one of them up broke nothing visible.
+	if md.DerivedFromPath == "" {
+		t.Error("derived_from_path did not survive the footer read; a fold's ancestor file is " +
+			"silently dropped from every real snapshot")
+	}
+	if md.DerivedFrom.IsZero() {
+		t.Error("derived_from_snapshot did not survive the footer read")
+	}
+	if md.MydumperFormat == "" {
+		t.Error("mydumper_format did not survive the footer read; it is the one signal that " +
+			"dates every pre-#1545 MySQL dump, so losing it regrades them all to unknown")
+	}
 	newAt, _ := snapshotdir.ParseTime(newStamp)
 	got := baseline.ProvenanceOf(newAt, md)
 	if got.ProducedBy != baseline.ProducedByCarriedForward {
@@ -113,5 +137,32 @@ func TestParquetWriter_stampsItsProducer(t *testing.T) {
 	}
 	if md.Producer != baseline.ProducerReconstruct {
 		t.Errorf("producer = %q, want %q", md.Producer, baseline.ProducerReconstruct)
+	}
+}
+
+// TestDumpWritersStampTheirProducer guards the two stamps that make a NEW dump
+// self-identifying.
+//
+// A source guard, deliberately, and the limitation is the point: driving
+// baseline.Run needs mydumper output and pgbaseline needs a live PostgreSQL, so
+// neither stamp has an executing test. Worse, deleting either is SILENT in
+// production too — a real mydumper file still carries mydumper_format and grades
+// `dump` through the legacy fallback, so the loss shows up only years later on a
+// PostgreSQL snapshot whose LSN happens to be absent.
+//
+// Text is what is available; the alternative was no guard at all.
+func TestDumpWritersStampTheirProducer(t *testing.T) {
+	for path, want := range map[string]string{
+		"../baseline/baseline.go":     "MetaKeySnapshotProducer: ProducerDump",
+		"../pgbaseline/pgbaseline.go": "baseline.MetaKeySnapshotProducer: baseline.ProducerDump",
+	} {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if !strings.Contains(string(raw), want) {
+			t.Errorf("%s no longer stamps %q into the footers it writes; new snapshots from it "+
+				"stop saying they came from the source, and nothing else reports the loss", path, want)
+		}
 	}
 }

--- a/internal/reconstruct/carryforward_provenance_test.go
+++ b/internal/reconstruct/carryforward_provenance_test.go
@@ -1,0 +1,117 @@
+package reconstruct
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
+	"github.com/dbtrail/dbtrail/internal/baselineintegrity"
+	"github.com/dbtrail/dbtrail/internal/snapshotdir"
+)
+
+// writeProvenanceSnapshot writes one real baseline Parquet under
+// <root>/<stamp>/demo/orders.parquet with the footer a run of `producer` leaves,
+// plus the _MANIFEST carryForward validates against.
+func writeProvenanceSnapshot(t *testing.T, root, stamp, producer string) string {
+	t.Helper()
+	snapDir := filepath.Join(root, stamp)
+	path := filepath.Join(snapDir, "demo", "orders.parquet")
+	at, ok := snapshotdir.ParseTime(stamp)
+	if !ok {
+		t.Fatalf("fixture stamp %q is not a snapshot directory name", stamp)
+	}
+	// Multi-line: the schema parser is a line scanner over mydumper's own
+	// -schema.sql layout, and a one-line CREATE TABLE yields no columns.
+	cols, err := baseline.ParseSchemaText("CREATE TABLE `orders` (\n" +
+		"  `id` int NOT NULL,\n" +
+		"  PRIMARY KEY (`id`)\n" +
+		") ENGINE=InnoDB;\n")
+	if err != nil {
+		t.Fatalf("parse fixture schema: %v", err)
+	}
+	w, werr := baseline.NewWriter(path, cols, baseline.WriterConfig{
+		Compression:  "none",
+		RowGroupSize: 10,
+		Metadata: map[string]string{
+			baseline.MetaKeySnapshotTimestamp: at.Format(time.RFC3339),
+			baseline.MetaKeySnapshotProducer:  producer,
+		},
+	})
+	if werr != nil {
+		t.Fatalf("baseline writer: %v", werr)
+	}
+	if err := w.WriteRow([]string{"1"}, []bool{false}); err != nil {
+		t.Fatalf("write row: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	if err := baselineintegrity.WriteManifest(snapDir); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	return path
+}
+
+// TestCarryForward_readsBackAsCarriedNotAsItsAncestor is the wiring behind
+// baseline.ProvenanceOf.
+//
+// carryForward HARD LINKS the previous file, so the carried file's footer is
+// the ancestor's, byte for byte, and cannot be stamped: rewriting it would edit
+// the older snapshot through the same inode. The derivation therefore rests on
+// a property of the real filesystem operation — that the footer's instant stays
+// behind while the directory moves on — which a test over hand-built metadata
+// asserts about itself and proves nothing about.
+//
+// Without this, a change that made carryForward COPY-and-restamp, or that moved
+// the snapshot instant out of the footer, would leave every unit test green
+// while the page reported a carried table as a fold.
+func TestCarryForward_readsBackAsCarriedNotAsItsAncestor(t *testing.T) {
+	root := t.TempDir()
+	const oldStamp, newStamp = "2026-06-03T12-00-00Z", "2026-06-10T12-00-00Z"
+	src := writeProvenanceSnapshot(t, root, oldStamp, baseline.ProducerReconstruct)
+
+	newDir := filepath.Join(root, newStamp)
+	if err := carryForward(context.Background(), src, newDir, "demo", "orders"); err != nil {
+		t.Fatalf("carryForward: %v", err)
+	}
+	dst := filepath.Join(newDir, "demo", "orders.parquet")
+
+	md, err := baseline.ReadParquetMetadata(dst)
+	if err != nil {
+		t.Fatalf("read the carried file's footer: %v", err)
+	}
+	newAt, _ := snapshotdir.ParseTime(newStamp)
+	got := baseline.ProvenanceOf(newAt, md)
+	if got.ProducedBy != baseline.ProducedByCarriedForward {
+		t.Fatalf("a carried file reads as %q; it was neither dumped nor folded into this snapshot, "+
+			"and calling it a fold credits it with a replay that never ran (footer stamp %v, snapshot %v)",
+			got.ProducedBy, md.SnapshotTimestamp, newAt)
+	}
+	oldAt, _ := snapshotdir.ParseTime(oldStamp)
+	if !got.From.Equal(oldAt) {
+		t.Errorf("From = %v, want %v — the ancestor whose bytes these are is the actionable half", got.From, oldAt)
+	}
+
+	// The other half of the same fixture: the ORIGINAL file, read under its own
+	// directory, is a fold. Without this the test above would pass on a
+	// derivation that called everything carried.
+	if got := baseline.ProvenanceOf(oldAt, md); got.ProducedBy != baseline.ProducedByFold {
+		t.Errorf("the source file under its OWN snapshot reads as %q, want %q", got.ProducedBy, baseline.ProducedByFold)
+	}
+}
+
+// And the fold's own writer is stamped, read back off a file it really wrote.
+func TestParquetWriter_stampsItsProducer(t *testing.T) {
+	root := t.TempDir()
+	const stamp = "2026-06-10T12-00-00Z"
+	path := writeProvenanceSnapshot(t, root, stamp, SnapshotProducerReconstruct)
+	md, err := baseline.ReadParquetMetadata(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if md.Producer != baseline.ProducerReconstruct {
+		t.Errorf("producer = %q, want %q", md.Producer, baseline.ProducerReconstruct)
+	}
+}

--- a/internal/reconstruct/parquet_writer.go
+++ b/internal/reconstruct/parquet_writer.go
@@ -148,19 +148,24 @@ type baselineMeta struct {
 	Metadata baseline.DumpMetadata
 }
 
-// Parquet file-metadata keys unique to a RECONSTRUCTED snapshot. They are pure
-// provenance: no existing reader looks them up, so their presence cannot change
-// how a consumer treats the snapshot (which is the #1169 requirement), but they
-// make "was this snapshot dumped from a source, or folded out of the index?"
-// answerable forever from the file itself.
+// Parquet file-metadata keys unique to a RECONSTRUCTED snapshot.
+//
+// The definitions moved to internal/baseline in #1545, where the rest of the
+// footer vocabulary lives and where the dump writers and every reader can reach
+// them. These aliases stay so existing call sites and tests keep compiling, and
+// because this is the package whose writer stamps them.
+//
+// Written since #1169 as pure provenance — nothing looked them up, so their
+// presence could not change how a consumer treated the snapshot. #1545 gave
+// them readers; the string values did not move, because every snapshot already
+// on disk carries them.
 const (
-	MetaKeySnapshotProducer = "bintrail.snapshot_producer"
-	MetaKeyDerivedFrom      = "bintrail.derived_from_snapshot"
-	MetaKeyDerivedFromPath  = "bintrail.derived_from_path"
+	MetaKeySnapshotProducer = baseline.MetaKeySnapshotProducer
+	MetaKeyDerivedFrom      = baseline.MetaKeyDerivedFrom
+	MetaKeyDerivedFromPath  = baseline.MetaKeyDerivedFromPath
 	// SnapshotProducerReconstruct is the MetaKeySnapshotProducer value this
-	// package stamps. A snapshot written by `bintrail baseline` carries no
-	// producer key at all.
-	SnapshotProducerReconstruct = "reconstruct"
+	// package stamps. A dump stamps baseline.ProducerDump.
+	SnapshotProducerReconstruct = baseline.ProducerReconstruct
 )
 
 // mergeBaselineIntoParquet is the OutputFormatParquet sibling of
@@ -217,14 +222,14 @@ func mergeBaselineIntoParquet(ctx context.Context, in mergeInput, rep *TableRepo
 	}
 
 	md := map[string]string{
-		"bintrail.snapshot_timestamp":  in.SnapshotAt.UTC().Format(time.RFC3339),
-		"bintrail.source_database":     in.Schema,
-		"bintrail.source_table":        in.Table,
-		"bintrail.bintrail_version":    baseline.Version,
-		baseline.MetaKeyCreateTableSQL: in.CreateTableSQL,
-		MetaKeySnapshotProducer:        SnapshotProducerReconstruct,
-		MetaKeyDerivedFrom:             in.SourceBaseline.Time.UTC().Format(time.RFC3339),
-		MetaKeyDerivedFromPath:         in.SourceBaseline.Path,
+		baseline.MetaKeySnapshotTimestamp: in.SnapshotAt.UTC().Format(time.RFC3339),
+		"bintrail.source_database":        in.Schema,
+		"bintrail.source_table":           in.Table,
+		"bintrail.bintrail_version":       baseline.Version,
+		baseline.MetaKeyCreateTableSQL:    in.CreateTableSQL,
+		MetaKeySnapshotProducer:           SnapshotProducerReconstruct,
+		MetaKeyDerivedFrom:                in.SourceBaseline.Time.UTC().Format(time.RFC3339),
+		MetaKeyDerivedFromPath:            in.SourceBaseline.Path,
 	}
 	if line := captureGapLines(in); line != "" {
 		md[baseline.MetaKeyCaptureGap] = line


### PR DESCRIPTION
closes #1545

## What was actually missing

Half the issue's premise was already false: the fold has stamped
`bintrail.snapshot_producer`, `derived_from_snapshot` and `derived_from_path`
since #1169. What was true is that **nothing read them**, and the dump path
stamped nothing at all — so no surface could answer a question the data was
already on disk to answer.

So: move the keys to `internal/baseline` (values byte-identical — every snapshot
already written carries them, and a rename silently drops provenance on exactly
the historical files this exists to explain), stamp `dump` on both dump writers,
read them, and show them.

## Carry-forward decides the design

`carryForward` **hard links** the previous file. The carried file *is* the older
snapshot's file, one inode, so its footer cannot be stamped: rewriting it would
edit the older snapshot through the same link. There is no write-time answer
available.

What there is, is a fact already on disk: the footer's
`bintrail.snapshot_timestamp` stays behind while the directory the file now sits
in moves on. `internal/snapshotdir` already documents that exact divergence, for
the opposite reason (the directory name is authoritative for a snapshot's time).
So `ProvenanceOf` takes the snapshot **directory** time plus the footer, and
checks carried **first** — a carried file's producer key is its ancestor's, and
reporting it would name an operation that never ran for this snapshot.

## Not guessing

Two legacy signals date a pre-#1545 dump positively: mydumper's format for
MySQL, the WAL floor for PostgreSQL. Neither is written by a fold. Absence names
nothing and reports `unknown` — an old fold carries no producer key either, and
a confident wrong answer is worse than none.

Verified against real files: a snapshot whose Parquet carries no `bintrail.*`
keys at all reads as `unknown`, not as a dump.

## In the console

Per table, in the expanded backup detail, in plain words. Rendered against real
Parquet:

```
Table        Size    Made by
shop.cold    290 B   reused unchanged · 2026-06-03 12:00:00
shop.fresh   283 B   read from source
shop.orders  290 B   built from changes
```

Local sources only: over S3 this is one object read per table, the same latency
the listing already declines to spend on footers. A row with no verdict reads as
"not looked up", and the column is not rendered at all when no row has one —
a header over a column of dashes reads as "we checked and there is nothing",
which is a different answer.

## Deliberately not included

The chain question ("when did we last take real evidence from the source?")
wants an inherited last-dump stamp or a generation counter. That is a NEW footer
key with inheritance rules, not a reader over existing ones, and it is
separable. Filing it as a follow-up.

## Test plan

- [x] `go test ./... -count=1`
- [x] Table-driven `ProvenanceOf`, including both orderings and both
      fall-through cases (no footer timestamp, no directory time)
- [x] Wiring: a REAL `carryForward` hard link, read back through
      `ReadParquetMetadata`, reports carried — and the same file read under its
      OWN snapshot reports fold, so the derivation cannot pass by calling
      everything carried
- [x] Endpoint test over one snapshot holding a folded, a carried and a dumped
      table — the mix a snapshot-level answer cannot describe
- [x] Mutations, each red: the carried check disabled (a carried file reads as
      fold), the check order inverted, the endpoint no longer looking it up
- [x] Rendered in a real browser
