### PR TITLE
console: grade Restore Coverage across every backup location

### DIFF
--- a/internal/console/coverage_api.go
+++ b/internal/console/coverage_api.go
@@ -157,12 +157,25 @@ func (s *Server) handleCoverage(w http.ResponseWriter, r *http.Request) {
 	case sum.Floor.Hour.IsZero():
 		resp.FullTableStatus = "unknown"
 	default:
-		files, err := reconstruct.ListBaselines(r.Context(), b.baselineSrc)
-		if err != nil {
-			slog.Warn("console: coverage card could not list baselines", "server", serverID(r), "source", b.baselineSrc, "error", err)
+		// EVERY configured location, not b.baselineSrc alone (#1571). This is
+		// a verdict about what can be restored, so deriving it from one of two
+		// places answers about a subset: on a server with a local directory
+		// and an S3 destination, a snapshot that survives only in the bucket
+		// would be graded as if it were gone, and the panel would report a
+		// shorter restorable window than the one that exists.
+		merged := listBaselinesMerged(r.Context(), baselineSourcesOf(b), reconstruct.ListBaselines)
+		// ANY location that did not answer makes the verdict unknown, not just
+		// all of them. A partial listing can only understate coverage, and an
+		// understated coverage window names healthy tables as broken -- the
+		// cry-wolf failure status.DeltaFloor already refuses when archives
+		// cannot be attributed. Unknown is the honest third state.
+		if merged.Listed < len(merged.Sources) || merged.Listed == 0 {
+			slog.Warn("console: coverage card could not list every backup location; the verdict is unknown rather than graded against a partial view",
+				"server", serverID(r), "listed", merged.Listed, "configured", len(merged.Sources))
 			resp.FullTableStatus = "unknown"
 			break
 		}
+		files := merged.Files
 		resp.FullTableStatus = "ok"
 		anchors := make(map[string]*tableAnchors, len(files))
 		for _, f := range files {

--- a/internal/console/coverage_sources_test.go
+++ b/internal/console/coverage_sources_test.go
@@ -1,0 +1,88 @@
+package console
+
+import (
+	"testing"
+	"time"
+)
+
+// Restore Coverage answers "how far back can this be restored", and it used to
+// derive that from bundle.baselineSrc alone (#1571). On a server with a local
+// directory AND an S3 destination that is a verdict about a subset: a table
+// whose only surviving anchor is in the bucket was not graded, not named
+// broken, and not counted -- it was simply absent, and the panel reported a
+// clean verdict over an inventory missing a table.
+//
+// This is the third instance of the shape; #1542 fixed the listing and #1541
+// the restore. The helpers those added are what the fix reuses.
+func TestCoverageAPI_gradesEveryBackupLocation(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	latest := now.Add(-30 * time.Second)
+	part := now.Add(-100 * time.Hour).Format("p_2006010215") // the floor
+	tsDir := func(age time.Duration) string { return now.Add(-age).Format("2006-01-02T15-04-05Z") }
+
+	primary, fallback := t.TempDir(), t.TempDir()
+	// Healthy and well inside the floor, so the verdict is "ok" either way and
+	// the test cannot pass merely because everything went unknown.
+	writeBaselineFixture(t, primary, tsDir(time.Hour), "shop", "orders.parquet")
+	// This table exists ONLY in the second location, and its newest anchor
+	// predates the floor. Ungraded it vanishes; graded it is broken.
+	writeBaselineFixture(t, fallback, tsDir(150*time.Hour), "shop", "archived.parquet")
+
+	srv := newBaselineServerWithFallback(t, primary, fallback)
+	srv.cm.boot.db = coverageMockDB(t, part, latest, nil)
+	srv.cm.boot.dbName = "binlog_index"
+	got := coverageGet(t, srv)
+
+	if got.FullTableStatus != "ok" {
+		t.Fatalf("status = %q, want ok: both locations answered", got.FullTableStatus)
+	}
+	found := false
+	for _, b := range got.BrokenTables {
+		if b == "shop.archived" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("broken_tables = %v, want shop.archived named. Its only anchor lives in the "+
+			"second backup location, so reading one location drops the table from the verdict "+
+			"entirely: not covered, not broken, just absent from a panel that claims to say "+
+			"what is restorable", got.BrokenTables)
+	}
+}
+
+// A location that does not answer makes the verdict UNKNOWN, even when the
+// other one did. A partial listing can only understate coverage, and an
+// understated window names healthy tables broken -- the cry-wolf failure
+// status.DeltaFloor already refuses when archives cannot be attributed.
+// Neither "ok" over a subset nor "broken" from a subset: unknown.
+func TestCoverageAPI_partialListingIsUnknownNotAShorterWindow(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	latest := now.Add(-30 * time.Second)
+	part := now.Add(-100 * time.Hour).Format("p_2006010215")
+	tsDir := func(age time.Duration) string { return now.Add(-age).Format("2006-01-02T15-04-05Z") }
+
+	primary := t.TempDir()
+	writeBaselineFixture(t, primary, tsDir(time.Hour), "shop", "orders.parquet")
+
+	srv := newBaselineServerWithFallback(t, primary, "/definitely/not/a/directory/1571")
+	srv.cm.boot.db = coverageMockDB(t, part, latest, nil)
+	srv.cm.boot.dbName = "binlog_index"
+	got := coverageGet(t, srv)
+
+	if got.FullTableStatus != "unknown" {
+		t.Errorf("status = %q with one location unreadable, want unknown. The readable half is a "+
+			"SUBSET, so grading it states a window narrower than the one that exists and can name "+
+			"healthy tables broken", got.FullTableStatus)
+	}
+	if got.FullTableFrom != "" {
+		t.Errorf("full_table_from = %q, want empty: an unknown verdict must claim no anchor", got.FullTableFrom)
+	}
+	if len(got.BrokenTables) != 0 {
+		t.Errorf("broken_tables = %v, want none: a partial view must not accuse", got.BrokenTables)
+	}
+	// The delta half is computed from the index, not from the backup
+	// locations, so it stays a real answer.
+	if got.DeltaFrom == "" {
+		t.Error("the live floor is independent of the backup listing and must still be reported")
+	}
+}

--- a/internal/console/views_api.go
+++ b/internal/console/views_api.go
@@ -103,6 +103,24 @@ func (s *Server) buildViewsInput(ctx context.Context, b *bundle, req viewsReques
 		if len(files) > 0 {
 			newest := files[0].SnapshotTime // ListBaselines returns newest first
 			in.BaselineSnapshot = newest
+			// #1571: this file pins ONE location, so a newer snapshot in the
+			// other one is invisible to its reader. Not merged -- the state
+			// views resolve paths under a single root, and a mixed file
+			// resolves for nobody. Named instead, best-effort: a location
+			// that will not answer leaves the header exactly as it was.
+			if other := otherBaselineSource(b, baseSrc); other != "" {
+				octx, cancel := context.WithTimeout(ctx, baselineListTimeout)
+				othersFiles, oerr := reconstruct.ListBaselines(octx, other)
+				cancel()
+				switch {
+				case oerr != nil:
+					slog.Warn("console: could not check the other backup location for a newer snapshot; the generated file says nothing about it",
+						"source", other, "error", oerr)
+				case len(othersFiles) > 0 && othersFiles[0].SnapshotTime.After(newest):
+					in.NewerElsewhere = othersFiles[0].SnapshotTime
+					in.NewerElsewhereSource = other
+				}
+			}
 			for _, f := range files {
 				if !f.SnapshotTime.Equal(newest) {
 					continue
@@ -405,4 +423,17 @@ func (s *Server) viewsAvailable(r *http.Request, b *bundle) bool {
 	// sources is nil whenever err is set, so the err check is intent, not a
 	// distinct branch: the gate must never say yes on a failed read.
 	return err == nil && len(sources) > 0
+}
+
+// otherBaselineSource names the configured backup location that `picked` is
+// NOT. Empty when the server has only one, or when the two are the same
+// string. It exists so the generated views file can say that a newer
+// snapshot lives somewhere it does not read (#1571).
+func otherBaselineSource(b *bundle, picked string) string {
+	for _, src := range baselineSourcesOf(b) {
+		if src != "" && src != picked {
+			return src
+		}
+	}
+	return ""
 }

--- a/internal/console/views_sources_test.go
+++ b/internal/console/views_sources_test.go
@@ -1,0 +1,92 @@
+package console
+
+import (
+	"strings"
+	"testing"
+)
+
+// A generated views.sql names ONE backup location and every state view
+// resolves a path under it. That is why #1571's fix here is a warning and not
+// a merge: a file carrying both a local directory and an s3:// prefix
+// produces views that half of its readers cannot open.
+//
+// What silence cost was quieter and worse. When the newest snapshot has aged
+// out of local retention but still lives in the bucket, the file pins the
+// older local one and reads as current: the state views describe a week-old
+// table and nothing in the file says so.
+func TestViewsFile_namesANewerSnapshotItDoesNotRead(t *testing.T) {
+	local, bucketish := t.TempDir(), t.TempDir()
+	writeBaselineFixture(t, local, "2026-06-03T12-00-00Z", "shop", "orders.parquet")
+	writeBaselineFixture(t, bucketish, "2026-06-10T12-00-00Z", "shop", "orders.parquet")
+
+	srv := newBaselineServerWithFallback(t, local, bucketish)
+	rec, body := doServersReq(t, srv, "GET", "/api/views.sql", "")
+	if rec.Code != 200 {
+		t.Fatalf("code = %d, body = %s", rec.Code, body)
+	}
+	sql := string(body)
+	if !strings.Contains(sql, "2026-06-03T12:00:00Z") {
+		t.Fatalf("the file no longer pins the location it was asked for:\n%s", firstLines(sql, 20))
+	}
+	if !strings.Contains(sql, "2026-06-10T12:00:00Z") || !strings.Contains(sql, bucketish) {
+		t.Errorf("the file pins the 06-03 snapshot and says nothing about the 06-10 one in the "+
+			"other location. A reader cannot tell the state views are describing a week-old "+
+			"table:\n%s", firstLines(sql, 20))
+	}
+	// The warning must not become a correction: the paths still have to
+	// resolve, so nothing from the other location may appear as a view source.
+	for _, line := range strings.Split(sql, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "--") {
+			continue
+		}
+		if strings.Contains(line, bucketish) {
+			t.Errorf("a view reads from the OTHER location: %q. The file names one root and its "+
+				"paths only resolve there; mixing them produces views nobody can open", line)
+		}
+	}
+}
+
+// The mirror case: when the pinned location IS the newest, the file says
+// nothing. A note that fires either way is noise, and a reader who learns to
+// skip it stops reading the one that matters.
+func TestViewsFile_saysNothingWhenItAlreadyPinsTheNewest(t *testing.T) {
+	local, bucketish := t.TempDir(), t.TempDir()
+	writeBaselineFixture(t, local, "2026-06-10T12-00-00Z", "shop", "orders.parquet")
+	writeBaselineFixture(t, bucketish, "2026-06-03T12-00-00Z", "shop", "orders.parquet")
+
+	srv := newBaselineServerWithFallback(t, local, bucketish)
+	rec, body := doServersReq(t, srv, "GET", "/api/views.sql", "")
+	if rec.Code != 200 {
+		t.Fatalf("code = %d, body = %s", rec.Code, body)
+	}
+	if strings.Contains(string(body), "NOTE: a newer snapshot") {
+		t.Errorf("the file warns about a newer snapshot while already pinning the newest:\n%s",
+			firstLines(string(body), 20))
+	}
+}
+
+// An unreadable second location must not fail the download. The file is
+// still correct about the location it does read; the warning is the only
+// thing lost, and it degrades to silence rather than to an error.
+func TestViewsFile_survivesAnUnreadableSecondLocation(t *testing.T) {
+	local := t.TempDir()
+	writeBaselineFixture(t, local, "2026-06-10T12-00-00Z", "shop", "orders.parquet")
+
+	srv := newBaselineServerWithFallback(t, local, "/definitely/not/a/directory/1571")
+	rec, body := doServersReq(t, srv, "GET", "/api/views.sql", "")
+	if rec.Code != 200 {
+		t.Fatalf("code = %d, want the file anyway; the location it reads is intact. body = %s",
+			rec.Code, firstLines(string(body), 8))
+	}
+	if !strings.Contains(string(body), "2026-06-10T12:00:00Z") {
+		t.Error("the pinned snapshot is missing from a file whose own location was readable")
+	}
+}
+
+func firstLines(s string, n int) string {
+	lines := strings.Split(s, "\n")
+	if len(lines) > n {
+		lines = lines[:n]
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/views/views.go
+++ b/internal/views/views.go
@@ -219,6 +219,18 @@ type Input struct {
 	// the header. BaselineSnapshot is that snapshot's timestamp.
 	BaselineSource   string
 	BaselineSnapshot time.Time
+	// NewerElsewhere names a snapshot that is more recent than the one this
+	// file pins, found in the server's OTHER backup location (#1571).
+	//
+	// It is a warning and deliberately NOT a correction. This file names ONE
+	// root, and every state view resolves a path under it: a reader who has
+	// the local directory cannot open an s3:// path and the reverse is just
+	// as true, so merging the two locations would produce views that half of
+	// the readers cannot resolve. What silence cost instead was worse in a
+	// quieter way — a file pinned to a week-old snapshot because the newest
+	// one had already aged out of local retention, reading as current.
+	NewerElsewhere       time.Time
+	NewerElsewhereSource string
 	// Follow records how, if at all, the state views reach a snapshot published
 	// after this file was generated (#1484, #1550). ApplyFollow is what sets
 	// it; see FollowMode for what each mode costs the reader.
@@ -701,6 +713,11 @@ func writeHeader(b *strings.Builder, in Input) {
 	default:
 		fmt.Fprintf(b, "--   %s at %s (%d table(s))\n",
 			in.BaselineSource, in.BaselineSnapshot.UTC().Format(time.RFC3339), len(in.Baselines))
+		if !in.NewerElsewhere.IsZero() {
+			fmt.Fprintf(b, "--   NOTE: a newer snapshot (%s) exists under %s, which this file does\n"+
+				"--   not read. A file names one location, and its paths only resolve there.\n",
+				in.NewerElsewhere.UTC().Format(time.RFC3339), in.NewerElsewhereSource)
+		}
 		switch in.Follow {
 		case FollowPointer:
 			// Name the timestamp AND the pointer: the timestamp is what the


### PR DESCRIPTION
closes #1571

## The defect

Restore Coverage answers how far back a server can be restored, and it derived that from `bundle.baselineSrc` alone. On a server with a local directory **and** an S3 destination, a table whose only surviving anchor is in the bucket was not graded, not named broken, and not counted. It was simply absent, and the panel reported a clean verdict over an inventory missing a table.

Third instance of the shape: #1542 fixed the listing, #1541 fixed restore. The helpers those added (`listBaselinesMerged`, `baselineSourcesOf`) are what this reuses.

## The decision the issue flagged

Any location that fails to answer makes the verdict `unknown`, not just all of them failing. A partial listing can only understate coverage, and an understated window names healthy tables broken. That is the cry-wolf failure `status.DeltaFloor` already refuses when archives cannot be attributed, so the third state is the honest one.

## Where the issue was wrong

It grouped `views.sql` with coverage as the same fix. Reading the code says otherwise: that file names **one** root and every state view resolves a path under it, so merging locations produces views half the readers cannot open (nobody has both a local filesystem and that bucket mounted the same way).

The real cost of silence there is quieter. When the newest snapshot has aged out of local retention but still lives in the bucket, the file pins the older local one and reads as current. So the file now **names** the newer snapshot it does not read, in its header, and the paths stay in one place. Best-effort and bounded: a second location that will not answer costs the warning, never the download.

## Verification

Five mutations, five killed, the first of each pair being the original bug:

- coverage reverted to one location → the fallback-only table vanishes from the verdict
- partial failure grading the readable half instead of degrading
- the newer-elsewhere check removed
- the header note fired unconditionally
- an unreadable second location failing the download

`internal/console` and `internal/views` green.