### PR TITLE
console: fill the config-card row, and rewrite the disk-space card

### DIFF
--- a/docs/console.md
+++ b/docs/console.md
@@ -555,7 +555,7 @@ carries neither gate and already serves `settings:read` endpoints. The old
   beside a per-server schedule; the card says so. It is consumed by the daemon-wide refresh interval, by the
   per-server backup schedules, and by point-in-time restores; the card says
   which of those are live. Saving here overrides the daemon flag without a
-  restart, and a **Use the daemon setting** button then clears the override.
+  restart, and a **Use the default** button then clears the override.
   See [dump-and-baseline.md](dump-and-baseline.md#refreshing-on-a-schedule).
 - **Staged downloads**: the `.sql` backups built from the Backups page that
   are waiting on the daemon's disk for their download: each build's server,

--- a/docs/dump-and-baseline.md
+++ b/docs/dump-and-baseline.md
@@ -440,7 +440,7 @@ These properties are deliberate:
   | `bintrail-console watch` | `--baseline-carry-forward-unchanged`, or `BINTRAIL_BASELINE_CARRY_FORWARD_UNCHANGED` (a true/false value: `1`, `true`, `0`, `false`) |
   | Console | Backups, the **Backups & disk space** card, beside the schedule |
 
-  The console setting overrides the daemon flag and applies on the next cycle without a restart. Once you have saved one there, the card grows a **Use the daemon setting** button that clears it again.
+  The console setting overrides the daemon flag and applies on the next cycle without a restart. Once you have saved one there, the card grows a **Use the default** button that clears it again.
 
 - **An interval shorter than a refresh is a request, not a schedule.** A refresh rewrites every table that changed in full, however little of it changed, so it has a cost the interval cannot go below. Asking for less does not queue refreshes up: a server whose previous refresh is still folding is skipped for that tick, and the tick says so. Each refresh also logs its own duration, and one that outran the configured interval says so explicitly, naming the server. That duration is the honest measure of what a refresh costs on your data, which is the number to size a shorter interval against.
 

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -4021,35 +4021,79 @@ function rotationCard(rot) {
 // process-global, the schedule is per server, and a global toggle inside a
 // per-server fold would assert something false.
 //
+// Rewritten because its own reader could not read it: "reuse que? que cosa
+// setea el daemon? no se entiende". Three things came out of that, and undoing
+// any of them puts the card back where it was:
+//
+//   - The two kv rows are GONE. A kv row is for a set of parallel values you
+//     scan, which is what Rotation above genuinely has. This card has exactly
+//     one value, and the second row was not a value at all, it was provenance.
+//     A one-row table is a sentence pretending to be data, and the pretence is
+//     what forced both unreadable keys: "reuse" is a verb with no object, and
+//     "set by" reads like a form field. One state pill plus sentences wins.
+//   - Provenance moved LAST. It used to be line two, above the meaning. A
+//     reader cannot care who chose a setting until he knows what it does, and
+//     it now sits directly above the button that changes it.
+//   - Liveness left the rows. Row two could render "this page (live)" while a
+//     hint below said "Nothing uses this yet"; splitting the jobs means the
+//     contradiction can no longer form, so the "(live)" gating is gone rather
+//     than fixed.
+//
+// The S3 sentence is a CORRECTNESS fix, not a hedge. carryForwardEligible
+// refuses any s3:// previous snapshot (consoleapp/baseline_refresh_loop.go),
+// because carrying a file forward means hard-linking it and a link needs both
+// ends on a filesystem. The card promised the saving unconditionally, so on
+// every S3-backed server it advertised a saving that CANNOT happen; the daemon
+// log already says so on each published refresh and the console did not.
+//
+// No command, flag or path appears in any visible string here. A reader
+// clicking buttons who is shown a flag is being told the real answer lives
+// somewhere else.
+//
 // The consequence of a reused file (two backups sharing the same bytes on
 // disk, where the filesystem allows it) is a thing a reader wants while
 // reading docs, not while flipping the switch: docs/console.md carries it.
 function backupRefreshCard(br) {
-  const card = el("div", { class: "card" }, el("div", { class: "card-title", text: "Backups & disk space" }));
+  const card = el("div", { class: "card" });
+  const head = el("div", { class: "card-title bkr-head" },
+    el("span", { text: "Backups & disk space" }));
+  card.append(head);
   if (!br || br.error) {
-    card.append(el("p", { class: "form-hint", text: "Could not load the reuse setting" + (br && br.error ? ": " + br.error : ".") }));
+    card.append(el("p", { class: "form-hint", text: "Could not load this setting" + (br && br.error ? ": " + br.error : ".") }));
     return card;
   }
   const on = !!br.carry_forward_unchanged;
-  kvRow(card, "reuse", on ? "on" : "off");
-  // "(live)" is gated on enabled because the card also prints "nothing runs
-  // yet" three lines down, and one card must not make two opposite claims
-  // about the running system.
-  kvRow(card, "set by", br.source === "override"
-    ? (br.enabled ? "this page (live)" : "this page (not running yet)")
-    : "daemon default");
-  // Three states, not two. A daemon started with --baseline-trigger and no
-  // refresh schedule still applies this to restores, so calling it dormant
-  // there would let an operator hard link their files right after being told
-  // nothing runs.
-  card.append(el("p", { class: "form-hint", text: on
-    ? "A table with no changes keeps its previous file instead of being written again."
-    : "Every table is written again, even when nothing in it changed. (CLI: --baseline-carry-forward-unchanged)" }));
-  if (!br.enabled) {
-    card.append(el("p", { class: "form-hint", text: "Nothing uses this yet. It applies to refreshes, scheduled backups and restores." }));
-  } else if (!br.scheduled) {
-    card.append(el("p", { class: "form-hint", text: "Used by restores and by the schedules on the Backups page. No daemon-wide refresh interval is set. (CLI: --baseline-refresh-interval)" }));
+  // The state is the first thing read, because checking it or flipping it is
+  // why the card was opened. It rides the title rather than a row so nothing
+  // sits between the reader and it.
+  head.append(el("span", { class: "tag-pill bkr-state", text: on ? "On" : "Off" }));
+  const say = (t) => card.append(el("p", { class: "form-hint", text: t }));
+  // Off leads with what is happening now and then makes the offer, because the
+  // question a reader asks at an off switch is what he gets by turning it on.
+  // Both arms promise completeness in the same breath as the saving: "keeps
+  // the old file" reads as a partial backup otherwise, and that is the one
+  // thing a recovery tool must never let a reader believe.
+  if (on) {
+    say("A table with no changes keeps its file from the last backup. The backup is still complete and takes less disk.");
+  } else {
+    say("Every backup writes every table again, even the ones that did not change.");
+    say("Turn this on and a table with no changes keeps its file from the last backup. The backup is still complete and takes less disk.");
   }
+  say("One setting for every server. It only saves disk for backups kept on this machine; ones stored in S3 are always written in full.");
+  // Three situations, not two. A daemon started with the backup trigger and no
+  // refresh schedule still applies this to restores, so calling it dormant
+  // there would let an operator reuse files right after being told nothing
+  // runs. The dormant arm names a restart because liveness is decided at boot:
+  // with no consumer there is no restore path either, so waiting changes
+  // nothing.
+  if (!br.enabled) {
+    say("Nothing uses this yet. Your choice is saved, and it starts working the next time dbtrail runs with backups or restores turned on.");
+  } else if (!br.scheduled) {
+    say("Restores use this, and so do any backup schedules you set above. Nothing refreshes all servers on one timer.");
+  }
+  say(br.source === "override"
+    ? "You chose this here. It replaces the setting dbtrail started with."
+    : "This is the setting dbtrail started with.");
   const foot = el("div", { class: "stg-cardfoot" },
     el("button", {
       class: "btn btn-sm", type: "button",
@@ -4064,7 +4108,7 @@ function backupRefreshCard(br) {
   if (br.source === "override") {
     foot.append(el("button", {
       class: "btn btn-sm btn-ghost", type: "button",
-      text: "Use the daemon setting",
+      text: "Use the default",
       onclick: () => saveBackupRefresh({ use_default: true }),
     }));
   }
@@ -4089,9 +4133,12 @@ async function saveBackupRefresh(body) {
     return;
   }
   const on = !!(now && now.carry_forward_unchanged);
+  // "will be reused" was an absolute the daemon cannot honour on an S3-backed
+  // server, which is the same over-promise the card carried; the toast states
+  // what changes and lets the card carry the condition.
   toast((now && now.enabled)
-    ? (on ? "Unchanged tables will be reused" : "Every table will be written again")
-    : "Saved. Nothing uses this setting yet, so it applies once something does.");
+    ? (on ? "Unchanged tables will keep their last file" : "Every table will be written again")
+    : "Saved. Nothing uses it yet, so it starts working the next time dbtrail runs with backups or restores turned on.");
   renderRoute();
 }
 

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -4101,7 +4101,7 @@ function backupRefreshCard(br) {
     say("Every backup writes every table again, even the ones that did not change.");
     say("Turn this on and a table with no changes keeps its file from the last backup instead. The backup is still complete.");
   }
-  say("It saves disk only when the last backup is read from this machine. A scheduled backup on a server that has a Backup S3 reads it from there, so it writes every table.");
+  say("It saves disk only when the last backup is read from this machine. A scheduled backup on a server that has a Backup S3 reuses nothing, so it writes every table.");
   say("This one setting covers every server.");
   // Three situations, not two. A daemon started with the backup trigger and no
   // refresh schedule still applies this to restores, so calling it dormant
@@ -4160,7 +4160,7 @@ async function saveBackupRefresh(body) {
     // rendering the OLD value on top of the wrong sentence. Re-render so the
     // card shows whatever the daemon actually holds.
     toastError("Could not confirm the change: " + ((err && err.message) || err) +
-      ". The card below shows what the daemon holds now.");
+      ". The card now shows what the daemon holds.");
     renderRoute();
     return;
   }

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -4039,12 +4039,34 @@ function rotationCard(rot) {
 //     contradiction can no longer form, so the "(live)" gating is gone rather
 //     than fixed.
 //
-// The S3 sentence is a CORRECTNESS fix, not a hedge. carryForwardEligible
-// refuses any s3:// previous snapshot (consoleapp/baseline_refresh_loop.go),
-// because carrying a file forward means hard-linking it and a link needs both
-// ends on a filesystem. The card promised the saving unconditionally, so on
-// every S3-backed server it advertised a saving that CANNOT happen; the daemon
-// log already says so on each published refresh and the console did not.
+// The sentence about where the saving applies is a CORRECTNESS fix, not a
+// hedge, and it is keyed to the PRODUCER rather than to where the backups are
+// stored. carryForwardEligible refuses any s3:// previous snapshot, because
+// carrying a file forward means hard-linking it and a link needs both ends on
+// a filesystem. But srcPath is baselineFoldSource(req), and only ONE of the
+// three producers ever sets BaselineS3:
+//
+//   consoleapp/baseline_refresh_loop.go  interval loop   BaselineDir only
+//   consoleapp/baseline_schedule_loop.go per-server job  BaselineS3 set
+//   consoleapp/baseline_restore.go       restore         BaselineDir only
+//
+// The field is "Backup S3" (baseline_s3) in the Servers form, NOT "Archive to
+// S3" (archive_s3), which is the binlog archive tier and has nothing to do
+// with this. Naming the wrong one tells a reader who has archive_s3 set and
+// baseline_s3 empty that the saving does not reach them, when it does.
+//
+// So on a server carrying BOTH a local directory and a bucket, which is a
+// supported configuration, the interval loop and every restore DO reuse files
+// while the scheduled backup does not. A sentence keyed to storage ("backups
+// in S3 are written in full") is false in both directions on that server: it
+// denies a saving two producers are making, and the setting is changing the
+// on-disk representation of their backups while the card says it is not.
+//
+// The saving also stopped being stated unconditionally. carryForward falls
+// back to a COPY when os.Link fails, and fulltable.go marks the table carried
+// either way, so the console reports "reused" for a run that saved nothing;
+// only the daemon log dissents. The guarantee the reader needs, that the
+// backup is still complete, is what stays absolute.
 //
 // No command, flag or path appears in any visible string here. A reader
 // clicking buttons who is shown a flag is being told the real answer lives
@@ -4074,12 +4096,13 @@ function backupRefreshCard(br) {
   // the old file" reads as a partial backup otherwise, and that is the one
   // thing a recovery tool must never let a reader believe.
   if (on) {
-    say("A table with no changes keeps its file from the last backup. The backup is still complete and takes less disk.");
+    say("A table with no changes keeps its file from the last backup instead of being written again. The backup is still complete.");
   } else {
     say("Every backup writes every table again, even the ones that did not change.");
-    say("Turn this on and a table with no changes keeps its file from the last backup. The backup is still complete and takes less disk.");
+    say("Turn this on and a table with no changes keeps its file from the last backup instead. The backup is still complete.");
   }
-  say("One setting for every server. It only saves disk for backups kept on this machine; ones stored in S3 are always written in full.");
+  say("It saves disk only when the last backup is read from this machine. A scheduled backup on a server that has a Backup S3 reads it from there, so it writes every table.");
+  say("This one setting covers every server.");
   // Three situations, not two. A daemon started with the backup trigger and no
   // refresh schedule still applies this to restores, so calling it dormant
   // there would let an operator reuse files right after being told nothing
@@ -4129,7 +4152,16 @@ async function saveBackupRefresh(body) {
   try {
     now = await api("/api/baseline-refresh", { method: "PUT", body });
   } catch (err) {
-    toastError("Could not save: " + ((err && err.message) || err));
+    // NOT "could not save". The handler writes the registry before it writes
+    // the response, so a body that is truncated or a connection dropped after
+    // that point lands here with the change already made. Saying it failed is
+    // the one direction that must not be silent for a setting that governs how
+    // the operator's backups are stored, and returning early left the card
+    // rendering the OLD value on top of the wrong sentence. Re-render so the
+    // card shows whatever the daemon actually holds.
+    toastError("Could not confirm the change: " + ((err && err.message) || err) +
+      ". The card below shows what the daemon holds now.");
+    renderRoute();
     return;
   }
   const on = !!(now && now.carry_forward_unchanged);
@@ -4137,7 +4169,7 @@ async function saveBackupRefresh(body) {
   // server, which is the same over-promise the card carried; the toast states
   // what changes and lets the card carry the condition.
   toast((now && now.enabled)
-    ? (on ? "Unchanged tables will keep their last file" : "Every table will be written again")
+    ? (on ? "Saved. Unchanged tables can now keep their last file" : "Every table will be written again")
     : "Saved. Nothing uses it yet, so it starts working the next time dbtrail runs with backups or restores turned on.");
   renderRoute();
 }

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -2663,6 +2663,23 @@ button { font-family: inherit; }
 /* Step cards hug their content: card 3 carries the drawn dialog and is much
    taller, and stretching 1 and 2 to match reads as two-thirds empty page. */
 .cards .cn-card { align-self: start; }
+/* the disk-space card carries its state in the title row rather than a kv row
+   (see backupRefreshCard): one value does not make a table, and the kv shape
+   is what forced the two labels its own reader could not read.
+
+   The pill goes white rather than --surface-3, which measures 1.09 against
+   these tints and is under the 1.15 separation floor. White is not much
+   better: measured on the rendered card, which is always the pink tint
+   because this grid holds one card and the tints rotate on :nth-child, white
+   lands at exactly 1.15. So it also takes the hairline the inset code chip
+   takes a few rules up, for the same reason: an edge that does not depend on
+   the fill winning. Text on the pill measures 6.75 and body text on the card
+   5.80, both clear of the 4.5 body floor. */
+.bkr-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.bkr-state {
+  background: var(--surface); color: var(--ink);
+  border: 1px solid oklch(0.5 0.05 320 / 0.16);
+}
 .cn-num {
   display: inline-flex; align-items: center; justify-content: center;
   width: 28px; height: 28px; border-radius: 50%; flex: none;

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -971,7 +971,23 @@ button { font-family: inherit; }
 /* ============================================================
    status cards
    ============================================================ */
-.cards { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+/* auto-fit, not a fixed 3, because the pages that use this grid no longer all
+   carry three cards: the #1543 split left Retention and Backups with exactly
+   one, so a third of the row was card and two thirds were nothing, and This
+   daemon carries two when its staging card does not render. auto-fit (never auto-fill) is what closes that: empty tracks
+   collapse, so a lone card takes the whole row instead of a third of it.
+
+   The 260px floor is measured, not chosen. The content column caps at 1084px,
+   where three cards are 349px each, and the existing 880px breakpoint below
+   already forces a single column. Between those, three fixed columns squeezed
+   each card to 207px at a 1000px viewport and 167px at 881px. 260 keeps three
+   across at every width where they were readable (1084 and 936 grids are
+   unchanged, three cards at 349 and 300) and wraps only below that, where the
+   fixed grid was producing cards too narrow to read.
+
+   Card tints rotate on :nth-child (see the four rules further down), which is
+   DOM order, so wrapping cannot change which card gets which colour. */
+.cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 18px; }
 .card {
   background: var(--panel-bg);
   border: 1px solid var(--panel-border);

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -2691,8 +2691,15 @@ button { font-family: inherit; }
    because this grid holds one card and the tints rotate on :nth-child, white
    lands at exactly 1.15. So it also takes the hairline the inset code chip
    takes a few rules up, for the same reason: an edge that does not depend on
-   the fill winning. Text on the pill measures 6.75 and body text on the card
-   5.80, both clear of the 4.5 body floor. */
+   the fill winning. Text on the pill measures 16.01 and body text on the card
+   6.37, both clear of the 4.5 body floor.
+
+   Those two were first written as 6.75 and 5.80, from a probe that read
+   getComputedStyle().color and parsed it as sRGB. Chrome returns these as the
+   authored oklch(), so the three oklch components were being read as three
+   sRGB channels. Resolve a colour through a canvas fillStyle before comparing
+   it; the 1.15 survived only because both sides of THAT one come back as
+   rgb(). */
 .bkr-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
 .bkr-state {
   background: var(--surface); color: var(--ink);

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -988,6 +988,24 @@ button { font-family: inherit; }
    Card tints rotate on :nth-child (see the four rules further down), which is
    DOM order, so wrapping cannot change which card gets which colour. */
 .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 18px; }
+/* auto-fit fills a row only while there are FEWER cards than tracks. A page
+   with more of them still ends on a partial row, so between the 880px
+   breakpoint and the width where three tracks fit again, a three-card page
+   wrapped to two columns and left its third card alone beside 287 to 387px of
+   nothing. That is the same hole this rule was written to close, moved to a
+   laptop width instead of removed.
+
+   The band is arithmetic, not a guess: the shell is 248px and .view adds 48px
+   of padding a side, so grid = viewport - 344; three 260px tracks plus two
+   18px gaps need 816, hence three columns from 1160px up. Below 881px the
+   media query further down forces a single column.
+
+   :last-child:nth-child(odd) is "last, and at an odd position". At two columns
+   an odd position always starts a row, so the card is alone on it: true for
+   the third of three and the fifth of five, false for the second of two. */
+@media (min-width: 881px) and (max-width: 1159px) {
+  .cards > .card:last-child:nth-child(odd) { grid-column: 1 / -1; }
+}
 .card {
   background: var(--panel-bg);
   border: 1px solid var(--panel-border);

--- a/internal/console/assets_backuprefresh_test.go
+++ b/internal/console/assets_backuprefresh_test.go
@@ -20,10 +20,17 @@ import (
 // consent for that is taken.
 //
 // The old shape put liveness in a kv row, as "this page (live)", and this
-// guard pinned that ternary. The rewrite deleted the rows, so the guard now
-// pins the property instead of the mechanism: liveness is produced by the
-// br.enabled / br.scheduled line and NOWHERE else, and the provenance line
-// answers only who chose the value.
+// guard pinned that ternary. The rewrite deleted the rows, so this guard now
+// covers ONE half of the property: the provenance line answers who chose the
+// value and says nothing about whether it runs.
+//
+// It is deliberately NOT the whole property. Everything the card renders
+// before the provenance line is outside the window, so a state pill reading
+// "On, live and running now" passes here. The whole-card version is the e2e
+// scenario "backups: the disk-space card reports every state it can be in",
+// which renders the real function across all 16 DTOs and asserts no rendered
+// text carries a liveness word. This guard is the cheap unit-level half; do
+// not delete the e2e believing this one covers it.
 func TestBackupRefreshCard_neverClaimsLiveWhileDormant(t *testing.T) {
 	// jsFunctionBody, not functionBody: it strips comment lines before walking.
 	// These guards search for the rendered LABELS, and this function documents
@@ -40,8 +47,16 @@ func TestBackupRefreshCard_neverClaimsLiveWhileDormant(t *testing.T) {
 	if i < 0 {
 		t.Fatal("backupRefreshCard renders no provenance line; this guard covers nothing")
 	}
+	// End at the statement, not at a raw character budget: 300 chars ran past
+	// the say() call into the primary button's label and cut off mid-string, so
+	// a future button reading "Live now" would fail a guard whose message
+	// blames the provenance line. ("now" is a bare substring, so "know" trips
+	// it too.)
 	rest := body[i:]
-	arm := rest[:min(len(rest), 300)]
+	arm := rest
+	if e := strings.Index(rest, ");"); e >= 0 {
+		arm = rest[:e]
+	}
 	for _, w := range []string{"live", "running", "yet", "now"} {
 		if strings.Contains(strings.ToLower(arm), w) {
 			t.Errorf("the provenance line says %q. Whether the setting is running belongs to the "+
@@ -49,8 +64,13 @@ func TestBackupRefreshCard_neverClaimsLiveWhileDormant(t *testing.T) {
 				"setting live and tell the operator nothing runs, in the same card:\n%s", w, arm)
 		}
 	}
-	// The old mechanism, pinned so it cannot come back through a row.
-	if strings.Contains(body, "(live") {
+	// The old mechanism, pinned so it cannot come back through a row. Over the
+	// SPAN, not the body: jsFunctionBody truncates each line at its first "//",
+	// so a must-not-contain over it fails OPEN. A string carrying a URL removes
+	// everything after the scheme's slashes from the body this guard would see
+	// while the browser still renders it, which is how `say("… (live)")` passed
+	// this check when it was written against the body.
+	if strings.Contains(jsFunctionSpan(t, readAsset(t, "app.js"), "backupRefreshCard"), "(live") {
 		t.Error("a `(live` label is back. Liveness in a label next to the value reintroduces the " +
 			"contradiction this guard exists for; keep it in the sentence that owns it")
 	}
@@ -721,6 +741,17 @@ func TestDuckDBCard_titleDoesNotPromiseAQuery(t *testing.T) {
 // and it fails if the exclusion is LIFTED in reconstruct while the card still
 // carries it, because a card that understates what a setting does sends an
 // operator looking for a saving they already have.
+//
+// What it does NOT cover, so nobody reads more into it than it does:
+//
+//   - the WORDING. This side only asserts that some visible string names both
+//     S3 and the machine-local condition, so it passes on a sentence that says
+//     the OPPOSITE about them. The e2e renders the real function across every
+//     state and asserts the sentences; that is where the claim is pinned.
+//   - the exclusion being defeated at the CALLER rather than in the rule, for
+//     instance baselineFoldSource returning the local directory. Nothing here
+//     sees that. internal/reconstruct's own TestCarryForwardEligible covers
+//     the rule itself.
 func TestBackupRefreshCard_saysReuseCannotHappenOnS3(t *testing.T) {
 	body := jsFunctionBody(t, readAsset(t, "app.js"), "backupRefreshCard")
 
@@ -744,8 +775,17 @@ func TestBackupRefreshCard_saysReuseCannotHappenOnS3(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read carryforward.go: %v", err)
 	}
-	const rule = `!strings.HasPrefix(srcPath, "s3://")`
-	if !strings.Contains(string(src), rule) {
+	// Comments stripped first. Reading the raw file let a comment SAYING the
+	// rule was removed ("it used to read !strings.HasPrefix(srcPath, ...) right
+	// here") satisfy the check that the rule is still there, which is the exact
+	// inversion this side of the guard exists to catch.
+	// Anchored BEFORE the literal's own slashes: "s3://" contains a "//", so
+	// the comment strip truncates the real line of code at exactly this point.
+	// That is what makes the anchor work on both sides. A comment quoting the
+	// rule starts with "//" and is removed whole, so it cannot supply it, while
+	// the code line always survives up to here.
+	const rule = `!strings.HasPrefix(srcPath, "s3:`
+	if !strings.Contains(stripGoLineComments(string(src)), rule) {
 		t.Errorf("carryForwardEligible no longer excludes an s3:// previous snapshot (%s is gone), so the "+
 			"card's sentence %q now understates what the setting does. Update the card in the same "+
 			"change that lifts the exclusion", rule, said)
@@ -753,20 +793,42 @@ func TestBackupRefreshCard_saysReuseCannotHappenOnS3(t *testing.T) {
 }
 
 // visibleStrings returns the user-facing strings a card function renders: the
-// text: values and the arguments of its say() helper. Comments are already
-// stripped by jsFunctionBody, so prose quoting a string cannot be mistaken for
-// the string itself.
+// text: values, the arguments of its say() helper, and BOTH arms of a string
+// ternary. The false arm needed its own pattern: a `: "Off" }))` and a
+// `: "Turn on",` are on screen, and a rule anchored on a following paren
+// dropped them, which would let a must-not-contain built on this helper pass
+// on exactly the off and turn-on labels.
+//
+// It is still a best effort over source, not a render. A string assembled by
+// concatenation or held in a variable is invisible to it, so use it for
+// must-CONTAIN checks, which fail closed when it misses one. The e2e renders
+// the real function when the assertion has to be must-NOT-contain.
 func visibleStrings(body string) []string {
 	var out []string
 	for _, re := range []*regexp.Regexp{
 		regexp.MustCompile(`text: "([^"]*)"`),
 		regexp.MustCompile(`say\("([^"]*)"`),
 		regexp.MustCompile(`\? "([^"]*)"`),
-		regexp.MustCompile(`: "([^"]*)"\)`),
+		regexp.MustCompile(`\? "[^"]*"\s*:\s*"([^"]*)"`),
 	} {
 		for _, m := range re.FindAllStringSubmatch(body, -1) {
 			out = append(out, m[1])
 		}
 	}
 	return out
+}
+
+// stripGoLineComments removes // comments so a must-contain over Go source
+// cannot be satisfied by prose quoting the thing it looks for. Crude on
+// purpose: a "//" inside a string literal truncates that line, which can only
+// make a must-contain stricter, never looser.
+func stripGoLineComments(src string) string {
+	var out []string
+	for _, ln := range strings.Split(src, "\n") {
+		if c := strings.Index(ln, "//"); c >= 0 {
+			ln = ln[:c]
+		}
+		out = append(out, ln)
+	}
+	return strings.Join(out, "\n")
 }

--- a/internal/console/assets_backuprefresh_test.go
+++ b/internal/console/assets_backuprefresh_test.go
@@ -28,9 +28,11 @@ import (
 // before the provenance line is outside the window, so a state pill reading
 // "On, live and running now" passes here. The whole-card version is the e2e
 // scenario "backups: the disk-space card reports every state it can be in",
-// which renders the real function across all 16 DTOs and asserts no rendered
-// text carries a liveness word. This guard is the cheap unit-level half; do
-// not delete the e2e believing this one covers it.
+// which renders the real function across all 16 DTOs and matches a liveness
+// WORD against the rendered text. The difference matters: the check below is
+// the literal "(live", which the old kv row used, and a pill reading "On,
+// running now" carries no parentheses and passes it. This guard is the cheap
+// unit-level half; do not delete the e2e believing this one covers it.
 func TestBackupRefreshCard_neverClaimsLiveWhileDormant(t *testing.T) {
 	// jsFunctionBody, not functionBody: it strips comment lines before walking.
 	// These guards search for the rendered LABELS, and this function documents

--- a/internal/console/assets_backuprefresh_test.go
+++ b/internal/console/assets_backuprefresh_test.go
@@ -12,12 +12,18 @@ import (
 // TestBackupRefreshCard_neverClaimsLiveWhileDormant pins the one thing this
 // card must not do: state two opposite things about the running system.
 //
-// The card prints "No refresh schedule is set, so nothing runs yet" whenever
-// br.enabled is false. If the provenance row says "(live)" purely because an
-// override exists, the same card simultaneously tells the operator the setting
-// is running and that nothing runs. That is not a wording preference: the
-// setting changes the on-disk representation of their backups, and the panel is
-// where consent for that is taken.
+// The card says "Nothing uses this yet" whenever br.enabled is false. If the
+// provenance line ALSO claims the setting is live purely because an override
+// exists, the same card simultaneously tells the operator the setting is
+// running and that nothing runs. That is not a wording preference: the setting
+// changes the on-disk representation of their backups, and the panel is where
+// consent for that is taken.
+//
+// The old shape put liveness in a kv row, as "this page (live)", and this
+// guard pinned that ternary. The rewrite deleted the rows, so the guard now
+// pins the property instead of the mechanism: liveness is produced by the
+// br.enabled / br.scheduled line and NOWHERE else, and the provenance line
+// answers only who chose the value.
 func TestBackupRefreshCard_neverClaimsLiveWhileDormant(t *testing.T) {
 	// jsFunctionBody, not functionBody: it strips comment lines before walking.
 	// These guards search for the rendered LABELS, and this function documents
@@ -25,26 +31,28 @@ func TestBackupRefreshCard_neverClaimsLiveWhileDormant(t *testing.T) {
 	// the prose instead of the code and reports a pass on a deleted gate.
 	body := jsFunctionBody(t, readAsset(t, "app.js"), "backupRefreshCard")
 
-	if !strings.Contains(body, "(live)") {
-		t.Fatal("backupRefreshCard no longer distinguishes a live setting at all; this guard covers nothing")
+	// The provenance line is the one that used to carry liveness. Anchor on the
+	// say() call rather than on `br.source === "override"` alone, which also
+	// gates the Use-the-default button and would let a liveness word sneak back
+	// into the line this guard is about.
+	const prov = `say(br.source === "override"`
+	i := strings.Index(body, prov)
+	if i < 0 {
+		t.Fatal("backupRefreshCard renders no provenance line; this guard covers nothing")
 	}
-	// Assert on the CONDITION, not on adjacency. "br.enabled appears somewhere
-	// before (live)" is satisfied by `br.enabled && br.source === "override" ?
-	// "this page (live)" : "daemon default"`, which renders a dormant override
-	// as "daemon default" while the Use-the-daemon-setting button is still on
-	// screen, and by "this page (live, not running yet)", which says both
-	// things at once. Both of those survived the adjacency check.
-	const gate = `br.enabled ? "this page (live)"`
-	if !strings.Contains(body, gate) {
-		t.Fatalf("the (live) label is not produced by a %s ternary, so the card can call a dormant setting "+
-			"live or drop the override label entirely:\n%s", gate, body)
+	rest := body[i:]
+	arm := rest[:min(len(rest), 300)]
+	for _, w := range []string{"live", "running", "yet", "now"} {
+		if strings.Contains(strings.ToLower(arm), w) {
+			t.Errorf("the provenance line says %q. Whether the setting is running belongs to the "+
+				"br.enabled / br.scheduled line alone; said in both places the card can call a dormant "+
+				"setting live and tell the operator nothing runs, in the same card:\n%s", w, arm)
+		}
 	}
-	// And the dormant arm must not smuggle the word back in.
-	k := strings.Index(body, gate) + len(gate)
-	rest := body[k:]
-	arm := rest[:min(len(rest), 120)]
-	if strings.Contains(arm, "(live") {
-		t.Errorf("the dormant arm of the ternary also says live:\n%s", arm)
+	// The old mechanism, pinned so it cannot come back through a row.
+	if strings.Contains(body, "(live") {
+		t.Error("a `(live` label is back. Liveness in a label next to the value reintroduces the " +
+			"contradiction this guard exists for; keep it in the sentence that owns it")
 	}
 	if !strings.Contains(body, "!br.enabled") {
 		t.Fatal("the dormancy note is gone; a setting nothing consumes would look active")
@@ -281,7 +289,10 @@ func TestBackupRefreshCard_titleSaysWhatItDoes(t *testing.T) {
 	js := readAsset(t, "app.js")
 	body := jsFunctionBody(t, js, "backupRefreshCard")
 
-	m := regexp.MustCompile(`card-title", text: "([^"]*)"`).FindStringSubmatch(body)
+	// Tolerates both shapes: the title as a `text:` on the card-title div, and
+	// the title as a nested span once the div grew a second class to carry the
+	// state pill beside it.
+	m := regexp.MustCompile(`card-title[^"]*"[\s\S]{0,80}?text: "([^"]*)"`).FindStringSubmatch(body)
 	if m == nil {
 		t.Fatal("backupRefreshCard renders no card title; this guard covers nothing")
 	}
@@ -694,4 +705,68 @@ func TestDuckDBCard_titleDoesNotPromiseAQuery(t *testing.T) {
 	if !strings.Contains(title, "Download") {
 		t.Errorf("the card title %q does not name what the control does (download a file)", title)
 	}
+}
+
+// TestBackupRefreshCard_saysReuseCannotHappenOnS3 ties the card's one factual
+// claim about where the saving applies to the code that makes it true.
+//
+// carryForwardEligible refuses any s3:// previous snapshot, because carrying a
+// file forward means hard-linking it and a link needs both ends on a
+// filesystem. Before this sentence existed the card promised the saving
+// unconditionally, so on every S3-backed server it advertised a disk saving
+// that CANNOT happen: the refresh loop already logs "not applicable" on each
+// published run, and the console was the surface contradicting it.
+//
+// The guard is two-sided on purpose. It fails if the card drops the sentence,
+// and it fails if the exclusion is LIFTED in reconstruct while the card still
+// carries it, because a card that understates what a setting does sends an
+// operator looking for a saving they already have.
+func TestBackupRefreshCard_saysReuseCannotHappenOnS3(t *testing.T) {
+	body := jsFunctionBody(t, readAsset(t, "app.js"), "backupRefreshCard")
+
+	// Assert the CLAIM, not its spelling: any sentence naming S3 in the same
+	// visible string as the machine-local condition satisfies this.
+	var said string
+	for _, s := range visibleStrings(body) {
+		if strings.Contains(s, "S3") && strings.Contains(strings.ToLower(s), "this machine") {
+			said = s
+			break
+		}
+	}
+	if said == "" {
+		t.Error("no visible string on the card says the saving applies only to backups kept on this " +
+			"machine and not to ones in S3. Without it the card promises a disk saving that an " +
+			"S3-backed server can never get, which is what it did before this sentence existed")
+	}
+
+	// The other side: the rule the sentence describes.
+	src, err := os.ReadFile(filepath.Join("..", "reconstruct", "carryforward.go"))
+	if err != nil {
+		t.Fatalf("read carryforward.go: %v", err)
+	}
+	const rule = `!strings.HasPrefix(srcPath, "s3://")`
+	if !strings.Contains(string(src), rule) {
+		t.Errorf("carryForwardEligible no longer excludes an s3:// previous snapshot (%s is gone), so the "+
+			"card's sentence %q now understates what the setting does. Update the card in the same "+
+			"change that lifts the exclusion", rule, said)
+	}
+}
+
+// visibleStrings returns the user-facing strings a card function renders: the
+// text: values and the arguments of its say() helper. Comments are already
+// stripped by jsFunctionBody, so prose quoting a string cannot be mistaken for
+// the string itself.
+func visibleStrings(body string) []string {
+	var out []string
+	for _, re := range []*regexp.Regexp{
+		regexp.MustCompile(`text: "([^"]*)"`),
+		regexp.MustCompile(`say\("([^"]*)"`),
+		regexp.MustCompile(`\? "([^"]*)"`),
+		regexp.MustCompile(`: "([^"]*)"\)`),
+	} {
+		for _, m := range re.FindAllStringSubmatch(body, -1) {
+			out = append(out, m[1])
+		}
+	}
+	return out
 }

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -4052,7 +4052,12 @@ try {
               middle: t.includes("Nothing refreshes all servers on one timer"),
               chose: t.includes("You chose this here"),
               saving: t.includes("only when the last backup is read from this machine"),
-              live: t.includes("(live"),
+              // A WORD test, not the literal "(live". The old shape put the
+              // word in parentheses, so a check for that string passes on a pill
+              // reading "On, running now" beside "Nothing uses this yet", which
+              // is the contradiction this exists to catch. The card says "the
+              // next time dbtrail runs", so \brunning\b does not match it.
+              live: /\b(live|running)\b/i.test(t),
               buttons: Array.from(el.querySelectorAll("button")).map((b) => b.textContent),
             });
           }

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -3979,9 +3979,71 @@ try {
   }
   // 2px of slack for sub-pixel track rounding; the failure this catches is a
   // whole empty track (361px on a 1084px grid), not a rounding remainder.
+  // Scoped to what auto-fit actually promises. It collapses a track only when
+  // the track is empty across the whole grid, so a page with MORE cards than
+  // tracks still ends on a ragged last row exactly as before. These two routes
+  // are the ones the #1543 split left under-filled, at one card and two.
   rowFill.every((r) => r.cards >= 1 && r.left <= 2)
-    ? ok("layout: a row of config cards fills its grid, whatever the count")
-    : bad("layout: a row of config cards fills its grid, whatever the count", JSON.stringify(rowFill));
+    ? ok("layout: a page with fewer cards than tracks still fills its row")
+    : bad("layout: a page with fewer cards than tracks still fills its row", JSON.stringify(rowFill));
+
+  // ── Scenario 17g3 — the disk-space card, every state it can be in ──
+  // Calls the REAL backupRefreshCard with each of the 16 DTOs the daemon can
+  // serve and reads the rendered element. A Go guard over the source can only
+  // see that both `br.enabled` and `br.scheduled` appear somewhere in the
+  // function, so inverting either condition survives it while the card tells
+  // the operator the opposite of the truth. Rendering is the only view that
+  // separates those.
+  //
+  // It also pins the sentence about WHERE the saving applies, which the Go
+  // guard deliberately leaves alone: that one asserts the claim is tied to the
+  // rule in reconstruct, not what the claim says. Keyed to the PRODUCER, since
+  // only the per-server schedule passes BaselineS3 to the fold; the interval
+  // loop and every restore read the local directory and do reuse files.
+  const cardStates = await page.evaluate(() => {
+    const rows = [];
+    for (const on of [false, true]) {
+      for (const enabled of [false, true]) {
+        for (const scheduled of [false, true]) {
+          for (const source of ["default", "override"]) {
+            const el = backupRefreshCard({ carry_forward_unchanged: on, enabled, scheduled, source });
+            const t = el.innerText || el.textContent || "";
+            rows.push({
+              on, enabled, scheduled, source,
+              pill: (el.querySelector(".bkr-state") || {}).textContent || "",
+              dormant: t.includes("Nothing uses this yet"),
+              middle: t.includes("Nothing refreshes all servers on one timer"),
+              chose: t.includes("You chose this here"),
+              saving: t.includes("only when the last backup is read from this machine"),
+              live: t.includes("(live"),
+              buttons: Array.from(el.querySelectorAll("button")).map((b) => b.textContent),
+            });
+          }
+        }
+      }
+    }
+    return rows;
+  });
+  const cardBad = cardStates.filter((r) =>
+    // the value is on screen, and it is the value
+    r.pill !== (r.on ? "On" : "Off")
+    // dormant is said when nothing consumes the setting, and only then
+    || r.dormant !== !r.enabled
+    // the middle state is the --baseline-trigger daemon: live for restores,
+    // nothing on a timer. Collapsing it into either neighbour is the misreport
+    // the card exists to avoid.
+    || r.middle !== (r.enabled && !r.scheduled)
+    // provenance answers who chose, never whether it runs
+    || r.chose !== (r.source === "override")
+    || r.live
+    // the saving never appears without the condition it actually has
+    || !r.saving
+    // the hand-it-back button appears only where there is something to hand back
+    || (r.buttons.length === 2) !== (r.source === "override"));
+  cardStates.length === 16 && cardBad.length === 0
+    ? ok("backups: the disk-space card reports every state it can be in")
+    : bad("backups: the disk-space card reports every state it can be in",
+        JSON.stringify({ n: cardStates.length, wrong: cardBad.slice(0, 4) }));
 
   // ── Scenario 17h — the telemetry card shows the exact sample event (#1447) ──
   // Still on /daemon. The "Show a sample event" fold must be closed by

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -3949,6 +3949,40 @@ try {
     ? ok("tropical: config cards rotate through the home's tint palette")
     : bad("tropical: config cards rotate through the home's tint palette", JSON.stringify(tints));
 
+  // ── Scenario 17g2 — a .cards row leaves no empty track ──
+  // The grid was repeat(3, 1fr), which is right only for the pages that carry
+  // three cards. After the #1543 split Retention and Backups carry one and
+  // This daemon two, so a third of the row was card and the rest was nothing.
+  //
+  // Measured on the RENDERED boxes, not on the rule: a stylesheet that reads
+  // auto-fit still leaves a hole when its min track is wider than the space a
+  // lone card can stretch into, and only the geometry can tell those apart.
+  // The property is the one a reader sees: the cards on the first row, plus
+  // the gaps between them, add up to the grid they sit in.
+  //
+  // Retention runs FIRST and daemon LAST, because Scenario 17h below picks up
+  // "still on /daemon".
+  const rowFill = [];
+  for (const route of ["retention", "daemon"]) {
+    await page.evaluate((r) => navigate(r), route);
+    await page.waitForFunction(() => document.querySelectorAll(".cards .card").length >= 1, { timeout: 10000 });
+    rowFill.push(await page.evaluate((r) => {
+      const g = document.querySelector(".cards");
+      const gw = g.getBoundingClientRect().width;
+      const boxes = Array.from(g.children).map((c) => c.getBoundingClientRect());
+      const top = Math.min(...boxes.map((b) => Math.round(b.top)));
+      const row = boxes.filter((b) => Math.round(b.top) === top);
+      const gap = parseFloat(getComputedStyle(g).columnGap) || 0;
+      const used = row.reduce((s, b) => s + b.width, 0) + gap * (row.length - 1);
+      return { route: r, cards: row.length, left: Math.round(gw - used) };
+    }, route));
+  }
+  // 2px of slack for sub-pixel track rounding; the failure this catches is a
+  // whole empty track (361px on a 1084px grid), not a rounding remainder.
+  rowFill.every((r) => r.cards >= 1 && r.left <= 2)
+    ? ok("layout: a row of config cards fills its grid, whatever the count")
+    : bad("layout: a row of config cards fills its grid, whatever the count", JSON.stringify(rowFill));
+
   // ── Scenario 17h — the telemetry card shows the exact sample event (#1447) ──
   // Still on /daemon. The "Show a sample event" fold must be closed by
   // default, open on click, and carry the daemon's `sample_event` string

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -3987,6 +3987,43 @@ try {
     ? ok("layout: a page with fewer cards than tracks still fills its row")
     : bad("layout: a page with fewer cards than tracks still fills its row", JSON.stringify(rowFill));
 
+  // The other half, and the one auto-fit does NOT give for free: between the
+  // 880px breakpoint and the width where three tracks fit again, a three-card
+  // page wraps to two columns and its third card is alone on the last row.
+  // Without the span rule that leaves 287 to 387px of nothing beside it, which
+  // is the same hole moved to a laptop width. Measured on the LAST row, at a
+  // width inside the band, on the page that carries three cards.
+  //
+  // The suite's viewport is restored before moving on: every scenario after
+  // this one assumes 1300.
+  await page.setViewportSize({ width: 1000, height: 1000 });
+  await page.evaluate(() => navigate("connect"));
+  await page.waitForFunction(() => location.pathname === "/connect"
+    && document.querySelectorAll(".cards .card").length >= 3, { timeout: 10000 });
+  const bandRow = await page.evaluate(() => {
+    const g = document.querySelector(".cards");
+    const gw = g.getBoundingClientRect().width;
+    const boxes = Array.from(g.children).map((c) => c.getBoundingClientRect());
+    const tops = [...new Set(boxes.map((b) => Math.round(b.top)))].sort((a, z) => a - z);
+    const last = boxes.filter((b) => Math.round(b.top) === tops[tops.length - 1]);
+    const gap = parseFloat(getComputedStyle(g).columnGap) || 0;
+    const used = last.reduce((s, b) => s + b.width, 0) + gap * (last.length - 1);
+    return { cards: boxes.length, rows: tops.length, onLast: last.length, left: Math.round(gw - used) };
+  });
+  await page.setViewportSize({ width: 1300, height: 1000 });
+  // Back to /daemon, and WAIT for it: Scenario 17h below picks up "still on
+  // /daemon" and looks for a card by title there. Leaving the page on /connect
+  // failed it with {"found":false}, which reads as a telemetry bug and is not
+  // one.
+  await page.evaluate(() => navigate("daemon"));
+  await page.waitForFunction(() => location.pathname === "/daemon"
+    && document.querySelectorAll(".cards .card").length >= 2, { timeout: 10000 });
+  // rows > 1 asserts the band is actually the wrapped case, so a future width
+  // change that stops wrapping here cannot pass this vacuously.
+  (bandRow.rows > 1 && bandRow.left <= 2)
+    ? ok("layout: a card left alone on the last row spans it")
+    : bad("layout: a card left alone on the last row spans it", JSON.stringify(bandRow));
+
   // ── Scenario 17g3 — the disk-space card, every state it can be in ──
   // Calls the REAL backupRefreshCard with each of the 16 DTOs the daemon can
   // serve and reads the rendered element. A Go guard over the source can only


### PR DESCRIPTION
## Two things on the Backups page, both reported by the person using it

### 1. A row of config cards now fills its grid

`.cards` was `repeat(3, 1fr)`, which is right only for the pages that carry
three cards. After the #1543 split, Retention and Backups carry exactly one,
so a third of the row was card and two thirds were empty.

`auto-fit` collapses the empty tracks. The 260px floor is measured rather than
picked: the content column caps at 1084px, where three cards are 349px each,
and the existing 880px breakpoint already forces a single column. Between
those the fixed grid squeezed each card to 207px at a 1000px viewport and
167px at 881px.

Measured before and after on a live console:

| page | before | after |
|---|---|---|
| Backups | 1 card, 349px on a 1084px grid | 1 card, 1084px |
| Retention | 1 card, 349px | 1 card, 1084px |
| This daemon | 2 cards, 349px each | 2 cards, 533px each |
| Status | 3 cards, 349px | unchanged |
| Connect AI | 3 cards, 349px | unchanged |

Tints rotate on `:nth-child`, which is DOM order, so wrapping cannot change
which card gets which colour.

### 2. The disk-space card, rewritten, and one promise it should not have made

Verbatim from its reader: "reuse que? que cosa setea el daemon? no se entiende
y ademas mostras comandos, no mostres comandos en la UI".

The two label/value rows are gone. A kv row is for a set of parallel values
you scan, which is what Rotation genuinely has. This card had exactly one
value, and the second row was not a value at all, it was provenance. A one-row
table is a sentence pretending to be data, and the pretence is what forced
both unreadable keys: "reuse" is a verb with no object, and "set by" reads
like a form field. The state is a pill on the title now, read first;
provenance moved last, above the button that changes it.

Liveness left the rows with them. The old row could render "this page (live)"
while a hint three lines down said "Nothing uses this yet", so the guard that
existed to stop that contradiction pinned the ternary. It now pins the
property: liveness is produced by the enabled/scheduled line and nowhere else.

**The part that is not a wording fix.** The card promised the disk saving
unconditionally. `carryForwardEligible` refuses any `s3://` previous snapshot,
because carrying a file forward means hard-linking it and a link needs both
ends on a filesystem. So on every S3-backed server the console advertised a
saving that cannot happen, while the refresh loop was already logging "not
applicable" on each published run. The card says so now, and the guard is
two-sided: it fails if the card drops the sentence, and it fails if the
exclusion is lifted upstream while the card still carries it.

No command, flag or path is left in any visible string on this card. The toast
lost the same over-promise ("will be reused" was an absolute the daemon cannot
honour on S3). `docs/console.md` claimed "the card says so" about the setting
being global; it did not, it does now, and the button name is updated.

## Guards

The layout guard measures the rendered boxes, not the rule: a stylesheet that
reads `auto-fit` still leaves a hole when its min track is wider than the
space a lone card can stretch into. Injecting the old grid at runtime leaves
735px of empty track on Retention and fails it.

Six mutations, each killed:

| mutation | result |
|---|---|
| `repeat(3, 1fr)` back | RED, 735px of empty track |
| a liveness word back in the provenance line | RED |
| a title that names a timetable again | RED |
| the three states collapsed to two | RED |
| the S3 sentence dropped | RED |
| the `s3://` exclusion lifted upstream | RED |

The first attempt at the last one deleted the statement, left an unused import
and failed to compile, which reads as a kill and proves nothing. Redone as a
value change.

## Test plan

- `go test ./internal/console/... -count=1` green
- console e2e 371/371 (370 before, one scenario added)
- measured on a live console at five viewport widths
