### PR TITLE
console: answer the download question on the Backups page

### DIFF
--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -3911,7 +3911,12 @@ async function renderBaselines() {
     // so the rows below can carry only what varies between snapshots.
     const cur = servers.find((s) => s.id === (currentServer || defaultServerId));
     v.append(baselineContextStrip(baselines, cur));
-    // The backup schedule (#1442) sits right under the facts about the
+    // The backup schedule (#1442), below the answer and the list. It used to
+    // sit directly under the context strip; the two download lanes took that
+    // spot, because a reader who came to fetch a copy should not scroll past
+    // scheduling to find one. Still ABOVE the fold line for a failed
+    // scheduled run, which has to be visible without opening anything.
+    // Reads, with the facts about the
     // collection: it is the answer to "will this list keep growing on its
     // own", and a failed scheduled run has to be visible without opening
     // anything.
@@ -4914,10 +4919,26 @@ function backupsPageIndex(serverId, pages) {
 
 // backupsPager draws the two controls and the position. Rendered only when
 // there is more than one page: a pager under five rows is furniture.
-function backupsPager(total, page, pages, onGo) {
+// truncated: /api/baselines caps its listing (baselinesMaxSnapshots) and says
+// so. The pager's one job is to tell a reader where they are, so it must not
+// render "46-50 of 50" for a server with 200 backups -- that is the one line
+// on the page asserting an inventory the API explicitly disclaimed.
+// backupsPageSlice is the page's window into the list, pulled out of the
+// panel so a test can EXECUTE it. The guard it replaces asserted the source
+// text contained ".slice(start," and "const idx = start + i" -- both of which
+// survive rewriting `start` to a constant 0, which leaves Older a dead
+// control, the pager still reporting "6-10 of 25", and every page re-crowning
+// its first row "Newest". Spelling is not behaviour.
+function backupsPageSlice(snapshots, page) {
+  const start = page * BACKUPS_PAGE_SIZE;
+  return { start: start, rows: snapshots.slice(start, start + BACKUPS_PAGE_SIZE) };
+}
+
+function backupsPager(total, page, pages, onGo, truncated) {
   if (pages < 2) return null;
   const from = page * BACKUPS_PAGE_SIZE + 1;
   const to = Math.min(total, (page + 1) * BACKUPS_PAGE_SIZE);
+  const of = truncated ? " of the newest " + total : " of " + total;
   const btn = (label, target, disabled) => {
     const el2 = el("button", { class: "btn btn-sm", type: "button", text: label });
     if (disabled) el2.disabled = true;
@@ -4926,7 +4947,7 @@ function backupsPager(total, page, pages, onGo) {
   };
   return el("div", { class: "bk-pager" },
     btn("Newer", page - 1, page === 0),
-    el("span", { class: "bk-pager-n", text: from + "–" + to + " of " + total }),
+    el("span", { class: "bk-pager-n", text: from + "–" + to + of }),
     btn("Older", page + 1, page >= pages - 1));
 }
 
@@ -4995,11 +5016,11 @@ function baselinesPanel(b, servers, opts) {
     const total = b.snapshots.length;
     const pages = Math.max(1, Math.ceil(total / BACKUPS_PAGE_SIZE));
     const page = backupsPageIndex(currentServer || defaultServerId, pages);
-    const start = page * BACKUPS_PAGE_SIZE;
+    const window = backupsPageSlice(b.snapshots, page);
     // idx is the index in the WHOLE list, not in the page: it decides the
     // "Newest" treatment, and paging must not promote the first row of page two.
-    b.snapshots.slice(start, start + BACKUPS_PAGE_SIZE).forEach((sn, i) => {
-      const idx = start + i;
+    window.rows.forEach((sn, i) => {
+      const idx = window.start + i;
       const row = el("div", { class: "stg-row" + (idx === 0 ? " stg-row-latest" : "") });
       if (idx === 0) row.append(el("span", { class: "tag-pill", text: "Newest" }));
       row.append(tsSpan("stg-name mono", sn.time));
@@ -5036,10 +5057,17 @@ function baselinesPanel(b, servers, opts) {
     });
     const pager = backupsPager(total, page, pages, (target) => {
       backupsPage = { server: currentServer || defaultServerId, index: target };
-      renderRoute();
-    });
+      // renderBaselines(), not renderRoute(): the route path bumps viewGen and
+      // runs viewLoading(), which blanks the view and drops the reader at the
+      // top of the page whose bottom they were reading. This is the same
+      // repaint watchBackupRuns uses.
+      renderBaselines();
+    }, !!b.truncated);
     if (pager) list.append(pager);
-    if (b.truncated) list.append(el("div", { class: "ev-empty", text: "…older backups not shown." }));
+    // Only when there is no pager to carry it: with one, "of the newest 50"
+    // already says it, and this line sitting under page 1 read as "backups 6
+    // and up are not shown" when they are on page 2.
+    if (b.truncated && !pager) list.append(el("div", { class: "ev-empty", text: "…older backups not shown." }));
   }
   panel.append(list);
   return panel;
@@ -5198,6 +5226,12 @@ async function downloadBackup(at, btn, totalBytes) {
         ". The browser holds all of it in memory before saving. Download anyway?")) {
     return;
   }
+  // Restore the caller's OWN label. This used to re-assert the per-row
+  // button's text, which is right for that button and renames every other
+  // one: the DuckDB lane's "Download the data" became "Download (.tar.gz) ·
+  // 210 MB" after a single click, and the next click captured the clobbered
+  // name as its own.
+  const btnLabel = btn ? btn.textContent : "";
   if (btn) { btn.disabled = true; btn.textContent = "Preparing…"; }
   try {
     const headers = TOKEN ? { Authorization: ["Bearer", TOKEN].join(" ") } : {};
@@ -5225,7 +5259,7 @@ async function downloadBackup(at, btn, totalBytes) {
   } catch (err) {
     toastError("Download failed: " + ((err && err.message) || err));
   } finally {
-    if (btn) { btn.disabled = false; btn.textContent = "Download (.tar.gz) · " + humanBytes(totalBytes || 0); }
+    if (btn) { btn.disabled = false; btn.textContent = btnLabel; }
   }
 }
 
@@ -5694,37 +5728,71 @@ function backupFilesShape(files) {
   return shape;
 }
 
-function backupLane(title, files, lead) {
+// backupLane DERIVES the count word from the tiles it is handed, so the
+// drawing and the sentence cannot disagree. They did: an earlier cut passed
+// the lead as a whole string, and gating the views tile below would have left
+// one tile under the words "Two files."
+//
+// "downloads", not "files": a tile is one thing you fetch, and the Parquet
+// tile is a whole folder arriving as one .tar.gz. Counting files would be
+// wrong by hundreds.
+const LANE_COUNT_WORD = ["No", "One", "Two", "Three"];
+function backupLane(title, files, tail) {
+  const n = files.length;
+  const word = (LANE_COUNT_WORD[n] || String(n)) + " download" + (n === 1 ? "" : "s");
   return el("div", { class: "bk-lane" },
     el("h3", { class: "bk-lane-t", text: title }),
     backupFilesShape(files),
-    el("p", { class: "bk-lane-lead", text: lead }));
+    el("p", { class: "bk-lane-lead", text: word + tail }));
 }
 
-// The DuckDB lane. Gated on there being a backup at all and nothing else:
-// downloading what is already stored asks for no capability, unlike the
-// build the other lane drives.
+// The DuckDB lane. Downloading what is already stored asks for no capability,
+// so the DATA half is gated on there being a backup and nothing else.
+//
+// The VIEWS half is a different promise and needs its own gate. It is not
+// produced here: the button sends the reader to Connect AI, where the panel
+// is gated on capsCache.views, and viewsAvailable() is false whenever the
+// selected server has archived data turned off (a checkbox on this console's
+// own server form), among other reasons. Ungated, this lane drew a views.sql
+// tile and a button leading to a page where that filename does not appear --
+// no error, no toast. views_api.go puts it plainly: "a button that only 404s
+// is a lie, and this codebase already refuses that trade for reconstruct and
+// verify." Naming the file from a shared constant pinned its NAME; only this
+// pins its EXISTENCE.
 function backupDuckLane(b) {
   if (!b || b.error || !b.configured) return null;
   const snaps = (b.snapshots || []);
   if (!snaps.length) return null;
-  const lane = backupLane("To open in DuckDB",
-    [{ name: "Parquet files", cap: "your tables" },
-     { name: DUCKDB_VIEWS_FILE, cap: "how to read them" }],
-    "Two files. The data, and the file that tells DuckDB how to read it.");
+  const hasViews = !!capsCache.views;
+  const files = [{ name: "Parquet files", cap: "your tables" }];
+  if (hasViews) files.push({ name: DUCKDB_VIEWS_FILE, cap: "how to read them" });
+  const lane = backupLane("To open in DuckDB", files, hasViews
+    ? ". The data, and the file that tells DuckDB how to read it."
+    : ". The data. DuckDB reads the Parquet files directly.");
   const msg = el("p", { class: "form-msg err" });
   msg.hidden = true;
   const dl = el("button", { class: "btn", type: "button", text: "Download the data" });
   dl.onclick = async () => {
     const err = await downloadNewestBackup(snaps[0].time, dl);
+    // The lane may have been repainted while the request was in flight, which
+    // leaves msg detached and the error written nowhere. Fall back to the
+    // toast the rest of the page already uses for exactly that.
+    if (err && !msg.isConnected) { toastError(err); return; }
     msg.textContent = err;
     msg.hidden = !err;
   };
-  const views = el("button", { class: "btn btn-ghost", type: "button", text: "Get " + DUCKDB_VIEWS_FILE });
-  views.onclick = () => navigate("connect");
-  lane.append(el("div", { class: "bk-lane-go" }, dl, views), msg);
+  const go = el("div", { class: "bk-lane-go" }, dl);
+  if (hasViews) {
+    const views = el("button", { class: "btn btn-ghost", type: "button", text: "Get " + DUCKDB_VIEWS_FILE });
+    views.onclick = () => navigate("connect");
+    go.append(views);
+  }
+  lane.append(go, msg);
+  // b.incomplete means at least one configured location would not answer, so
+  // the list is a SUBSET and "the newest" is only the newest of what was read.
   lane.append(el("p", { class: "form-hint", text:
-    "This takes the newest backup, from " + utcLabel(snaps[0].time) + ". Any other one in the list below downloads the same way." }));
+    (b.incomplete ? "This takes the newest backup that could be read, from " : "This takes the newest backup, from ") +
+    utcLabel(snaps[0].time) + ". Any other one in the list downloads the same way." }));
   return lane;
 }
 
@@ -5763,7 +5831,7 @@ async function downloadNewestBackup(at, btn) {
 // (#1448). The two terminal states after that, "downloaded" and "expired",
 // both mean the same thing to the operator: the file is gone, build again.
 // S3-backed backups qualify too (the fold engine reads them directly), which
-// is why this card has no b.kind === "dir" gate.
+// is why this lane has no b.kind === "dir" gate.
 // backupSnapshotsFor narrows the listing to the snapshots a JOB can actually
 // fold from (#1542).
 //
@@ -5774,13 +5842,14 @@ async function downloadNewestBackup(at, btn) {
 // in the bucket, and the job would refuse it while the page above says it is
 // right there. Listing more must not mean offering more than the job can do.
 //
-// The full answer is folding from S3 (#1541); until then the cards offer what
+// The full answer is folding from S3 (#1541); until then the restore card and
+// the .sql lane offer what
 // works and say what they left out.
 function backupSnapshotsFor(b, kind) {
   return ((b && b.snapshots) || []).filter((s) => !s.kinds || !s.kinds.length || s.kinds.includes(kind));
 }
 
-// backupElsewhereNote names the snapshots a card had to skip, so a shorter
+// backupElsewhereNote names the snapshots a caller had to skip, so a shorter
 // dropdown than the list above it is explained rather than merely odd.
 function backupElsewhereNote(b, usable) {
   const all = ((b && b.snapshots) || []).length;
@@ -5809,7 +5878,7 @@ function backupSQLLane(cur, b, sqlSt) {
   const st = sqlSt && sqlSt.sql_export;
   const lane = backupLane("To load into MySQL",
     [{ name: ".sql files", cap: "your tables" }],
-    "One file, built for whatever moment you pick.");
+    ", built for whatever moment you pick.");
   const body = el("div", { class: "bk-restore-body" });
   // Running used to return null and take the whole card off the page. In a
   // two-lane panel that leaves a hole where an answer was, so the lane stays
@@ -5842,7 +5911,16 @@ function backupSQLLane(cur, b, sqlSt) {
     const row = el("div", { class: "bk-restore-row" },
       el("span", { class: "stg-age", text: "Ready: every table as of " + utcLabel(st.at || "") +
         (st.bytes ? " (" + humanBytes(st.bytes) + " on this machine)" : "") + "." }));
-    if (!st.removal_owed) row.append(dl);
+    // removal_owed means the staged files are owed a removal, so the build is
+    // no longer handed out. Withholding the button under a line that still
+    // leads with "Ready" left the reader with a deadline for a file they
+    // cannot fetch, and the held-download case reaches here with no
+    // staging_error to explain it either.
+    if (st.removal_owed) {
+      row.append(el("span", { class: "form-hint", text: "This build is being cleaned up and can no longer be downloaded. Build again for a fresh copy." }));
+    } else {
+      row.append(dl);
+    }
     body.append(row);
     body.append(el("p", { class: "form-hint", text:
       (st.expires_at ? "The download stays available until " + utcLabel(st.expires_at) + ". " : "") +

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -33,6 +33,13 @@ const TOKEN_KEY = "bintrail_console_token";
 const SERVER_KEY = "bintrail_console_server";
 const ONBOARD_KEY = "bintrail_console_onboarded";
 
+// The generated DuckDB views file, named in two places that must not drift:
+// the Connect AI panel that produces it, and the Backups lane that sends a
+// reader there to get it. Shared rather than guarded -- a constant cannot
+// disagree with itself, and a test comparing two literals only reports the
+// drift after someone ships it.
+const DUCKDB_VIEWS_FILE = "views.sql";
+
 // Export columns. connection_id is INCLUDED (epic #701 D1 — no longer a
 // gated field on the events API; CSV mirrors the JSON view exactly).
 const EVENT_CSV_COLUMNS = [
@@ -3908,14 +3915,6 @@ async function renderBaselines() {
     // collection: it is the answer to "will this list keep growing on its
     // own", and a failed scheduled run has to be visible without opening
     // anything.
-    const scheduleCard = backupScheduleCard(cur, baselines);
-    if (scheduleCard) v.append(scheduleCard);
-    // Directly under the schedule, because the two were the pair #1528 named:
-    // "Automatic backup refresh" and "Scheduled backups" both promised
-    // "backups, automatically" from different pages, for unrelated settings.
-    // Side by side, under names that say what each does, the difference needs
-    // no paragraph.
-    v.append(el("div", { class: "cards" }, backupRefreshCard(backupRefresh)));
     // A visible in-progress region (mirrors the verification page): while a
     // backup is being created or restored, the page must look like a page
     // doing work, not a stale list.
@@ -3929,10 +3928,22 @@ async function renderBaselines() {
       // live watcher.
       watchBackupRuns(cur && cur.id, vgen, running.map((r) => r.kind));
     }
+    // Above the list, because it is the answer to why a reader opened this
+    // page: what do I download to open this in DuckDB, what do I download to
+    // load it into MySQL. It sits BELOW the run region on purpose -- the SQL
+    // lane hands a running build off to it with "its progress is above".
+    const takeAway = backupTakeAway(cur, baselines, sqlSt);
+    if (takeAway) v.append(takeAway);
+    const scheduleCard = backupScheduleCard(cur, baselines);
+    if (scheduleCard) v.append(scheduleCard);
+    // Directly under the schedule, because the two were the pair #1528 named:
+    // "Automatic backup refresh" and "Scheduled backups" both promised
+    // "backups, automatically" from different pages, for unrelated settings.
+    // Side by side, under names that say what each does, the difference needs
+    // no paragraph.
+    v.append(el("div", { class: "cards" }, backupRefreshCard(backupRefresh)));
     const restoreCard = backupRestoreCard(cur, baselines, restoreSt);
     if (restoreCard) v.append(restoreCard);
-    const sqlCard = backupSQLExportCard(cur, baselines, sqlSt);
-    if (sqlCard) v.append(sqlCard);
     v.append(baselinesPanel(baselines, servers, { serversErr: serversErr }));
     // Below the list: what these backups can become, for a reader who has
     // one and wants it in front of a reporting engine (#1466).
@@ -4323,7 +4334,7 @@ function duckdbPanel() {
     el("p", { class: "form-hint", text:
       "The views follow your newest backup where the backup folder supports it. (CLI: bintrail views)" })));
 
-  const btn = el("button", { class: "btn btn-sm", type: "button", text: "Download views.sql" });
+  const btn = el("button", { class: "btn btn-sm", type: "button", text: "Download " + DUCKDB_VIEWS_FILE });
   btn.onclick = async () => {
     btn.disabled = true;
     try {
@@ -4333,7 +4344,7 @@ function duckdbPanel() {
       // Its own name. The browser saves into one folder and overwrites a
       // repeated name without asking, so downloading both would leave the
       // reader with whichever came last and no way to tell which.
-      const name = portable && portable.checked ? "views-portable.sql" : "views.sql";
+      const name = portable && portable.checked ? "views-portable.sql" : DUCKDB_VIEWS_FILE;
       const sql = await apiText("/api/views.sql" + (q.length ? "?" + q.join("&") : ""));
       downloadBlob(name, sql, "text/plain");
       // The instruction used to be a toast, which is the wrong container for the
@@ -5639,7 +5650,111 @@ async function startBackupRestore(id, at, btn, msgEl) {
   if (location.pathname === "/baselines") renderBaselines();
 }
 
-// backupSQLExportCard offers the made-to-measure .sql backup: pick any past
+// ── Take a copy with you ───────────────────────────────────────────────────
+//
+// This page had two downloads and neither could be found. The Parquet
+// .tar.gz sat inside a row's expand with nothing saying the row opened, and
+// the .sql builder was a <details> summary in small caps below three other
+// folds. A reader who wants a copy arrives with one question -- what do I
+// download to open this in DuckDB, what do I download to load it into MySQL
+// -- and had to open two folds to learn there was an answer at all.
+//
+// The two lanes are deliberately NOT symmetrical, and the drawing is what
+// says so before any text does. DuckDB takes two files and one of them is
+// not on this page (the views file moved to Connect AI in #1549), so that
+// lane points at both. MySQL takes one file that does not exist until you
+// pick a moment, so that lane asks for the moment. Dressing them as a
+// matched pair would be a lie about the work each one is.
+function backupTakeAway(cur, b, sqlSt) {
+  const duck = backupDuckLane(b);
+  const sql = backupSQLLane(cur, b, sqlSt);
+  if (!duck && !sql) return null;
+  const panel = el("section", { class: "ov-panel bk-take" });
+  panel.append(el("div", { class: "ov-panel-head" },
+    el("h2", { class: "ov-panel-title", text: "Take a copy with you" })));
+  const lanes = el("div", { class: "bk-lanes" });
+  if (duck) lanes.append(duck);
+  if (sql) lanes.append(sql);
+  panel.append(lanes);
+  return panel;
+}
+
+// backupFilesShape draws the count instead of stating it: two tiles on the
+// DuckDB lane, one on the MySQL lane. A reader who takes nothing else off
+// this panel should still leave knowing that much. Built with el() and CSS
+// like duckdbShape(), never svgEl -- that path is for static icon constants.
+function backupFilesShape(files) {
+  const shape = el("div", { class: "bk-shape" });
+  files.forEach((f, i) => {
+    if (i) shape.append(el("span", { class: "bk-shape-plus", text: "+" }));
+    shape.append(el("div", { class: "bk-file" },
+      el("span", { class: "bk-file-n", text: f.name }),
+      el("span", { class: "bk-file-c", text: f.cap })));
+  });
+  return shape;
+}
+
+function backupLane(title, files, lead) {
+  return el("div", { class: "bk-lane" },
+    el("h3", { class: "bk-lane-t", text: title }),
+    backupFilesShape(files),
+    el("p", { class: "bk-lane-lead", text: lead }));
+}
+
+// The DuckDB lane. Gated on there being a backup at all and nothing else:
+// downloading what is already stored asks for no capability, unlike the
+// build the other lane drives.
+function backupDuckLane(b) {
+  if (!b || b.error || !b.configured) return null;
+  const snaps = (b.snapshots || []);
+  if (!snaps.length) return null;
+  const lane = backupLane("To open in DuckDB",
+    [{ name: "Parquet files", cap: "your tables" },
+     { name: DUCKDB_VIEWS_FILE, cap: "how to read them" }],
+    "Two files. The data, and the file that tells DuckDB how to read it.");
+  const msg = el("p", { class: "form-msg err" });
+  msg.hidden = true;
+  const dl = el("button", { class: "btn", type: "button", text: "Download the data" });
+  dl.onclick = async () => {
+    const err = await downloadNewestBackup(snaps[0].time, dl);
+    msg.textContent = err;
+    msg.hidden = !err;
+  };
+  const views = el("button", { class: "btn btn-ghost", type: "button", text: "Get " + DUCKDB_VIEWS_FILE });
+  views.onclick = () => navigate("connect");
+  lane.append(el("div", { class: "bk-lane-go" }, dl, views), msg);
+  lane.append(el("p", { class: "form-hint", text:
+    "This takes the newest backup, from " + utcLabel(snaps[0].time) + ". Any other one in the list below downloads the same way." }));
+  return lane;
+}
+
+// downloadNewestBackup resolves the size before handing off, because
+// downloadBackup warns above 1 GB (the browser holds the whole archive in
+// memory before the save starts) and that warning is driven by a number the
+// LISTING does not carry. Calling it with a zero would drop the warning
+// silently, which is the failure a shortcut like this invites.
+async function downloadNewestBackup(at, btn) {
+  const label = btn.textContent;
+  btn.disabled = true;
+  btn.textContent = "Checking size…";
+  let d;
+  try {
+    d = await api("/api/baselines/files?at=" + encodeURIComponent(at));
+  } catch (err) {
+    btn.disabled = false;
+    btn.textContent = label;
+    return "Could not read that backup: " + ((err && err.message) || err);
+  }
+  btn.disabled = false;
+  btn.textContent = label;
+  if (d.incomplete) {
+    return "The newest backup is marked incomplete, so it cannot be downloaded. Open another one in the list below.";
+  }
+  downloadBackup(at, btn, d.total_bytes || 0);
+  return "";
+}
+
+// backupSQLLane offers the made-to-measure .sql backup: pick any past
 // moment, the console folds the nearest earlier backup forward to it and
 // packages the result as plain SQL files. Unlike the point-in-time restore it
 // publishes NOTHING: the build lives in a staging directory until it is
@@ -5676,7 +5791,7 @@ function backupElsewhereNote(b, usable) {
     (n === 1 ? "that one" : "those") + " yet." });
 }
 
-function backupSQLExportCard(cur, b, sqlSt) {
+function backupSQLLane(cur, b, sqlSt) {
   if (!capsCache.sql_export || !cur || !cur.id || cur.kind !== "registry") return null;
   if (!b || b.error || !b.configured) return null;
   // b.kind, NOT cur.baseline_dir. cur is the RAW registry entry; the export
@@ -5692,12 +5807,20 @@ function backupSQLExportCard(cur, b, sqlSt) {
   const usable = backupSnapshotsFor(b, b.kind === "dir" ? "dir" : "s3");
   if (!usable.length) return null;
   const st = sqlSt && sqlSt.sql_export;
-  if (st && st.state === "running") return null; // the run region owns it
-  const details = el("details", { class: "form-advanced bk-restore" },
-    el("summary", { class: "form-adv-summary", text: "Build a .sql backup for any moment" }));
+  const lane = backupLane("To load into MySQL",
+    [{ name: ".sql files", cap: "your tables" }],
+    "One file, built for whatever moment you pick.");
   const body = el("div", { class: "bk-restore-body" });
+  // Running used to return null and take the whole card off the page. In a
+  // two-lane panel that leaves a hole where an answer was, so the lane stays
+  // and hands off to the run region above instead of vanishing.
+  if (st && st.state === "running") {
+    body.append(el("p", { class: "form-hint", text: "A build is running. Its progress is above." }));
+    lane.append(body);
+    return lane;
+  }
   body.append(el("p", { class: "form-hint", text:
-    "Pick a past moment. The console takes the backup from just before it, replays the recorded changes up to it, and packages the result as plain SQL files (mydumper format), ready for myloader. Restoring needs nothing from dbtrail. Your database is not touched." }));
+    "Plain SQL files in mydumper format, ready for myloader. Loading them back needs nothing from dbtrail, and your database is never touched: the console starts from the backup before that moment and replays the changes it already recorded." }));
   const input = el("input", { class: "in", type: "text", spellcheck: "false",
     placeholder: "YYYY-MM-DD HH:MM:SS (UTC)" });
   input.value = (usable[0] && usable[0].time) || "";
@@ -5713,7 +5836,6 @@ function backupSQLExportCard(cur, b, sqlSt) {
   if (st && st.state === "failed") {
     body.append(el("p", { class: "form-msg err", text:
       "Last build failed: " + backupFoldError(st.last_error || "unknown error") + " Nothing was built." }));
-    details.open = true;
   } else if (st && st.state === "succeeded") {
     const dl = el("button", { class: "btn", type: "button", text: "Download .sql backup (.tar.gz)" });
     dl.onclick = () => downloadSQLExport(cur.id, dl, st.bytes || 0);
@@ -5725,16 +5847,13 @@ function backupSQLExportCard(cur, b, sqlSt) {
     body.append(el("p", { class: "form-hint", text:
       (st.expires_at ? "The download stays available until " + utcLabel(st.expires_at) + ". " : "") +
       "The file is removed from this machine once you download it, when that time passes, or when a new build starts." }));
-    details.open = true;
   } else if (st && st.state === "downloaded") {
     body.append(el("p", { class: "form-hint", text:
       "Downloaded" + (st.downloaded_at ? " at " + utcLabel(st.downloaded_at) : "") +
       ": the backup as of " + utcLabel(st.at || "") + " was handed over and its file was removed from this machine. Build again for another copy." }));
-    details.open = true;
   } else if (st && st.state === "expired") {
     body.append(el("p", { class: "form-hint", text:
       "The backup built for " + utcLabel(st.at || "") + " is no longer on this machine: it was not downloaded before its deadline, or its files were removed. Build again for a fresh copy." }));
-    details.open = true;
   }
   // The state follows the disk: a removal that failed keeps the build in
   // its previous state and says so here, over a download button that would
@@ -5742,10 +5861,9 @@ function backupSQLExportCard(cur, b, sqlSt) {
   if (st && st.staging_error) {
     body.append(el("p", { class: "form-msg err", text:
       "Staging problem: " + st.staging_error + ". The daemon retries every minute; check the staging directory on the machine running it." }));
-    details.open = true;
   }
-  details.append(body);
-  return details;
+  lane.append(body);
+  return lane;
 }
 
 async function startSQLExport(id, at, btn, msgEl) {

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -3911,15 +3911,6 @@ async function renderBaselines() {
     // so the rows below can carry only what varies between snapshots.
     const cur = servers.find((s) => s.id === (currentServer || defaultServerId));
     v.append(baselineContextStrip(baselines, cur));
-    // The backup schedule (#1442), below the answer and the list. It used to
-    // sit directly under the context strip; the two download lanes took that
-    // spot, because a reader who came to fetch a copy should not scroll past
-    // scheduling to find one. Still ABOVE the fold line for a failed
-    // scheduled run, which has to be visible without opening anything.
-    // Reads, with the facts about the
-    // collection: it is the answer to "will this list keep growing on its
-    // own", and a failed scheduled run has to be visible without opening
-    // anything.
     // A visible in-progress region (mirrors the verification page): while a
     // backup is being created or restored, the page must look like a page
     // doing work, not a stale list.
@@ -3939,6 +3930,12 @@ async function renderBaselines() {
     // lane hands a running build off to it with "its progress is above".
     const takeAway = backupTakeAway(cur, baselines, sqlSt);
     if (takeAway) v.append(takeAway);
+    // The backup schedule (#1442). It used to sit directly under the context
+    // strip; the two download lanes took that spot, because a reader who came
+    // to fetch a copy should not scroll past scheduling to find one. Still
+    // ABOVE the list, because it answers "will this list keep growing on its
+    // own" and a failed scheduled run has to be visible without opening
+    // anything.
     const scheduleCard = backupScheduleCard(cur, baselines);
     if (scheduleCard) v.append(scheduleCard);
     // Directly under the schedule, because the two were the pair #1528 named:
@@ -5016,11 +5013,11 @@ function baselinesPanel(b, servers, opts) {
     const total = b.snapshots.length;
     const pages = Math.max(1, Math.ceil(total / BACKUPS_PAGE_SIZE));
     const page = backupsPageIndex(currentServer || defaultServerId, pages);
-    const window = backupsPageSlice(b.snapshots, page);
+    const pageWindow = backupsPageSlice(b.snapshots, page);
     // idx is the index in the WHOLE list, not in the page: it decides the
     // "Newest" treatment, and paging must not promote the first row of page two.
-    window.rows.forEach((sn, i) => {
-      const idx = window.start + i;
+    pageWindow.rows.forEach((sn, i) => {
+      const idx = pageWindow.start + i;
       const row = el("div", { class: "stg-row" + (idx === 0 ? " stg-row-latest" : "") });
       if (idx === 0) row.append(el("span", { class: "tag-pill", text: "Newest" }));
       row.append(tsSpan("stg-name mono", sn.time));
@@ -5215,17 +5212,29 @@ async function loadBackupDetail(at, box) {
   box.append(tbl);
 }
 
+let backupDownloadBusy = false;
+
 // downloadBackup streams the whole snapshot as one tar.gz. Fetch + blob
 // because the API authenticates via header; a plain link would arrive
 // tokenless on token-auth consoles. The blob buffers the WHOLE archive in
 // browser memory before the save starts — fine for the common case, and the
 // confirm below makes the operator choose it knowingly for a huge one.
 async function downloadBackup(at, btn, totalBytes) {
+  // One at a time, process-wide, and checked before the size prompt: a
+  // repaint (a settling run, or paging) replaces the lane while a download
+  // is still buffering, which leaves the NEW button enabled and a second
+  // click starting a second full archive, both held whole in browser memory.
+  // The flag outlives the node the click came from.
+  if (backupDownloadBusy) {
+    toastError("A backup is already downloading. Wait for that one to finish before starting another.");
+    return;
+  }
   if (totalBytes > 1 << 30 &&
       !window.confirm("This backup weighs " + humanBytes(totalBytes) +
         ". The browser holds all of it in memory before saving. Download anyway?")) {
     return;
   }
+  backupDownloadBusy = true;
   // Restore the caller's OWN label. This used to re-assert the per-row
   // button's text, which is right for that button and renames every other
   // one: the DuckDB lane's "Download the data" became "Download (.tar.gz) ·
@@ -5259,7 +5268,10 @@ async function downloadBackup(at, btn, totalBytes) {
   } catch (err) {
     toastError("Download failed: " + ((err && err.message) || err));
   } finally {
-    if (btn) { btn.disabled = false; btn.textContent = btnLabel; }
+    backupDownloadBusy = false;
+    // Never revive a detached button: it belongs to a repainted lane and
+    // nobody will ever see it again.
+    if (btn && btn.isConnected) { btn.disabled = false; btn.textContent = btnLabel; }
   }
 }
 
@@ -5713,8 +5725,9 @@ function backupTakeAway(cur, b, sqlSt) {
   return panel;
 }
 
-// backupFilesShape draws the count instead of stating it: two tiles on the
-// DuckDB lane, one on the MySQL lane. A reader who takes nothing else off
+// backupFilesShape draws the count instead of stating it: on the DuckDB lane
+// two tiles when Connect AI can produce the views file and one when it
+// cannot, one on the MySQL lane. A reader who takes nothing else off
 // this panel should still leave knowing that much. Built with el() and CSS
 // like duckdbShape(), never svgEl -- that path is for static icon constants.
 function backupFilesShape(files) {
@@ -5768,7 +5781,7 @@ function backupDuckLane(b) {
   if (hasViews) files.push({ name: DUCKDB_VIEWS_FILE, cap: "how to read them" });
   const lane = backupLane("To open in DuckDB", files, hasViews
     ? ". The data, and the file that tells DuckDB how to read it."
-    : ". The data. DuckDB reads the Parquet files directly.");
+    : ". The data, on its own.");
   const msg = el("p", { class: "form-msg err" });
   msg.hidden = true;
   const dl = el("button", { class: "btn", type: "button", text: "Download the data" });
@@ -5793,6 +5806,16 @@ function backupDuckLane(b) {
   lane.append(el("p", { class: "form-hint", text:
     (b.incomplete ? "This takes the newest backup that could be read, from " : "This takes the newest backup, from ") +
     utcLabel(snaps[0].time) + ". Any other one in the list downloads the same way." }));
+  // Say WHY the second file is missing, and do not dress it as a property of
+  // the data. It is withheld by this console's own setting, not by the
+  // backup: the same folder still yields the file from the command line. And
+  // it is not a convenience -- money columns are stored as text in Parquet,
+  // so without it the first SUM a reader writes fails to bind.
+  if (!hasViews) {
+    lane.append(el("p", { class: "form-hint", text:
+      "The file that describes these tables is not offered here, because this console is set not to read archived data. " +
+      "DuckDB still opens the Parquet files, but decimal columns arrive as text, so totals will not add up until you cast them." }));
+  }
   return lane;
 }
 
@@ -5908,9 +5931,17 @@ function backupSQLLane(cur, b, sqlSt) {
   } else if (st && st.state === "succeeded") {
     const dl = el("button", { class: "btn", type: "button", text: "Download .sql backup (.tar.gz)" });
     dl.onclick = () => downloadSQLExport(cur.id, dl, st.bytes || 0);
+    // The lead has to agree with whether the button is there. Adding the
+    // explanation below was not enough: this line still opened with "Ready"
+    // and the paragraph after it still quoted a download deadline, so a build
+    // that cannot be fetched was announced by three sentences, two of which
+    // said it could.
+    const lead = st.removal_owed
+      ? "Built for " + utcLabel(st.at || "") + ", and already being cleaned up."
+      : "Ready: every table as of " + utcLabel(st.at || "") +
+        (st.bytes ? " (" + humanBytes(st.bytes) + " on this machine)" : "") + ".";
     const row = el("div", { class: "bk-restore-row" },
-      el("span", { class: "stg-age", text: "Ready: every table as of " + utcLabel(st.at || "") +
-        (st.bytes ? " (" + humanBytes(st.bytes) + " on this machine)" : "") + "." }));
+      el("span", { class: "stg-age", text: lead }));
     // removal_owed means the staged files are owed a removal, so the build is
     // no longer handed out. Withholding the button under a line that still
     // leads with "Ready" left the reader with a deadline for a file they
@@ -5922,9 +5953,11 @@ function backupSQLLane(cur, b, sqlSt) {
       row.append(dl);
     }
     body.append(row);
-    body.append(el("p", { class: "form-hint", text:
-      (st.expires_at ? "The download stays available until " + utcLabel(st.expires_at) + ". " : "") +
-      "The file is removed from this machine once you download it, when that time passes, or when a new build starts." }));
+    if (!st.removal_owed) {
+      body.append(el("p", { class: "form-hint", text:
+        (st.expires_at ? "The download stays available until " + utcLabel(st.expires_at) + ". " : "") +
+        "The file is removed from this machine once you download it, when that time passes, or when a new build starts." }));
+    }
   } else if (st && st.state === "downloaded") {
     body.append(el("p", { class: "form-hint", text:
       "Downloaded" + (st.downloaded_at ? " at " + utcLabel(st.downloaded_at) : "") +

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -4877,6 +4877,48 @@ function backupIncompleteNotice(b) {
   return box;
 }
 
+// BACKUPS_PAGE_SIZE caps how many backups a page shows.
+//
+// The list is a recency view, not an inventory: what an operator comes here for
+// is the newest few and whether they are fresh. Twenty-five rows pushed the
+// per-row Download and the restore controls below the fold, so the panel read
+// as a wall with nothing to do in it.
+const BACKUPS_PAGE_SIZE = 5;
+
+// backupsPage survives a re-render on purpose. The panel repaints every ~10s
+// while a backup run is in flight (watchBackupRuns), and page state held in the
+// DOM would snap back to the first page under a reader who had paged away.
+// Keyed by server so switching does not land you on page 4 of a list that has
+// two.
+let backupsPage = { server: null, index: 0 };
+
+function backupsPageIndex(serverId, pages) {
+  if (backupsPage.server !== serverId) backupsPage = { server: serverId, index: 0 };
+  // Clamped on READ rather than on write: the list shrinks under you when
+  // retention prunes, and a stored index past the end would render an empty
+  // page with no way back.
+  if (backupsPage.index > pages - 1) backupsPage.index = Math.max(0, pages - 1);
+  return backupsPage.index;
+}
+
+// backupsPager draws the two controls and the position. Rendered only when
+// there is more than one page: a pager under five rows is furniture.
+function backupsPager(total, page, pages, onGo) {
+  if (pages < 2) return null;
+  const from = page * BACKUPS_PAGE_SIZE + 1;
+  const to = Math.min(total, (page + 1) * BACKUPS_PAGE_SIZE);
+  const btn = (label, target, disabled) => {
+    const el2 = el("button", { class: "btn btn-sm", type: "button", text: label });
+    if (disabled) el2.disabled = true;
+    else el2.onclick = () => onGo(target);
+    return el2;
+  };
+  return el("div", { class: "bk-pager" },
+    btn("Newer", page - 1, page === 0),
+    el("span", { class: "bk-pager-n", text: from + "–" + to + " of " + total }),
+    btn("Older", page + 1, page >= pages - 1));
+}
+
 function baselinesPanel(b, servers, opts) {
   // Full-width (#1415): this list is the page. The Create-baseline action
   // moved to the context strip — at page level it is a page action; inside
@@ -4939,7 +4981,14 @@ function baselinesPanel(b, servers, opts) {
     // appears per-row only when it VARIES — a value identical in every row
     // is a fact about the collection and lives in the context strip.
     const uniformTables = snapshotTablesUniform(b.snapshots, b.truncated);
-    b.snapshots.forEach((sn, idx) => {
+    const total = b.snapshots.length;
+    const pages = Math.max(1, Math.ceil(total / BACKUPS_PAGE_SIZE));
+    const page = backupsPageIndex(currentServer || defaultServerId, pages);
+    const start = page * BACKUPS_PAGE_SIZE;
+    // idx is the index in the WHOLE list, not in the page: it decides the
+    // "Newest" treatment, and paging must not promote the first row of page two.
+    b.snapshots.slice(start, start + BACKUPS_PAGE_SIZE).forEach((sn, i) => {
+      const idx = start + i;
       const row = el("div", { class: "stg-row" + (idx === 0 ? " stg-row-latest" : "") });
       if (idx === 0) row.append(el("span", { class: "tag-pill", text: "Newest" }));
       row.append(tsSpan("stg-name mono", sn.time));
@@ -4957,6 +5006,10 @@ function baselinesPanel(b, servers, opts) {
       // once per row, on first open.
       const detail = el("div", { class: "bk-detail" });
       detail.hidden = true;
+      // A chevron, because the only thing that said "this opens" was a hover
+      // background and a pointer cursor. The per-row Download lives inside
+      // this fold, so an invisible affordance hid the whole feature.
+      row.append(el("span", { class: "bk-chev", text: "›" }));
       row.classList.add("bk-expandable");
       row.setAttribute("role", "button");
       row.setAttribute("aria-expanded", "false");
@@ -4970,6 +5023,11 @@ function baselinesPanel(b, servers, opts) {
       };
       list.append(row, detail);
     });
+    const pager = backupsPager(total, page, pages, (target) => {
+      backupsPage = { server: currentServer || defaultServerId, index: target };
+      renderRoute();
+    });
+    if (pager) list.append(pager);
     if (b.truncated) list.append(el("div", { class: "ev-empty", text: "…older backups not shown." }));
   }
   panel.append(list);

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -2793,8 +2793,14 @@ button { font-family: inherit; }
 /* auto-fit, not a fixed 1fr 1fr: the MySQL lane is absent whenever the
    selected server is the ephemeral --index-dsn entry or sql_export is off,
    and a fixed pair left the surviving lane at half width beside an empty
-   column on every desktop viewport. */
-.bk-lanes { display: grid; grid-template-columns: repeat(auto-fit, minmax(340px, 1fr)); gap: 14px; padding: 14px; }
+   column on every desktop viewport.
+
+   300px, not 340: the track budget here is the viewport minus the 248px
+   shell, 96px of view padding and 14px of panel padding, so 340 made a
+   1024px window stack two lanes that 1fr 1fr kept side by side. 300 holds
+   the pair down to about 970px, and the 860px rule below still covers the
+   narrow band. */
+.bk-lanes { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 14px; padding: 14px; }
 @media (max-width: 860px) { .bk-lanes { grid-template-columns: 1fr; } }
 .bk-lane {
   background: var(--surface); border: 1px solid var(--line);

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -2112,6 +2112,30 @@ button { font-family: inherit; }
    treatment; relative age rides beside the absolute time */
 .stg-row-latest { background: var(--violet-tint); border-radius: var(--radius-sm); }
 .stg-rel { font-family: var(--f-mono); font-size: 11px; color: var(--ink-3); white-space: nowrap; }
+/* The newest row is the one tint on this page, so everything it carries has
+   to survive the ground it sits on. Measured with this file's own converter
+   (assets_tint_contrast_test.go), on --violet-tint: --ink-3 is 4.20:1 and
+   --ink-4 is 2.80:1. That put the row's age, its location chip and its
+   chevron all under their floor the moment the tint went on, and the tint
+   is not optional: it marks the copy a restore actually reads.
+
+   The pill is a different case and is NOT a contrast fix, so do not read it
+   as one. Its default ink-2 on surface-3 measures 6.74:1 and was always
+   legible; what it lost on this ground was its EDGE (surface-3 against the
+   tint is 1.09:1). White barely moves that (1.18:1). It takes the white
+   ground because .tcard-violet .tag-pill already does, and one pill on one
+   tint should not have two looks. */
+.stg-row-latest .stg-rel  { color: var(--ink-2); }
+.stg-row-latest .bk-where { color: var(--ink-2); }
+.stg-row-latest .bk-chev  { color: var(--ink-2); }
+.stg-row-latest .tag-pill { background: var(--surface); color: var(--violet-deep); }
+/* Hover must not erase the mark. --surface-2 is LIGHTER than the tint, so
+   pointing at the newest row used to remove the one thing distinguishing
+   it. Keep the ground, add a ring. */
+.stg-row-latest.bk-expandable:hover {
+  background: var(--violet-tint);
+  box-shadow: inset 0 0 0 1px var(--violet-line);
+}
 .vfy-summary { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
 
 /* Verify explain modal: a wider modal + doctor-cards for each diverging row,

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -2737,3 +2737,11 @@ button { font-family: inherit; }
 .bk-made { font-size: 11.5px; color: var(--ink-3); }
 .bk-made-from { color: var(--ink-4); }
 .bk-made-none { color: var(--ink-4); }
+
+/* Backups list paging (#1572). The pager sits under the rows, and the chevron
+   is what says a row opens at all: the per-row Download lives inside that fold,
+   so a hover background was hiding the feature rather than hinting at it. */
+.bk-pager { display: flex; align-items: center; gap: 12px; padding: 10px 14px; border-top: 1px solid var(--line-soft); }
+.bk-pager-n { font-size: 11.5px; color: var(--ink-4); }
+.bk-chev { margin-left: auto; color: var(--ink-4); font-size: 15px; line-height: 1; flex: none; transition: transform .12s ease; }
+.bk-expandable[aria-expanded="true"] .bk-chev { transform: rotate(90deg); }

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -2769,3 +2769,44 @@ button { font-family: inherit; }
 .bk-pager-n { font-size: 11.5px; color: var(--ink-4); }
 .bk-chev { margin-left: auto; color: var(--ink-4); font-size: 15px; line-height: 1; flex: none; transition: transform .12s ease; }
 .bk-expandable[aria-expanded="true"] .bk-chev { transform: rotate(90deg); }
+
+/* ── Take a copy with you: the two lanes ───────────────────────────────────
+   White lanes on the panel's --surface-2, so each reads as a card and not as
+   a region of the panel. Worth knowing when the Iceberg panel below is next
+   touched: its .ice-stage cards are --surface-2 on a --surface-2 ground, so
+   they are separated by a hairline and nothing else. */
+.bk-lanes { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; padding: 14px; }
+@media (max-width: 860px) { .bk-lanes { grid-template-columns: 1fr; } }
+.bk-lane {
+  background: var(--surface); border: 1px solid var(--line);
+  border-radius: var(--radius-sm); padding: 18px;
+  display: flex; flex-direction: column; gap: 10px;
+}
+.bk-lane-t {
+  margin: 0; font-family: var(--f-display); font-size: 15px;
+  font-weight: 600; letter-spacing: -0.01em; color: var(--ink);
+}
+.bk-lane-lead { margin: 0; font-size: 13px; color: var(--ink-2); }
+.bk-lane-go { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+.bk-lane .bk-restore-body { padding: 0; }
+
+/* The drawing: one tile per file. TWO on the DuckDB lane and ONE on the
+   MySQL lane, and that count is the whole message -- it says "this takes two
+   files" before any sentence does. Drawn with el() and these classes, never
+   svgEl (that path is for static icon constants). */
+.bk-shape { display: flex; align-items: flex-start; gap: 10px; padding: 2px 0; }
+.bk-file {
+  position: relative; display: flex; flex-direction: column; gap: 3px;
+  min-width: 104px; padding: 10px 12px 9px;
+  background: var(--surface-3); border: 1px solid var(--line); border-radius: 8px;
+}
+/* the folded corner, so a rectangle reads as a file */
+.bk-file::after {
+  content: ""; position: absolute; top: -1px; right: -1px;
+  border-width: 0 11px 11px 0; border-style: solid;
+  border-color: var(--surface) var(--surface) var(--line) var(--line);
+  border-top-right-radius: 8px;
+}
+.bk-file-n { font-family: var(--f-mono); font-size: 12.5px; font-weight: 500; color: var(--ink); }
+.bk-file-c { font-size: 12px; color: var(--ink-3); }
+.bk-shape-plus { align-self: center; font-size: 15px; color: var(--ink-4); }

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -2113,11 +2113,22 @@ button { font-family: inherit; }
 .stg-row-latest { background: var(--violet-tint); border-radius: var(--radius-sm); }
 .stg-rel { font-family: var(--f-mono); font-size: 11px; color: var(--ink-3); white-space: nowrap; }
 /* The newest row is the one tint on this page, so everything it carries has
-   to survive the ground it sits on. Measured with this file's own converter
-   (assets_tint_contrast_test.go), on --violet-tint: --ink-3 is 4.20:1 and
-   --ink-4 is 2.80:1. That put the row's age, its location chip and its
-   chevron all under their floor the moment the tint went on, and the tint
-   is not optional: it marks the copy a restore actually reads.
+   to survive the ground it sits on. Measured with the converter in
+   assets_tint_contrast_test.go; the rules below are guarded by
+   assets_latest_row_contrast_test.go, which walks what the row RENDERS. On
+   --violet-tint: --ink-3 is 4.20:1 and --ink-4 is 2.80:1.
+
+   The row's age and its location chip had been under their floor since the
+   tint went on. The chevron never was: it arrives in this same change, so it
+   was born under the floor rather than falling below it. The tint itself is
+   not optional -- it marks the copy a restore actually reads.
+
+   The location chip needed its BORDER moved too, not just its ink: it is
+   drawn with --line-soft, which the token block already records as 1.01:1 on
+   violet, invisible. --violet-line is the token that exists for this and
+   measures 1.20:1. The staleness chip next to it needs nothing -- its own
+   --ochre border is 2.14:1 on the tint, so its shape survives the ground its
+   --ochre-bg fill does not.
 
    The pill is a different case and is NOT a contrast fix, so do not read it
    as one. Its default ink-2 on surface-3 measures 6.74:1 and was always
@@ -2126,7 +2137,7 @@ button { font-family: inherit; }
    ground because .tcard-violet .tag-pill already does, and one pill on one
    tint should not have two looks. */
 .stg-row-latest .stg-rel  { color: var(--ink-2); }
-.stg-row-latest .bk-where { color: var(--ink-2); }
+.stg-row-latest .bk-where { color: var(--ink-2); border-color: var(--violet-line); }
 .stg-row-latest .bk-chev  { color: var(--ink-2); }
 .stg-row-latest .tag-pill { background: var(--surface); color: var(--violet-deep); }
 /* Hover must not erase the mark. --surface-2 is LIGHTER than the tint, so
@@ -2766,7 +2777,11 @@ button { font-family: inherit; }
    is what says a row opens at all: the per-row Download lives inside that fold,
    so a hover background was hiding the feature rather than hinting at it. */
 .bk-pager { display: flex; align-items: center; gap: 12px; padding: 10px 14px; border-top: 1px solid var(--line-soft); }
-.bk-pager-n { font-size: 11.5px; color: var(--ink-4); }
+/* --ink-3, not --ink-4: this is the only thing on the page telling a reader
+   where they are in the list, and --ink-4 on --surface-2 is 3.15:1 (the hint
+   floor, not the body one). --ink-3 is 4.74:1. Raised in the same change that
+   lifted three siblings off the floor for the same reason. */
+.bk-pager-n { font-size: 11.5px; color: var(--ink-3); }
 .bk-chev { margin-left: auto; color: var(--ink-4); font-size: 15px; line-height: 1; flex: none; transition: transform .12s ease; }
 .bk-expandable[aria-expanded="true"] .bk-chev { transform: rotate(90deg); }
 
@@ -2775,7 +2790,11 @@ button { font-family: inherit; }
    a region of the panel. Worth knowing when the Iceberg panel below is next
    touched: its .ice-stage cards are --surface-2 on a --surface-2 ground, so
    they are separated by a hairline and nothing else. */
-.bk-lanes { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; padding: 14px; }
+/* auto-fit, not a fixed 1fr 1fr: the MySQL lane is absent whenever the
+   selected server is the ephemeral --index-dsn entry or sql_export is off,
+   and a fixed pair left the surviving lane at half width beside an empty
+   column on every desktop viewport. */
+.bk-lanes { display: grid; grid-template-columns: repeat(auto-fit, minmax(340px, 1fr)); gap: 14px; padding: 14px; }
 @media (max-width: 860px) { .bk-lanes { grid-template-columns: 1fr; } }
 .bk-lane {
   background: var(--surface); border: 1px solid var(--line);
@@ -2790,7 +2809,10 @@ button { font-family: inherit; }
 .bk-lane-go { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
 .bk-lane .bk-restore-body { padding: 0; }
 
-/* The drawing: one tile per file. TWO on the DuckDB lane and ONE on the
+/* The drawing: one tile per DOWNLOAD, not per file -- the Parquet tile is a
+   whole folder arriving as one .tar.gz, so counting files would be wrong by
+   hundreds. TWO on the DuckDB lane (when Connect AI can produce the views
+   file) and ONE on the
    MySQL lane, and that count is the whole message -- it says "this takes two
    files" before any sentence does. Drawn with el() and these classes, never
    svgEl (that path is for static icon constants). */

--- a/internal/console/assets_backup_sources_test.go
+++ b/internal/console/assets_backup_sources_test.go
@@ -105,7 +105,7 @@ func TestBackupJobCardsOfferOnlyWhatTheirJobCanRead(t *testing.T) {
 	exportCard := stripJSLineComments(functionBody(t, js, "function backupSQLLane("))
 	if strings.Contains(exportCard, "cur.baseline_dir") {
 		t.Error("the .sql lane gates on cur.baseline_dir, which is the RAW registry entry. " +
-			"A server inheriting the daemon-wide backup location has none, so the card either " +
+			"A server inheriting the daemon-wide backup location has none, so the lane either " +
 			"vanishes or defaults to a snapshot the build cannot read")
 	}
 	if !strings.Contains(exportCard, `backupSnapshotsFor(b, b.kind === "dir" ? "dir" : "s3")`) {

--- a/internal/console/assets_backup_sources_test.go
+++ b/internal/console/assets_backup_sources_test.go
@@ -201,3 +201,32 @@ func stripJSLineComments(body string) string {
 	}
 	return b.String()
 }
+
+// downloadBackup is shared by the per-row button and the DuckDB lane's, and
+// it re-enables whichever one it was given when the transfer ends. It used to
+// re-assert the PER-ROW label there, so one click renamed the lane's
+// "Download the data" to "Download (.tar.gz) · 210 MB" for good -- and the
+// next click captured the clobbered text as its own label.
+//
+// Source-level on purpose: no test renders a button, clicks it through a real
+// transfer and reads the label back, so this is what stands between that bug
+// and a second appearance.
+func TestDownloadBackupRestoresTheLabelItWasGiven(t *testing.T) {
+	body := stripJSLineComments(functionBody(t, readAsset(t, "app.js"), "async function downloadBackup("))
+	if !strings.Contains(body, "const btnLabel = btn ? btn.textContent") {
+		t.Error("downloadBackup no longer captures the caller's own button label")
+	}
+	if strings.Contains(body, `btn.textContent = "Download (.tar.gz) · "`) {
+		t.Error("downloadBackup re-asserts the per-row button's label. That is right for that one " +
+			"button and renames every other caller's: the DuckDB lane's button loses its name " +
+			"after a single click, and the click after that adopts the wrong one")
+	}
+	if !strings.Contains(body, "btn.isConnected") {
+		t.Error("downloadBackup revives a button that may have been detached by a repaint. The " +
+			"node belongs to a lane nobody will see again, and the visible button is a different one")
+	}
+	if !strings.Contains(body, "backupDownloadBusy") {
+		t.Error("nothing serialises whole-archive downloads. A repaint mid-transfer leaves the new " +
+			"button enabled, and a second click buffers a second full archive in browser memory")
+	}
+}

--- a/internal/console/assets_backup_sources_test.go
+++ b/internal/console/assets_backup_sources_test.go
@@ -102,14 +102,14 @@ func TestBackupJobCardsOfferOnlyWhatTheirJobCanRead(t *testing.T) {
 	// Comments stripped first. This function's own comment explains why
 	// cur.baseline_dir is the wrong field here, and a raw substring check reads
 	// that explanation as the mistake it warns about.
-	exportCard := stripJSLineComments(functionBody(t, js, "function backupSQLExportCard("))
+	exportCard := stripJSLineComments(functionBody(t, js, "function backupSQLLane("))
 	if strings.Contains(exportCard, "cur.baseline_dir") {
-		t.Error("the .sql-export card gates on cur.baseline_dir, which is the RAW registry entry. " +
+		t.Error("the .sql lane gates on cur.baseline_dir, which is the RAW registry entry. " +
 			"A server inheriting the daemon-wide backup location has none, so the card either " +
 			"vanishes or defaults to a snapshot the build cannot read")
 	}
 	if !strings.Contains(exportCard, `backupSnapshotsFor(b, b.kind === "dir" ? "dir" : "s3")`) {
-		t.Error("the .sql-export card does not choose its default from the location the build " +
+		t.Error("the .sql lane does not choose its default from the location the build " +
 			"will actually read")
 	}
 
@@ -122,7 +122,7 @@ func TestBackupJobCardsOfferOnlyWhatTheirJobCanRead(t *testing.T) {
 		t.Error("the restore card does not narrow to the snapshots its fold can read")
 	}
 
-	for _, fn := range []string{"function backupSQLExportCard(", "function backupRestoreCard("} {
+	for _, fn := range []string{"function backupSQLLane(", "function backupRestoreCard("} {
 		if strings.Contains(stripJSLineComments(functionBody(t, js, fn)), "b.snapshots[0]") {
 			t.Errorf("%s still defaults to the merged newest snapshot, which its job may not be "+
 				"able to read", fn)

--- a/internal/console/assets_backups_paging_test.go
+++ b/internal/console/assets_backups_paging_test.go
@@ -1,0 +1,107 @@
+package console
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestBackupsListPagesAndSaysItOpens guards the two halves of #1572.
+//
+// The list showed every backup it had, which pushed the per-row Download and
+// the restore controls below the fold on a server with a real retention
+// history. And the only thing that said a row OPENS was a hover background and
+// a pointer cursor, so the download lived behind an affordance nobody could
+// see. Both are UI-only; no Go test in this package can reach them.
+func TestBackupsListPagesAndSaysItOpens(t *testing.T) {
+	raw, err := os.ReadFile("assets/app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	js := string(raw)
+	panel := functionBody(t, js, "function baselinesPanel(")
+
+	if !strings.Contains(panel, "BACKUPS_PAGE_SIZE") || !strings.Contains(panel, ".slice(start,") {
+		t.Error("the list is not paged; every backup renders and the per-row Download goes below the fold")
+	}
+	if !strings.Contains(panel, "backupsPager(") {
+		t.Error("the panel renders no pager, so a reader on page one cannot reach page two")
+	}
+	// The row treatment is decided by position in the WHOLE list. Taking it
+	// from the page would crown the first row of every page "Newest", which is
+	// a claim about which backup a restore uses.
+	if !strings.Contains(panel, "const idx = start + i") {
+		t.Error("the row index is not offset by the page; the first row of page two would be " +
+			"labelled Newest and given the treatment reserved for the backup restores use")
+	}
+	if !strings.Contains(panel, `class: "bk-chev"`) {
+		t.Error("rows carry no chevron. The per-row Download lives inside the fold a click opens, " +
+			"so with no visible affordance the feature is unreachable in practice")
+	}
+
+	// Page state must OUTLIVE a render: the panel repaints every ~10s while a
+	// run is in flight, and state held in the DOM would snap a reader back to
+	// page one under their hands.
+	if !strings.Contains(js, "let backupsPage = {") {
+		t.Error("page state is not held outside the render, so a repaint resets it")
+	}
+}
+
+// backupsPageIndex is pure, so it is EXECUTED. The clamp is the half that only
+// shows up when the list SHRINKS under a reader who had paged away, which no
+// source assertion can express.
+func TestBackupsPageIndexClamps(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		if os.Getenv(requireNodeEnv) != "" {
+			t.Fatalf("%s is set and node is not on PATH", requireNodeEnv)
+		}
+		t.Skip("node is not installed")
+	}
+	raw, err := os.ReadFile("assets/app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	js := string(raw)
+	script := "let backupsPage = { server: null, index: 0 };\n" +
+		functionBody(t, js, "function backupsPageIndex(") + `
+const out = {};
+out.first = backupsPageIndex("a", 5);
+backupsPage.index = 3;
+out.kept = backupsPageIndex("a", 5);
+out.shrunk = backupsPageIndex("a", 2);          // retention pruned the list
+out.switched = backupsPageIndex("b", 5);        // another server
+out.noPages = backupsPageIndex("c", 0);         // nothing to show
+console.log(JSON.stringify(out));
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "page.js")
+	if err := os.WriteFile(path, []byte(script), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := exec.Command(node, path).Output()
+	if err != nil {
+		t.Fatalf("node: %v", err)
+	}
+	var got struct{ First, Kept, Shrunk, Switched, NoPages int }
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("decode %q: %v", out, err)
+	}
+	if got.First != 0 || got.Kept != 3 {
+		t.Errorf("first=%d kept=%d, want 0 and 3 — the chosen page has to survive a repaint", got.First, got.Kept)
+	}
+	if got.Shrunk != 1 {
+		t.Errorf("a list that shrank to 2 pages left the reader on index %d; anything past the end "+
+			"renders an empty page with no way back", got.Shrunk)
+	}
+	if got.Switched != 0 {
+		t.Errorf("switching server kept index %d; page 4 of a two-page list is not where a "+
+			"different server's history starts", got.Switched)
+	}
+	if got.NoPages != 0 {
+		t.Errorf("an empty list gave index %d, want 0", got.NoPages)
+	}
+}

--- a/internal/console/assets_backups_paging_test.go
+++ b/internal/console/assets_backups_paging_test.go
@@ -28,8 +28,25 @@ func TestBackupsListPagesAndSaysItOpens(t *testing.T) {
 	panel := stripJSLineComments(functionBody(t, js, "function baselinesPanel("))
 	js = stripJSLineComments(js)
 
-	if !strings.Contains(panel, "backupsPageSlice(") {
-		t.Error("the list is not paged; every backup renders and the per-row Download goes below the fold")
+	// The ARGUMENT, not just the call. Both halves are pure and both are
+	// executed by tests, but their composition is not: passing a literal 0
+	// here keeps every other assertion green while Older goes dead, page two
+	// renders page one's rows, and every page crowns its first row "Newest".
+	if !strings.Contains(panel, "backupsPageSlice(b.snapshots, page)") {
+		t.Error("the list does not window itself by the CLAMPED page. Either it is not paged at " +
+			"all, or it is sliced from a page index that did not come from backupsPageIndex, which " +
+			"is what keeps a reader off a page the list no longer has")
+	}
+	if !strings.Contains(panel, "backupsPageIndex(") {
+		t.Error("the page index is not clamped on read, so a list that shrinks under a viewer " +
+			"leaves them on an empty page with no way back")
+	}
+	// truncated reaches the pager or its count lies: /api/baselines caps the
+	// listing and says so, and "46-50 of 50" for a server with 200 backups is
+	// the one line on the page asserting an inventory the API disclaimed.
+	if !strings.Contains(panel, "!!b.truncated") {
+		t.Error("the pager is not told the listing was capped, so its count reads as a complete " +
+			"inventory of a list the API explicitly truncated")
 	}
 	if !strings.Contains(panel, "backupsPager(") {
 		t.Error("the panel renders no pager, so a reader on page one cannot reach page two")
@@ -37,7 +54,11 @@ func TestBackupsListPagesAndSaysItOpens(t *testing.T) {
 	// The row treatment is decided by position in the WHOLE list. Taking it
 	// from the page would crown the first row of every page "Newest", which is
 	// a claim about which backup a restore uses.
-	if !strings.Contains(panel, "window.start + i") {
+	// Matched on the SHAPE, not on the local's name: pinning the identifier
+	// coupled this guard to a variable that had to be renamed (it was called
+	// `window`, which shadows the browser global inside the block the row
+	// handlers close over).
+	if !regexp.MustCompile(`\.start \+ i\b`).MatchString(panel) {
 		t.Error("the row index is not offset by the page; the first row of page two would be " +
 			"labelled Newest and given the treatment reserved for the backup restores use")
 	}

--- a/internal/console/assets_backups_paging_test.go
+++ b/internal/console/assets_backups_paging_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -22,9 +23,12 @@ func TestBackupsListPagesAndSaysItOpens(t *testing.T) {
 		t.Fatal(err)
 	}
 	js := string(raw)
-	panel := functionBody(t, js, "function baselinesPanel(")
+	// Stripped: every check below is a substring test, and a comment line
+	// mentioning one of these names would satisfy it without any code doing so.
+	panel := stripJSLineComments(functionBody(t, js, "function baselinesPanel("))
+	js = stripJSLineComments(js)
 
-	if !strings.Contains(panel, "BACKUPS_PAGE_SIZE") || !strings.Contains(panel, ".slice(start,") {
+	if !strings.Contains(panel, "backupsPageSlice(") {
 		t.Error("the list is not paged; every backup renders and the per-row Download goes below the fold")
 	}
 	if !strings.Contains(panel, "backupsPager(") {
@@ -33,7 +37,7 @@ func TestBackupsListPagesAndSaysItOpens(t *testing.T) {
 	// The row treatment is decided by position in the WHOLE list. Taking it
 	// from the page would crown the first row of every page "Newest", which is
 	// a claim about which backup a restore uses.
-	if !strings.Contains(panel, "const idx = start + i") {
+	if !strings.Contains(panel, "window.start + i") {
 		t.Error("the row index is not offset by the page; the first row of page two would be " +
 			"labelled Newest and given the treatment reserved for the backup restores use")
 	}
@@ -104,4 +108,67 @@ console.log(JSON.stringify(out));
 	if got.NoPages != 0 {
 		t.Errorf("an empty list gave index %d, want 0", got.NoPages)
 	}
+}
+
+// The page window, EXECUTED. The source assertions above can only see that
+// baselinesPanel calls backupsPageSlice; they cannot see whether it returns
+// the right rows. Rewriting `start` to 0 kept every string the old guard
+// required while making Older a dead control -- that mutation is what this
+// test exists to kill.
+func TestBackupsPageSliceWindowsTheList(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		if os.Getenv(requireNodeEnv) != "" {
+			t.Fatalf("%s is set and node is not on PATH", requireNodeEnv)
+		}
+		t.Skip("node is not installed")
+	}
+	raw, err := os.ReadFile("assets/app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	js := string(raw)
+	script := "const BACKUPS_PAGE_SIZE = " + backupsPageSizeFromSource(t, js) + ";\n" +
+		functionBody(t, js, "function backupsPageSlice(") + `
+const list = [];
+for (let i = 0; i < 8; i++) list.push({ n: i });
+const out = {};
+const p0 = backupsPageSlice(list, 0), p1 = backupsPageSlice(list, 1);
+out.p0start = p0.start;
+out.p0 = p0.rows.map((r) => r.n).join(",");
+out.p1start = p1.start;
+out.p1 = p1.rows.map((r) => r.n).join(",");
+console.log(JSON.stringify(out));
+`
+	cmd := exec.Command(node, "-e", script)
+	outBytes, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("node: %v\n%s", err, outBytes)
+	}
+	var got struct {
+		P0start, P1start int
+		P0, P1           string
+	}
+	if err := json.Unmarshal(outBytes, &got); err != nil {
+		t.Fatalf("parsing node output %q: %v", outBytes, err)
+	}
+	// Page one is the newest five. Page two CONTINUES the list; it does not
+	// restart it, and its offset is what keeps the "Newest" treatment on the
+	// backup a restore actually reads.
+	if got.P0start != 0 || got.P0 != "0,1,2,3,4" {
+		t.Errorf("page one is {start:%d, rows:%s}, want {0, 0,1,2,3,4}", got.P0start, got.P0)
+	}
+	if got.P1start != 5 || got.P1 != "5,6,7" {
+		t.Errorf("page two is {start:%d, rows:%s}, want {5, 5,6,7} — a page that restarts at 0 "+
+			"makes Older a dead control and re-crowns a row Newest on every page", got.P1start, got.P1)
+	}
+}
+
+func backupsPageSizeFromSource(t *testing.T, js string) string {
+	t.Helper()
+	m := regexp.MustCompile(`const BACKUPS_PAGE_SIZE = (\d+);`).FindStringSubmatch(js)
+	if m == nil {
+		t.Fatal("BACKUPS_PAGE_SIZE is gone from app.js")
+	}
+	return m[1]
 }

--- a/internal/console/assets_latest_row_contrast_test.go
+++ b/internal/console/assets_latest_row_contrast_test.go
@@ -24,18 +24,18 @@ const latestRowGround = "violet-tint"
 
 // What the newest row renders. Kept explicit because one of these is NOT
 // visible from the row builder: .bk-where is produced by backupWhereChip(),
-// several hundred lines away, and a regex over the builder block would miss
+// well over a hundred lines away, and a regex over the builder block would miss
 // exactly the child that was worst off. latestRowChildrenAreAllListed below
 // is the anti-rot half -- a class appended directly to the row fails until
 // it is named here.
 var latestRowChildren = []string{
-	"tag-pill",  // "Newest"
-	"stg-name",  // the timestamp
-	"stg-rel",   // the age
-	"stg-dest",  // tables / binlog coordinates
-	"chip-mon",  // staleness, newest row only
-	"bk-where",  // from backupWhereChip()
-	"bk-chev",   // the expand affordance
+	"tag-pill", // "Newest"
+	"stg-name", // the timestamp
+	"stg-rel",  // the age
+	"stg-dest", // tables / binlog coordinates
+	"chip-mon", // staleness, newest row only
+	"bk-where", // from backupWhereChip()
+	"bk-chev",  // the expand affordance
 }
 
 func TestNewestBackupRowClearsItsFloorOnTheTint(t *testing.T) {
@@ -44,7 +44,12 @@ func TestNewestBackupRowClearsItsFloorOnTheTint(t *testing.T) {
 	for _, class := range latestRowChildren {
 		tok := effectiveDecl(css, class, "color")
 		if tok == "" {
-			continue // inherits from the row; the row's own ink is covered by the tint-token test
+			// Genuinely inherits: it declares no colour of its own anywhere.
+			// This used to be reached by .chip-mon too, not because it
+			// inherits (it sets --orange-2) but because its rule is written
+			// as the compound .chip.chip-mon and the lookup missed it. See
+			// selectorTargets.
+			continue
 		}
 		// A child may bring its own ground (the pill does, and must: see the
 		// .tcard-violet precedent). Measure against whatever it actually sits
@@ -54,9 +59,13 @@ func TestNewestBackupRowClearsItsFloorOnTheTint(t *testing.T) {
 			ground, groundName = anyToken(t, css, bg), bg
 		}
 		if r := wcagRatioHex(anyToken(t, css, tok), ground); r < 4.5 {
-			t.Errorf(".stg-row-latest .%s renders var(--%s) on --%s = %.2f:1, below the 4.5:1 "+
-				"floor. The tint is not optional (it marks the copy in use), so the fix is to "+
-				"override this child under .stg-row-latest, not to drop the tint.", class, tok, groundName, r)
+			why := "The tint is not optional (it marks the copy in use), so the fix is to override " +
+				"this child under .stg-row-latest, not to drop the tint."
+			if groundName != latestRowGround {
+				why = "That is this child's OWN ground, so the row is not what put it under the floor."
+			}
+			t.Errorf(".stg-row-latest .%s renders var(--%s) on --%s = %.2f:1, below the 4.5:1 floor. %s",
+				class, tok, groundName, r, why)
 		}
 	}
 }
@@ -96,10 +105,38 @@ func TestNewestBackupRowChildrenAreAllListed(t *testing.T) {
 	for _, c := range latestRowChildren {
 		known[c] = true
 	}
-	for _, m := range regexp.MustCompile(`class: "([^"]+)"`).FindAllStringSubmatch(js[start:end], -1) {
-		for _, c := range strings.Fields(m[1]) {
-			if c == "stg-row" || c == "stg-row-latest" || c == "bk-detail" ||
-				c == "mono" || c == "chip" || c == "bk-expandable" || known[c] {
+	defined := definedClasses(string(readStyleCSS(t)))
+	skip := map[string]bool{"stg-row": true, "stg-row-latest": true, "bk-detail": true,
+		"mono": true, "chip": true, "bk-expandable": true}
+	// Every quoted string in the span, not just class: "...". The row builds
+	// one child as tsSpan("stg-name mono", ...) -- a class list passed
+	// POSITIONALLY, which a class:-anchored regex cannot see, and .stg-name is
+	// one of the very children this check exists to keep honest. A string
+	// counts as a class list when every one of its tokens is a class the
+	// stylesheet defines, which no prose string satisfies.
+	for _, m := range regexp.MustCompile(`"([^"\n]+)"`).FindAllStringSubmatch(js[start:end], -1) {
+		fields := strings.Fields(m[1])
+		if len(fields) == 0 {
+			continue
+		}
+		// A single bare word is rejected even when it names a class: the row
+		// compares sn.staleness against "ok", and .ok exists, so accepting it
+		// made the guard fail on a literal that renders nothing. Requiring a
+		// hyphen or a second token separates this file's class vocabulary
+		// (stg-name, bk-chev) from English. The gap that leaves: a positional
+		// single-word un-hyphenated class would still be missed.
+		looksLikeClasses := len(fields) > 1 || strings.Contains(fields[0], "-")
+		for _, f := range fields {
+			if !defined[f] {
+				looksLikeClasses = false
+				break
+			}
+		}
+		if !looksLikeClasses {
+			continue
+		}
+		for _, c := range fields {
+			if skip[c] || known[c] {
 				continue
 			}
 			t.Errorf("the newest backup row renders .%s, which no contrast check covers. Add it to "+
@@ -124,7 +161,13 @@ func effectiveDecl(css, class, prop string) string {
 }
 
 // ruleBody returns the declarations of the first rule whose selector list
-// contains sel as a whole selector.
+// contains sel.
+//
+// "Contains" is compound-aware, and that is not a nicety: the staleness chip's
+// rule is written `.chip.chip-mon`, so an exact string comparison found
+// nothing, effectiveDecl returned "" and the caller skipped the child while
+// still listing it as covered. A guard that reports six of seven measured is
+// worse than one that measures six, because the seventh looks guarded.
 func ruleBody(css, sel string) string {
 	// Comments are stripped first: splitting raw CSS on "}" leaves the comment
 	// that documents a rule glued to the front of its selector, so every
@@ -136,8 +179,8 @@ func ruleBody(css, sel string) string {
 		if open < 0 {
 			continue
 		}
-		for _, s := range strings.Split(block[:open], ",") {
-			if strings.TrimSpace(s) == sel {
+		for _, cand := range strings.Split(block[:open], ",") {
+			if selectorTargets(strings.TrimSpace(cand), sel) {
 				return block[open+1:]
 			}
 		}
@@ -179,4 +222,49 @@ func TestNewestBackupRowPillMatchesTheOtherVioletPill(t *testing.T) {
 
 func norm(decls string) string {
 	return strings.Join(strings.Fields(strings.ReplaceAll(decls, "\n", " ")), " ")
+}
+
+// selectorTargets reports whether CSS selector cand styles the element that
+// sel names. Both are compared descendant-part by descendant-part, and the
+// LAST part is compared as a SET of classes: `.chip.chip-mon` targets
+// `.chip-mon`, and `.stg-row-latest .chip.chip-mon` targets
+// `.stg-row-latest .chip-mon`. Anything with a pseudo, an attribute or a
+// combinator is left alone -- those style a state, not the resting element
+// this file measures.
+func selectorTargets(cand, sel string) bool {
+	if strings.ContainsAny(cand, ":[>+~*") {
+		return cand == sel
+	}
+	cp, sp := strings.Fields(cand), strings.Fields(sel)
+	if len(cp) != len(sp) {
+		return false
+	}
+	for i := range cp {
+		if i < len(cp)-1 {
+			if cp[i] != sp[i] {
+				return false
+			}
+			continue
+		}
+		have := map[string]bool{}
+		for _, c := range strings.Split(strings.TrimPrefix(cp[i], "."), ".") {
+			have[c] = true
+		}
+		for _, want := range strings.Split(strings.TrimPrefix(sp[i], "."), ".") {
+			if !have[want] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// definedClasses collects every class name the stylesheet defines, which is
+// what lets the scan above tell a class list from any other string literal.
+func definedClasses(css string) map[string]bool {
+	out := map[string]bool{}
+	for _, m := range regexp.MustCompile(`\.([a-zA-Z][a-zA-Z0-9_-]*)`).FindAllStringSubmatch(css, -1) {
+		out[m[1]] = true
+	}
+	return out
 }

--- a/internal/console/assets_latest_row_contrast_test.go
+++ b/internal/console/assets_latest_row_contrast_test.go
@@ -44,11 +44,19 @@ func TestNewestBackupRowClearsItsFloorOnTheTint(t *testing.T) {
 	for _, class := range latestRowChildren {
 		tok := effectiveDecl(css, class, "color")
 		if tok == "" {
-			// Genuinely inherits: it declares no colour of its own anywhere.
-			// This used to be reached by .chip-mon too, not because it
-			// inherits (it sets --orange-2) but because its rule is written
-			// as the compound .chip.chip-mon and the lookup missed it. See
-			// selectorTargets.
+			// Two very different things reach here and only one is benign.
+			// Benign: the class declares no colour anywhere and inherits.
+			// Not benign: it declares one this reader cannot resolve -- a
+			// literal hex, or a rule behind a combinator or an at-rule -- in
+			// which case the child is listed as covered and measured never.
+			// (.chip-mon used to land here for a third reason, a compound
+			// selector; see selectorTargets.)
+			if declaresUnreadableColor(css, class) {
+				t.Errorf(".%s declares a colour this test cannot resolve (not a var(--token)). It "+
+					"would be listed as covered and never measured, which is the failure this file "+
+					"exists to prevent. Teach the reader that notation rather than leaving the "+
+					"child silently skipped.", class)
+			}
 			continue
 		}
 		// A child may bring its own ground (the pill does, and must: see the
@@ -57,6 +65,17 @@ func TestNewestBackupRowClearsItsFloorOnTheTint(t *testing.T) {
 		ground, groundName := ground, latestRowGround
 		if bg := effectiveDecl(css, class, "background"); bg != "" {
 			ground, groundName = anyToken(t, css, bg), bg
+		}
+		// A border is what draws a chip against the row. .bk-where lost its
+		// shape at 1.01:1 for a whole release and no assertion noticed,
+		// because this file only ever measured ink. 1.15 is the separation
+		// floor the token block documents (--violet-line clears it at 1.20).
+		if bt := effectiveBorderToken(css, class); bt != "" {
+			if r := wcagRatioHex(anyToken(t, css, bt), ground); r < 1.15 {
+				t.Errorf(".stg-row-latest .%s draws its border in var(--%s), %.2f:1 against --%s. "+
+					"Below 1.15 the outline is gone and the chip has no shape; --violet-line is "+
+					"the token that exists for this ground.", class, bt, r, groundName)
+			}
 		}
 		if r := wcagRatioHex(anyToken(t, css, tok), ground); r < 4.5 {
 			why := "The tint is not optional (it marks the copy in use), so the fix is to override " +
@@ -267,4 +286,62 @@ func definedClasses(css string) map[string]bool {
 		out[m[1]] = true
 	}
 	return out
+}
+
+// declaresUnreadableColor reports whether a rule for class sets a colour that
+// effectiveDecl cannot read. Its whole purpose is to turn a silent skip into
+// a failure: "declares nothing" and "declares something I cannot parse" look
+// identical to the caller, and only one of them is safe.
+func declaresUnreadableColor(css, class string) bool {
+	for _, sel := range []string{".stg-row-latest ." + class, "." + class} {
+		body := ruleBody(css, sel)
+		if body == "" {
+			continue
+		}
+		if regexp.MustCompile(`(^|[;{\s])color:`).MatchString(body) {
+			return true // a colour is set here; effectiveDecl already failed to read it
+		}
+	}
+	return false
+}
+
+// The pager's position line is not a child of the newest row, so the walk
+// above cannot see it -- and it was shipped at 3.15:1 in the very change that
+// lifted three siblings off the floor. It is the only thing on the page that
+// tells a reader where they are in the list.
+func TestBackupsPagerNumberClearsTheBodyFloor(t *testing.T) {
+	css := string(readStyleCSS(t))
+	tok := effectiveDecl(css, "bk-pager-n", "color")
+	if tok == "" {
+		t.Fatal("no .bk-pager-n colour rule: if the pager's position line moved, re-point this " +
+			"rather than deleting it")
+	}
+	// --surface-2 is --panel-bg, the ground .stg-list sits on inside .ov-panel.
+	if r := wcagRatioHex(anyToken(t, css, tok), anyToken(t, css, "surface-2")); r < 4.5 {
+		t.Errorf(".bk-pager-n is var(--%s) on --surface-2 = %.2f:1, below the 4.5:1 body floor. "+
+			"This line is the only thing saying which page the reader is on", tok, r)
+	}
+}
+
+// effectiveBorderToken resolves a child's border colour, reading BOTH the
+// longhand and the shorthand. Reading only `border-color:` was a survivor:
+// .bk-where declares `border: 1px solid var(--line-soft)`, so dropping the
+// row's override left the check with nothing to read and it skipped -- the
+// same silent-skip shape as an unreadable colour, one property over.
+func effectiveBorderToken(css, class string) string {
+	longhand := regexp.MustCompile(`border-color:\s*var\(--([a-z0-9-]+)\)`)
+	shorthand := regexp.MustCompile(`border:[^;}]*var\(--([a-z0-9-]+)\)`)
+	for _, sel := range []string{".stg-row-latest ." + class, "." + class} {
+		body := ruleBody(css, sel)
+		if body == "" {
+			continue
+		}
+		if m := longhand.FindStringSubmatch(body); m != nil {
+			return m[1]
+		}
+		if m := shorthand.FindStringSubmatch(body); m != nil {
+			return m[1]
+		}
+	}
+	return ""
 }

--- a/internal/console/assets_latest_row_contrast_test.go
+++ b/internal/console/assets_latest_row_contrast_test.go
@@ -1,0 +1,182 @@
+package console
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The newest backup row is the one tinted row on the Backups page, and the
+// tint is load-bearing: it marks the copy Time-travel and a restore actually
+// read. Everything the row carries therefore sits on --violet-tint instead of
+// on the page ground, and three of its children were below their floor the
+// moment the tint went on: the age at --ink-3 (4.20:1), the location chip and
+// the chevron at --ink-4 (2.80:1), plus a pill whose --surface-3 ground on
+// violet is 1.09:1 -- the mark was invisible on the only row that wears it.
+//
+// TestTintGroundsHoldTheAAFloorForTheirBodyText already measures the TOKENS
+// and its comment says outright that --ink-3 on violet fails "which is
+// exactly why nothing may use it there". Nothing checked that no SELECTOR
+// used it there, so every one of these shipped green. This is that check:
+// it walks what the row actually renders and resolves the cascade the way
+// the browser does, overrides first.
+const latestRowGround = "violet-tint"
+
+// What the newest row renders. Kept explicit because one of these is NOT
+// visible from the row builder: .bk-where is produced by backupWhereChip(),
+// several hundred lines away, and a regex over the builder block would miss
+// exactly the child that was worst off. latestRowChildrenAreAllListed below
+// is the anti-rot half -- a class appended directly to the row fails until
+// it is named here.
+var latestRowChildren = []string{
+	"tag-pill",  // "Newest"
+	"stg-name",  // the timestamp
+	"stg-rel",   // the age
+	"stg-dest",  // tables / binlog coordinates
+	"chip-mon",  // staleness, newest row only
+	"bk-where",  // from backupWhereChip()
+	"bk-chev",   // the expand affordance
+}
+
+func TestNewestBackupRowClearsItsFloorOnTheTint(t *testing.T) {
+	css := string(readStyleCSS(t))
+	ground := cssHexToken(t, []byte(css), latestRowGround)
+	for _, class := range latestRowChildren {
+		tok := effectiveDecl(css, class, "color")
+		if tok == "" {
+			continue // inherits from the row; the row's own ink is covered by the tint-token test
+		}
+		// A child may bring its own ground (the pill does, and must: see the
+		// .tcard-violet precedent). Measure against whatever it actually sits
+		// on, not against the row, or the correct fix reads as a failure.
+		ground, groundName := ground, latestRowGround
+		if bg := effectiveDecl(css, class, "background"); bg != "" {
+			ground, groundName = anyToken(t, css, bg), bg
+		}
+		if r := wcagRatioHex(anyToken(t, css, tok), ground); r < 4.5 {
+			t.Errorf(".stg-row-latest .%s renders var(--%s) on --%s = %.2f:1, below the 4.5:1 "+
+				"floor. The tint is not optional (it marks the copy in use), so the fix is to "+
+				"override this child under .stg-row-latest, not to drop the tint.", class, tok, groundName, r)
+		}
+	}
+}
+
+// Hover used to swap the row to --surface-2, which is LIGHTER than the tint:
+// pointing at the newest row removed the one thing that distinguished it.
+func TestNewestBackupRowKeepsItsTintOnHover(t *testing.T) {
+	css := string(readStyleCSS(t))
+	rule := ruleBody(css, ".stg-row-latest.bk-expandable:hover")
+	if rule == "" {
+		t.Fatal("no hover rule scoped to .stg-row-latest: the generic .bk-expandable:hover sets " +
+			"background:var(--surface-2), which is lighter than --violet-tint, so hovering the " +
+			"newest row erases the mark the tint exists to carry")
+	}
+	if !strings.Contains(rule, "var(--"+latestRowGround+")") {
+		t.Errorf("the newest row's hover no longer repaints --%s: %q", latestRowGround, rule)
+	}
+}
+
+// Anti-rot: every class literal appended to the row must be covered above.
+func TestNewestBackupRowChildrenAreAllListed(t *testing.T) {
+	js := readAsset(t, "app.js")
+	// Anchored on stg-row-latest, not on stg-row: the latter is a shared list
+	// class and starting there swept in every earlier panel on the page.
+	start := strings.Index(js, `"stg-row" + (idx === 0 ? " stg-row-latest"`)
+	end := -1
+	if start >= 0 {
+		if rel := strings.Index(js[start:], "list.append(row, detail);"); rel >= 0 {
+			end = start + rel
+		}
+	}
+	if start < 0 || end <= start {
+		t.Fatal("could not find the backups row builder in app.js; if it moved, re-point this test " +
+			"rather than deleting it")
+	}
+	known := map[string]bool{}
+	for _, c := range latestRowChildren {
+		known[c] = true
+	}
+	for _, m := range regexp.MustCompile(`class: "([^"]+)"`).FindAllStringSubmatch(js[start:end], -1) {
+		for _, c := range strings.Fields(m[1]) {
+			if c == "stg-row" || c == "stg-row-latest" || c == "bk-detail" ||
+				c == "mono" || c == "chip" || c == "bk-expandable" || known[c] {
+				continue
+			}
+			t.Errorf("the newest backup row renders .%s, which no contrast check covers. Add it to "+
+				"latestRowChildren so its colour is measured against the tint.", c)
+		}
+	}
+}
+
+// effectiveDecl resolves prop for class the way the cascade does: an override
+// scoped under .stg-row-latest wins over the class's own rule. Returns the
+// token name, or "" when the class never sets prop (it inherits, and the row
+// itself is checked by the tint-token test).
+func effectiveDecl(css, class, prop string) string {
+	for _, sel := range []string{`.stg-row-latest .` + class, `.` + class} {
+		if body := ruleBody(css, sel); body != "" {
+			if m := regexp.MustCompile(prop + `:\s*var\(--([a-z0-9-]+)\)`).FindStringSubmatch(body); m != nil {
+				return m[1]
+			}
+		}
+	}
+	return ""
+}
+
+// ruleBody returns the declarations of the first rule whose selector list
+// contains sel as a whole selector.
+func ruleBody(css, sel string) string {
+	// Comments are stripped first: splitting raw CSS on "}" leaves the comment
+	// that documents a rule glued to the front of its selector, so every
+	// commented rule reads as absent -- which is how this test first reported
+	// a defect that had already been fixed two lines above it.
+	css = regexp.MustCompile(`(?s)/\*.*?\*/`).ReplaceAllString(css, "")
+	for _, block := range strings.Split(css, "}") {
+		open := strings.Index(block, "{")
+		if open < 0 {
+			continue
+		}
+		for _, s := range strings.Split(block[:open], ",") {
+			if strings.TrimSpace(s) == sel {
+				return block[open+1:]
+			}
+		}
+	}
+	return ""
+}
+
+// anyToken reads a token that may be written as either oklch() or hex.
+func anyToken(t *testing.T, css, name string) string {
+	t.Helper()
+	if regexp.MustCompile(`--` + name + `:\s*oklch\(`).MatchString(css) {
+		return cssOklchToken(t, []byte(css), name)
+	}
+	return cssHexToken(t, []byte(css), name)
+}
+
+// The pill is NOT a contrast case: its default ink-2 on surface-3 is 6.74:1
+// and always read fine. What it loses on the tint is its edge, and white
+// barely improves that (1.09 -> 1.18). It takes the white ground for one
+// reason only, and it is the reason this test exists: .tcard-violet .tag-pill
+// already does, and the same pill on the same tint must not have two looks.
+// A ratio assertion cannot express that, so it is checked structurally.
+func TestNewestBackupRowPillMatchesTheOtherVioletPill(t *testing.T) {
+	css := string(readStyleCSS(t))
+	want := ruleBody(css, ".tcard-violet .tag-pill")
+	if want == "" {
+		t.Fatal("no .tcard-violet .tag-pill rule: this test compares the newest backup row's pill " +
+			"against it, so if that rule moved, re-point this rather than deleting it")
+	}
+	got := ruleBody(css, ".stg-row-latest .tag-pill")
+	if got == "" {
+		t.Fatal("the newest backup row's pill no longer overrides its ground. It sits on the same " +
+			"--violet-tint as the .tcard-violet pill and must look the same there")
+	}
+	if norm(got) != norm(want) {
+		t.Errorf("the two pills on --violet-tint have drifted apart:\n  .tcard-violet    %s\n  .stg-row-latest  %s", norm(want), norm(got))
+	}
+}
+
+func norm(decls string) string {
+	return strings.Join(strings.Fields(strings.ReplaceAll(decls, "\n", " ")), " ")
+}

--- a/internal/console/assets_takeaway_test.go
+++ b/internal/console/assets_takeaway_test.go
@@ -1,0 +1,92 @@
+package console
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The Backups page answers one question: what do I download to open this in
+// DuckDB, what do I download to load it into MySQL. The drawing carries the
+// difference before any sentence does -- TWO file tiles on the DuckDB lane,
+// ONE on the MySQL lane -- and a drawing can lie in a way prose cannot: it
+// keeps rendering the old answer after the code stops producing it, and no
+// screenshot notices because a picture of two files looks correct on its own.
+//
+// So the count is pinned in three places at once and they must agree: the
+// tiles the lane draws, the sentence the lane says, and the lane it is.
+func TestTakeAwayLanesDrawAsManyFilesAsTheyClaim(t *testing.T) {
+	js := readAsset(t, "app.js")
+	for _, c := range []struct {
+		fn, says string
+		files    int
+	}{
+		{"function backupDuckLane(", "Two files", 2},
+		{"function backupSQLLane(", "One file", 1},
+	} {
+		body := stripJSLineComments(functionBody(t, js, c.fn))
+		call := strings.Index(body, "backupLane(")
+		if call < 0 {
+			t.Errorf("%s no longer builds a lane, so nothing draws its files", c.fn)
+			continue
+		}
+		end := strings.Index(body[call:], "\n  const ")
+		if end < 0 {
+			end = len(body) - call
+		}
+		spec := body[call : call+end]
+		if n := strings.Count(spec, "{ name:"); n != c.files {
+			t.Errorf("%s draws %d file tile(s) but this lane is %d file(s). The tile count IS the "+
+				"message on this panel, so a drawing that outlives its lane is worse than no drawing.",
+				c.fn, n, c.files)
+		}
+		if !strings.Contains(spec, c.says) {
+			t.Errorf("%s draws %d tile(s) but no longer says %q. The picture and the sentence have "+
+				"to agree, or one of them is lying to a reader who only read the other.",
+				c.fn, c.files, c.says)
+		}
+	}
+}
+
+// The views file is named on two surfaces: the Connect AI panel that builds
+// it, and the Backups lane that sends a reader there to get it. They share a
+// constant so they cannot drift; this pins that neither re-hardcodes it.
+func TestViewsFileIsNamedFromOneConstant(t *testing.T) {
+	js := stripJSLineComments(readAsset(t, "app.js"))
+	decl := regexp.MustCompile(`const DUCKDB_VIEWS_FILE = "([^"]+)"`).FindStringSubmatch(js)
+	if decl == nil {
+		t.Fatal("DUCKDB_VIEWS_FILE is gone: the Backups lane sends readers to Connect AI for that " +
+			"file by name, and two literals in two panels drift the moment one is renamed")
+	}
+	// Counted as a bare substring, not as a standalone "views.sql" literal: a
+	// real re-hardcode embeds the name in a longer string (text: "Get
+	// views.sql"), which a quoted-literal check walks straight past. The route
+	// /api/views.sql legitimately contains it and is removed first.
+	body := strings.ReplaceAll(js, "/api/"+decl[1], "")
+	if n := strings.Count(body, decl[1]); n != 1 {
+		t.Errorf("%q appears %d times outside a comment line; only its own declaration may spell "+
+			"it out. Everywhere else it must come from DUCKDB_VIEWS_FILE, or the Backups lane can "+
+			"promise a file Connect AI no longer produces", decl[1], n)
+	}
+}
+
+// A panel nobody mounts answers nothing. This is the wiring half: the guards
+// above prove the lanes are right, not that a reader ever sees them.
+func TestTakeAwayPanelIsMountedAboveTheList(t *testing.T) {
+	body := stripJSLineComments(functionBody(t, readAsset(t, "app.js"), "async function renderBaselines("))
+	// v.append(takeAway), not backupTakeAway(: dropping only the append leaves
+	// the call sitting there, and a guard that reads the call reports a panel
+	// that no reader can see.
+	mount := strings.Index(body, "v.append(takeAway)")
+	list := strings.Index(body, "baselinesPanel(")
+	switch {
+	case mount < 0:
+		t.Fatal("renderBaselines no longer mounts backupTakeAway: both downloads go back to being " +
+			"invisible, one inside a row expand and one inside a fold")
+	case list < 0:
+		t.Fatal("renderBaselines no longer mounts baselinesPanel")
+	case mount > list:
+		t.Error("the two lanes render BELOW the backups list. They are the answer to why the page " +
+			"was opened; the list is how you pick a different one")
+	}
+}

--- a/internal/console/assets_takeaway_test.go
+++ b/internal/console/assets_takeaway_test.go
@@ -8,44 +8,98 @@ import (
 
 // The Backups page answers one question: what do I download to open this in
 // DuckDB, what do I download to load it into MySQL. The drawing carries the
-// difference before any sentence does -- TWO file tiles on the DuckDB lane,
-// ONE on the MySQL lane -- and a drawing can lie in a way prose cannot: it
+// difference before any sentence does -- two file tiles on the DuckDB lane,
+// one on the MySQL lane -- and a drawing can lie in a way prose cannot: it
 // keeps rendering the old answer after the code stops producing it, and no
 // screenshot notices because a picture of two files looks correct on its own.
 //
-// So the count is pinned in three places at once and they must agree: the
-// tiles the lane draws, the sentence the lane says, and the lane it is.
-func TestTakeAwayLanesDrawAsManyFilesAsTheyClaim(t *testing.T) {
+// The first cut of this guard compared the tiles a lane PASSES against a
+// hardcoded sentence, and review killed it twice over. It counted the
+// argument list rather than the drawing, so slicing backupFilesShape to one
+// tile passed; and once the views tile became conditional, the fixed sentence
+// was wrong by construction on the ungated arm.
+//
+// So the sentence is no longer written by hand at all. backupLane derives the
+// count word from the tiles it is handed, and these three checks pin that
+// arrangement: nothing downstream may re-hardcode a count, and nothing may
+// draw fewer tiles than it was given.
+func TestTakeAwayLaneCountIsDerivedNotWritten(t *testing.T) {
 	js := readAsset(t, "app.js")
-	for _, c := range []struct {
-		fn, says string
-		files    int
-	}{
-		{"function backupDuckLane(", "Two files", 2},
-		{"function backupSQLLane(", "One file", 1},
-	} {
-		body := stripJSLineComments(functionBody(t, js, c.fn))
-		call := strings.Index(body, "backupLane(")
-		if call < 0 {
-			t.Errorf("%s no longer builds a lane, so nothing draws its files", c.fn)
-			continue
-		}
-		end := strings.Index(body[call:], "\n  const ")
-		if end < 0 {
-			end = len(body) - call
-		}
-		spec := body[call : call+end]
-		if n := strings.Count(spec, "{ name:"); n != c.files {
-			t.Errorf("%s draws %d file tile(s) but this lane is %d file(s). The tile count IS the "+
-				"message on this panel, so a drawing that outlives its lane is worse than no drawing.",
-				c.fn, n, c.files)
-		}
-		if !strings.Contains(spec, c.says) {
-			t.Errorf("%s draws %d tile(s) but no longer says %q. The picture and the sentence have "+
-				"to agree, or one of them is lying to a reader who only read the other.",
-				c.fn, c.files, c.says)
+	lane := stripJSLineComments(functionBody(t, js, "function backupLane("))
+	if !strings.Contains(lane, "files.length") || !strings.Contains(lane, "LANE_COUNT_WORD") {
+		t.Error("backupLane no longer derives its count word from the tiles it is handed. A lane " +
+			"that states its own count can disagree with its own drawing, which is the whole " +
+			"defect this panel's guard exists for")
+	}
+	// A lane that spelled its own count would silently win over the derived
+	// one, so no caller may contain a count word.
+	for _, fn := range []string{"function backupDuckLane(", "function backupSQLLane("} {
+		body := stripJSLineComments(functionBody(t, js, fn))
+		for _, word := range []string{"One download", "Two downloads", "One file", "Two files"} {
+			if strings.Contains(body, word) {
+				t.Errorf("%s writes %q by hand. The count comes from backupLane, which reads the "+
+					"tiles actually drawn; a hand-written one drifts the first time a tile is gated",
+					fn, word)
+			}
 		}
 	}
+	// And the drawing must render every tile it is given. Slicing here was a
+	// surviving mutation: the DuckDB lane drew one tile under the words for
+	// two, and every assertion stayed green.
+	shape := stripJSLineComments(functionBody(t, js, "function backupFilesShape("))
+	if !strings.Contains(shape, "files.forEach(") || strings.Contains(shape, ".slice(") {
+		t.Error("backupFilesShape no longer draws one tile per file it is handed. The tile count " +
+			"is the message on this panel, so a shape that drops one lies about what you need")
+	}
+}
+
+// The views half is a promise this page cannot keep on its own: the file is
+// produced by the Connect AI panel, which is gated on capsCache.views.
+// Ungated here, the lane drew a views.sql tile and a button leading to a page
+// where that filename does not appear -- exactly the trade views_api.go says
+// this codebase refuses ("a button that only 404s is a lie").
+func TestDuckLaneGatesTheFileItDoesNotProduce(t *testing.T) {
+	js := readAsset(t, "app.js")
+	lane := stripJSLineComments(functionBody(t, js, "function backupDuckLane("))
+	if !strings.Contains(lane, "capsCache.views") {
+		t.Fatal("the DuckDB lane no longer checks capsCache.views, so it can promise a views file " +
+			"that Connect AI will not render")
+	}
+	// Both halves must sit behind it, and "behind" means INSIDE the branch,
+	// not merely later in the file. Comparing byte offsets was the first cut
+	// and it passed a mutation that gated the tile and left the button loose:
+	// the button still came after `const hasViews = ...`.
+	for _, half := range []string{"DUCKDB_VIEWS_FILE, cap:", `navigate("connect")`} {
+		if !guardedByHasViews(lane, half) {
+			t.Errorf("%q is not inside an `if (hasViews)` branch. A gated tile beside an ungated "+
+				"button still sends the reader to a page with no views file on it", half)
+		}
+	}
+}
+
+// guardedByHasViews reports whether every line mentioning needle sits inside
+// an `if (hasViews)` branch -- either the single-statement form on the same
+// line, or a braced block. Line-based on purpose: the lane uses both forms,
+// so a brace matcher alone would miss the one-liner that pushes the tile.
+func guardedByHasViews(body, needle string) bool {
+	depth, seen := 0, false
+	for _, line := range strings.Split(body, "\n") {
+		guardOpensHere := strings.Contains(line, "if (hasViews)")
+		if strings.Contains(line, needle) {
+			seen = true
+			if depth == 0 && !guardOpensHere {
+				return false
+			}
+		}
+		if guardOpensHere && strings.HasSuffix(strings.TrimSpace(line), "{") {
+			depth++
+			continue
+		}
+		if depth > 0 && strings.TrimSpace(line) == "}" {
+			depth--
+		}
+	}
+	return seen
 }
 
 // The views file is named on two surfaces: the Connect AI panel that builds
@@ -81,8 +135,9 @@ func TestTakeAwayPanelIsMountedAboveTheList(t *testing.T) {
 	list := strings.Index(body, "baselinesPanel(")
 	switch {
 	case mount < 0:
-		t.Fatal("renderBaselines no longer mounts backupTakeAway: both downloads go back to being " +
-			"invisible, one inside a row expand and one inside a fold")
+		t.Fatal("renderBaselines no longer mounts backupTakeAway: the Parquet download goes back " +
+			"inside a row expand, and the .sql builder leaves the page entirely — backupTakeAway " +
+			"is its only caller")
 	case list < 0:
 		t.Fatal("renderBaselines no longer mounts baselinesPanel")
 	case mount > list:

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -2345,11 +2345,10 @@ try {
   const sqlxGate = await page.evaluate(async () => {
     const out = { cap: !!capsCache.sql_export };
     const v = document.querySelector(".view");
-    const card = Array.from(v.querySelectorAll(".bk-restore")).find((c) =>
-      /Build a \.sql backup/.test((c.querySelector(".form-adv-summary") || {}).textContent || ""));
+    const card = Array.from(v.querySelectorAll(".bk-lane")).find((c) =>
+      /To load into MySQL/.test((c.querySelector(".bk-lane-t") || {}).textContent || ""));
     out.card = !!card;
     if (!card) return out;
-    card.open = true;
     const input = card.querySelector("input");
     out.prefilled = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(input.value);
     // Before any build the download must refuse with words, not stream bytes.
@@ -2388,23 +2387,22 @@ try {
     const st = { sql_export: { state: "idle" } };
     const keep = capsCache.sql_export;
     capsCache.sql_export = false;
-    const off = backupSQLExportCard(cur, b, st);
+    const off = backupSQLLane(cur, b, st);
     capsCache.sql_export = keep;
-    return { off: !!off, on: !!backupSQLExportCard(cur, b, st) };
+    return { off: !!off, on: !!backupSQLLane(cur, b, st) };
   });
   (!sqlxGateOff.off && sqlxGateOff.on)
-    ? ok("sqlx: the capability gates the card (off absent, on present)")
-    : bad("sqlx: the capability gates the card (off absent, on present)", JSON.stringify(sqlxGateOff));
+    ? ok("sqlx: the capability gates the lane (off absent, on present)")
+    : bad("sqlx: the capability gates the lane (off absent, on present)", JSON.stringify(sqlxGateOff));
 
   // The real build. TT_AT sits after every fixture event; the fold reads the
   // baseline AND the index. Poll the status endpoint, not the DOM — the page
   // re-renders itself while the run region is up.
   const sqlxRun = await page.evaluate(async (TT_AT) => {
     const v = document.querySelector(".view");
-    const card = Array.from(v.querySelectorAll(".bk-restore")).find((c) =>
-      /Build a \.sql backup/.test((c.querySelector(".form-adv-summary") || {}).textContent || ""));
-    if (!card) return { err: "card vanished" };
-    card.open = true;
+    const card = Array.from(v.querySelectorAll(".bk-lane")).find((c) =>
+      /To load into MySQL/.test((c.querySelector(".bk-lane-t") || {}).textContent || ""));
+    if (!card) return { err: "the .sql lane vanished" };
     const input = card.querySelector("input");
     input.value = TT_AT;
     Array.from(card.querySelectorAll("button")).find((b) => b.textContent === "Build").click();
@@ -2426,8 +2424,8 @@ try {
   await page.waitForFunction(() => {
     const v = document.querySelector(".view");
     if (!v) return false;
-    const card = Array.from(v.querySelectorAll(".bk-restore")).find((c) =>
-      /Build a \.sql backup/.test((c.querySelector(".form-adv-summary") || {}).textContent || ""));
+    const card = Array.from(v.querySelectorAll(".bk-lane")).find((c) =>
+      /To load into MySQL/.test((c.querySelector(".bk-lane-t") || {}).textContent || ""));
     return !!card && /Ready: every table as of/.test(card.textContent) &&
       Array.from(card.querySelectorAll("button")).some((b) => /Download \.sql backup/.test(b.textContent));
   }, { timeout: 30000 });
@@ -2509,14 +2507,14 @@ try {
       await page.waitForFunction(() => {
         const v = document.querySelector(".view");
         if (!v) return false;
-        const card = Array.from(v.querySelectorAll(".bk-restore")).find((c) =>
-          /Build a \.sql backup/.test((c.querySelector(".form-adv-summary") || {}).textContent || ""));
+        const card = Array.from(v.querySelectorAll(".bk-lane")).find((c) =>
+          /To load into MySQL/.test((c.querySelector(".bk-lane-t") || {}).textContent || ""));
         return !!card && /Last build failed/.test(card.textContent);
       }, { timeout: 15000 });
       const gapMsg = await page.evaluate(() => {
         const v = document.querySelector(".view");
-        const card = Array.from(v.querySelectorAll(".bk-restore")).find((c) =>
-          /Build a \.sql backup/.test((c.querySelector(".form-adv-summary") || {}).textContent || ""));
+        const card = Array.from(v.querySelectorAll(".bk-lane")).find((c) =>
+          /To load into MySQL/.test((c.querySelector(".bk-lane-t") || {}).textContent || ""));
         return card.textContent;
       });
       (/capture gap/.test(gapMsg) && !/--allow-gaps/.test(gapMsg))

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -2342,6 +2342,44 @@ try {
   // baseline rows 1,2,4 + INSERT id 3 + UPDATE id 1 (-> shipped) + DELETE
   // id 2, built at TT_AT (after all three), so the dump must carry the folded
   // state — not the baseline, not the raw events.
+  // The two download lanes (#1572). The Go guards read the SOURCE: they can
+  // see that backupLane derives its count word and that backupFilesShape
+  // draws one tile per file, but not that a reader ends up looking at two
+  // tiles. This is the only check that renders them.
+  const lanes = await page.evaluate(() => {
+    const out = { views: !!capsCache.views, lanes: [] };
+    document.querySelectorAll(".bk-take .bk-lane").forEach((l) => {
+      const t = l.querySelector(".bk-lane-t");
+      out.lanes.push({
+        title: t ? t.textContent : "",
+        tiles: l.querySelectorAll(".bk-file").length,
+        lead: (l.querySelector(".bk-lane-lead") || {}).textContent || "",
+        views: Array.from(l.querySelectorAll("button")).some((b) => /views\.sql/.test(b.textContent)),
+      });
+    });
+    return out;
+  });
+  const duck = lanes.lanes.find((l) => /DuckDB/.test(l.title));
+  const mysql = lanes.lanes.find((l) => /MySQL/.test(l.title));
+  (duck && mysql)
+    ? ok("take-away: both download lanes render")
+    : bad("take-away: both download lanes render", JSON.stringify(lanes));
+  // The drawing and the sentence come from one source, so the rendered tile
+  // count must match the word the lane prints. A drawing that outlived its
+  // lane is the failure this pins.
+  const counts = { 1: "One download", 2: "Two downloads" };
+  (duck && counts[duck.tiles] && duck.lead.startsWith(counts[duck.tiles]))
+    ? ok("take-away: the DuckDB lane's drawing and its sentence agree")
+    : bad("take-away: the DuckDB lane's drawing and its sentence agree", JSON.stringify(duck));
+  (mysql && mysql.tiles === 1 && mysql.lead.startsWith("One download"))
+    ? ok("take-away: the MySQL lane draws one download and says so")
+    : bad("take-away: the MySQL lane draws one download and says so", JSON.stringify(mysql));
+  // The views half is a promise this page cannot keep alone: the file comes
+  // from the Connect AI panel, which is gated on the same capability.
+  (duck && duck.views === lanes.views && duck.tiles === (lanes.views ? 2 : 1))
+    ? ok("take-away: the views file is offered only when Connect AI can produce it")
+    : bad("take-away: the views file is offered only when Connect AI can produce it", JSON.stringify({ caps: lanes.views, duck: duck }));
+
   const sqlxGate = await page.evaluate(async () => {
     const out = { cap: !!capsCache.sql_export };
     const v = document.querySelector(".view");
@@ -2350,6 +2388,10 @@ try {
     out.card = !!card;
     if (!card) return out;
     const input = card.querySelector("input");
+    // The lane renders neither input nor Build while a build is running (it
+    // hands off to the run region). Say so, rather than dereferencing null
+    // and turning a named failure into a stack trace.
+    if (!input) { out.running = true; return out; }
     out.prefilled = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(input.value);
     // Before any build the download must refuse with words, not stream bytes.
     const headers = TOKEN ? { Authorization: ["Bearer", TOKEN].join(" ") } : {};

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -2380,6 +2380,85 @@ try {
     ? ok("take-away: the views file is offered only when Connect AI can produce it")
     : bad("take-away: the views file is offered only when Connect AI can produce it", JSON.stringify({ caps: lanes.views, duck: duck }));
 
+  // The GATED arm, fixture-driven through the real builder. The assertions
+  // above run on a stack whose views capability is ON, so the one-tile arm --
+  // its sentence, its missing button -- is drawn by nothing otherwise. Same
+  // shape as sqlxGateOff below: flip the capability, call the builder,
+  // restore. Without this, inverting the gate is caught only by the assertion
+  // above, and the arm itself is never rendered at all.
+  const duckOff = await page.evaluate(() => {
+    const b = { configured: true, snapshots: [{ time: "2026-06-10 12:00:00" }] };
+    const keep = capsCache.views;
+    capsCache.views = false;
+    const off = backupDuckLane(b);
+    capsCache.views = true;
+    const on = backupDuckLane(b);
+    capsCache.views = keep;
+    const read = (lane) => lane && ({
+      tiles: lane.querySelectorAll(".bk-file").length,
+      lead: (lane.querySelector(".bk-lane-lead") || {}).textContent || "",
+      views: Array.from(lane.querySelectorAll("button")).some((x) => /views\.sql/.test(x.textContent)),
+      text: lane.textContent,
+    });
+    return { off: read(off), on: read(on) };
+  });
+  (duckOff.off && duckOff.off.tiles === 1 && !duckOff.off.views && duckOff.off.lead.startsWith("One download"))
+    ? ok("take-away: with no views capability the lane draws one download and offers no views file")
+    : bad("take-away: with no views capability the lane draws one download and offers no views file", JSON.stringify(duckOff.off));
+  // And it must say WHY, rather than dressing a console setting as a property
+  // of the data: the same folder still yields the file from the command line.
+  (duckOff.off && /not offered here/.test(duckOff.off.text) && /decimal columns arrive as text/.test(duckOff.off.text))
+    ? ok("take-away: the withheld views file is explained, not implied away")
+    : bad("take-away: the withheld views file is explained, not implied away", JSON.stringify(duckOff.off && duckOff.off.text));
+  // The on-arm is the vacuousness control: a builder that always drew one
+  // tile would pass the off-arm alone.
+  (duckOff.on && duckOff.on.tiles === 2 && duckOff.on.views)
+    ? ok("take-away: with the capability on, the same builder draws both downloads")
+    : bad("take-away: with the capability on, the same builder draws both downloads", JSON.stringify(duckOff.on));
+
+  // Paging, EXECUTED through the real panel. The Go guards test the window
+  // function and the clamp in isolation and read the call site as text; their
+  // COMPOSITION is what a literal page argument breaks, and only rendering
+  // catches that. The fixture index carries one snapshot, so the list is
+  // handed eight synthetic ones instead.
+  const paged = await page.evaluate(() => {
+    const snaps = [];
+    for (let i = 0; i < 8; i++) snaps.push({ time: "2026-06-1" + i + " 12:00:00", age_hours: i });
+    const keep = backupsPage;
+    const read = (idx) => {
+      backupsPage = { server: currentServer, index: idx };
+      const panel = baselinesPanel({ configured: true, snapshots: snaps }, [], {});
+      return {
+        rows: Array.from(panel.querySelectorAll(".stg-row .stg-name")).map((n) => n.textContent),
+        latest: panel.querySelectorAll(".stg-row-latest").length,
+        pager: (panel.querySelector(".bk-pager-n") || {}).textContent || "",
+      };
+    };
+    const p0 = read(0), p1 = read(1);
+    backupsPage = keep;
+    return { p0: p0, p1: p1 };
+  });
+  (paged.p0.rows.length === 5 && paged.p1.rows.length === 3)
+    ? ok("backups paging: five rows a page, and the last page holds the remainder")
+    : bad("backups paging: five rows a page, and the last page holds the remainder",
+        JSON.stringify({ p0: paged.p0.rows.length, p1: paged.p1.rows.length }));
+  // The composition is what a literal page argument breaks: the window has to
+  // MOVE. Page two showing page one's rows is the shape that passed every
+  // source assertion and both isolated node tests.
+  (paged.p1.rows[0] && paged.p1.rows[0] !== paged.p0.rows[0])
+    ? ok("backups paging: page two continues the list instead of restarting it")
+    : bad("backups paging: page two continues the list instead of restarting it",
+        JSON.stringify({ p0first: paged.p0.rows[0], p1first: paged.p1.rows[0] }));
+  // The treatment marks the backup a restore reads, so it belongs to the
+  // whole list, not to a page.
+  (paged.p0.latest === 1 && paged.p1.latest === 0)
+    ? ok("backups paging: only the real newest backup wears the treatment")
+    : bad("backups paging: only the real newest backup wears the treatment",
+        JSON.stringify({ p0: paged.p0.latest, p1: paged.p1.latest }));
+  (/^1.5 of 8$/.test(paged.p0.pager) && /^6.8 of 8$/.test(paged.p1.pager))
+    ? ok("backups paging: the pager says which rows are on screen")
+    : bad("backups paging: the pager says which rows are on screen",
+        JSON.stringify({ p0: paged.p0.pager, p1: paged.p1.pager }));
   const sqlxGate = await page.evaluate(async () => {
     const out = { cap: !!capsCache.sql_export };
     const v = document.querySelector(".view");

--- a/test/console-e2e/shot-lanes.local.mjs
+++ b/test/console-e2e/shot-lanes.local.mjs
@@ -1,0 +1,67 @@
+// Renders the Backups page and reads the two download lanes back off the DOM.
+// go test never renders the SPA, so "the panel is mounted" and "the panel is
+// VISIBLE with two file tiles on one lane and one on the other" are different
+// claims; the Go guards cover the first, this covers the second.
+//
+// Run it against the e2e fixture stack, which is what has a real baseline
+// snapshot to list:
+//
+//   sed "s|node console_e2e.mjs|SHOT_OUT=/tmp node shot-lanes.local.mjs|" \
+//     test/console-e2e/run.sh > /tmp/r.sh && chmod +x /tmp/r.sh && \
+//     (cd test/console-e2e && /tmp/r.sh)
+//
+// It creates the "byo-idx" registry server itself (run.sh does not; scenario 5
+// of console_e2e.mjs does), so it works on a stack run.sh brought up alone.
+import { chromium } from "playwright";
+const OUT = process.env.SHOT_OUT;
+const URL = process.env.CONSOLE_URL, TOK = process.env.CONSOLE_TOKEN;
+const browser = await chromium.launch();
+const page = await (await browser.newContext()).newPage();
+await page.setViewportSize({ width: 1440, height: 1000 });
+await page.goto(URL + "/?token=" + encodeURIComponent(TOK));
+await page.waitForFunction(() => document.querySelector(".side"), { timeout: 15000 });
+await page.evaluate(() => { if (typeof closeServersModal === "function") closeServersModal(); });
+// The fixture with a real baseline snapshot is the "byo-idx" registry server;
+// the default selection is the source-less boot entry, which has none.
+const byoId = await page.evaluate(async (baselineDir) => {
+  const r = await api("/api/servers");
+  const found = (r.servers || []).find((x) => x.name === "byo-idx");
+  if (found) return found.id;
+  const res = await api("/api/servers", { method: "POST", body: {
+    name: "byo-idx", host: "127.0.0.1", port: "13306", user: "root", password: "testroot",
+    dbname: "bintrail_e2e_idx", baseline_dir: baselineDir,
+  } });
+  return res.id;
+}, process.env.E2E_BASELINE_DIR || "");
+console.log("byo-idx id:", byoId);
+if (byoId) await page.evaluate(async (id) => { await switchServer(id); }, byoId);
+await page.waitForTimeout(600);
+await page.evaluate(() => navigate("baselines"));
+await page.waitForFunction(() => location.pathname === "/baselines", { timeout: 10000 });
+await page.waitForTimeout(1200);
+await page.evaluate(() => { if (typeof closeServersModal === "function") closeServersModal(); });
+
+const seen = await page.evaluate(() => {
+  const q = (s) => Array.from(document.querySelectorAll(s));
+  const panel = document.querySelector(".bk-take");
+  const lanes = q(".bk-lane");
+  const listTop = document.querySelector(".stg-list");
+  return {
+    panelPresent: !!panel,
+    panelTitle: panel ? panel.querySelector(".ov-panel-title").textContent : null,
+    lanes: lanes.map((l) => ({
+      title: l.querySelector(".bk-lane-t") ? l.querySelector(".bk-lane-t").textContent : null,
+      tiles: l.querySelectorAll(".bk-file").length,
+      tileNames: Array.from(l.querySelectorAll(".bk-file-n")).map((n) => n.textContent),
+      buttons: Array.from(l.querySelectorAll("button")).map((b) => b.textContent),
+      visible: l.getBoundingClientRect().height > 0,
+    })),
+    panelAboveList: !!(panel && listTop) &&
+      panel.getBoundingClientRect().top < listTop.getBoundingClientRect().top,
+    rowsShown: q(".stg-row").length,
+    pagerText: document.querySelector(".bk-pager") ? document.querySelector(".bk-pager").innerText.replace(/\s+/g, " ") : null,
+  };
+});
+console.log(JSON.stringify(seen, null, 2));
+await page.screenshot({ path: OUT + "/backups-lanes.png", fullPage: true });
+await browser.close();


### PR DESCRIPTION
## What this is

The Backups page had two downloads and neither could be found. The Parquet
`.tar.gz` sat inside a row expand with nothing saying the row opened, and the
`.sql` builder was a `<details>` summary in small caps below three other folds.
A reader arrives with one question, what do I download to open this in DuckDB
and what do I download to load it into MySQL, and had to open two folds to
learn there was an answer at all.

Four commits, each standing on its own.

## The two lanes

The drawing carries the difference before any sentence does: two file tiles on
the DuckDB lane, one on the MySQL lane. They are deliberately not symmetrical.
DuckDB takes two files and one of them is not on this page (the views file
moved to Connect AI in #1549), so that lane points at both. MySQL takes one
file that does not exist until you pick a moment, so that lane asks for the
moment.

Three things worth keeping:

- The lane resolves the archive size before handing off to `downloadBackup`,
  which warns above 1 GB because the browser holds the whole thing in memory.
  That number is not in the listing, so a shortcut passing zero would have
  dropped the warning silently.
- The `.sql` lane no longer returns null while a build runs. In a two-lane
  panel that left a hole where an answer was.
- `views.sql` is named from one constant now, shared with the Connect AI panel
  that produces it.

## The newest row was under its floor

The tint on the newest row marks the copy Time-travel and a restore actually
read, so everything the row carries sits on `--violet-tint`. Measured with the
repo converter: the age at `--ink-3` is 4.20:1, and the location chip and the
chevron at `--ink-4` are 2.80:1. Hover made it worse, swapping the row to
`--surface-2`, which is lighter than the tint, so pointing at the newest row
erased the only thing marking it.

`assets_tint_contrast_test.go` already measured the TOKENS, and its comment
says outright that `--ink-3` on violet fails "which is exactly why nothing may
use it there". Nothing checked that no SELECTOR used it there, so all three
shipped green. The new guard walks what the row actually renders and resolves
the cascade overrides-first.

The pill is **not** a contrast fix and the code says so: its default ink-2 on
surface-3 measures 6.74:1 and always read fine. It takes the white ground
because `.tcard-violet .tag-pill` already does. A ratio assertion cannot
express that, so it is checked structurally against that rule.

## Paging

Five per page. The page index is clamped on read, not on write: a server whose
snapshot count shrinks under a viewer would otherwise leave the state pointing
past the end and render an empty list with no way back. Paging is keyed by
server, so a page-three position never carries onto a server with two
snapshots.

## Verification

- 359/359 console e2e.
- Eleven mutations across the two new guards, all killed, including one that
  appends an unmeasured child to the row and one that deletes only the
  `v.append` and leaves the call.
- Rendered in headless Chrome and read back off the DOM
  (`shot-lanes.local.mjs`): both lanes visible, 2 tiles and 1 tile, panel above
  the list.

One thing to know when reviewing the guards: a drawing can lie in a way prose
cannot, because it keeps rendering the old answer after the code stops
producing it and a screenshot does not notice. So the tile count is pinned
against the sentence that claims it and the lane it belongs to. One of the
row children is built by `backupWhereChip()` hundreds of lines from the row
builder, so a regex over that block would have missed exactly the child that
was worst off; the list is explicit with an anti-rot check beside it.
