### PR TITLE
console: move the DuckDB schema card from Connect AI to Backups

### DIFF
--- a/consoleapp/compose_sqlpanel_test.go
+++ b/consoleapp/compose_sqlpanel_test.go
@@ -80,9 +80,12 @@ func TestSQLPanelEnvIsReportedAsRetired(t *testing.T) {
 				t.Fatalf("value %q: warned=%v, want %v (log: %s)", tc.value, got, tc.wantWarn, buf.String())
 			}
 			// The warning has to say what to do instead, or it is only an
-			// obituary. Connect is where the DuckDB schema download went.
-			if tc.wantWarn && !strings.Contains(buf.String(), "Connect") {
-				t.Errorf("the warning does not point at the Connect page: %s", buf.String())
+			// obituary. Backups is where the DuckDB schema download lives
+			// (#1581); Connect only serves the read-only console, so an
+			// assertion on "Connect" alone would be satisfied by the
+			// parenthetical while every watch operator is misdirected.
+			if tc.wantWarn && !strings.Contains(buf.String(), "Backups") {
+				t.Errorf("the warning does not point at the Backups page: %s", buf.String())
 			}
 		})
 	}

--- a/consoleapp/serve.go
+++ b/consoleapp/serve.go
@@ -342,8 +342,13 @@ func warnSQLPanelRetired() {
 	if strings.TrimSpace(os.Getenv("BINTRAIL_CONSOLE_SQL_PANEL")) == "" {
 		return
 	}
+	// Page-neutral wording on purpose: one function warns for BOTH binaries,
+	// and the card lives on Backups under `watch` and on Connect only for the
+	// serve-only fallback (#1581) — naming a single page here sends half the
+	// operators to a page without the card.
 	slog.Warn("BINTRAIL_CONSOLE_SQL_PANEL is set but no longer does anything: " +
 		"the console SQL page and POST /api/sql were removed. Download a DuckDB schema " +
-		"from the Connect page and query the same Parquet in your own DuckDB. " +
+		"from the console's Backups page (Connect, on a read-only console) and query " +
+		"the same Parquet in your own DuckDB. " +
 		"Remove the variable; a future release stops reading it")
 }

--- a/docs/console.md
+++ b/docs/console.md
@@ -528,13 +528,18 @@ Two cards left the page entirely. **Backups & disk space** moved to the
 Backups page, beside the **Scheduled backups** it was being confused with:
 those two names both promised "backups, automatically" from different pages,
 for unrelated settings, and side by side the difference needs no paragraph.
-**Download a DuckDB schema** moved to the SQL page, and from there to
-**Connect** (#1549): `GET /api/views.sql` requires `settings:read`, while the
+**Download a DuckDB schema** moved to the SQL page, from there to
+**Connect** (#1549) — `GET /api/views.sql` requires `settings:read`, while the
 SQL page is gated on `query:execute` and on the `sql` capability, so the
 download was unreachable for a role the endpoint would have authorized, and
-gone entirely on a daemon started with `BINTRAIL_CONSOLE_SQL_PANEL=0`. Connect
-carries neither gate and already serves `settings:read` endpoints. The old
-`/storage` link still works and lands on Retention.
+gone entirely on a daemon started with `BINTRAIL_CONSOLE_SQL_PANEL=0` — and
+finally to **Backups** (#1581), below the snapshot listing: the file describes
+the baseline snapshots, and the `.tar.gz` of the very same files downloads
+from that page, so the two halves of one task now share it. `GET
+/api/baselines` requires the same `settings:read`, so the move loses nobody
+the download. On a read-only console (`serve`, where the Backups page does
+not exist) the card still renders on Connect. The old `/storage` link still
+works and lands on Retention.
 
 - **Backups & disk space** (#1528/#1543, formerly *File reuse for unchanged
   tables*, and before that *Automatic backup refresh*) — the one behaviour
@@ -565,7 +570,7 @@ carries neither gate and already serves `settings:read` endpoints. The old
   could not be removed stays listed with the reason (a previous build a
   newer one could not clear included) and is retried every minute. Shown
   only on a daemon that can build `.sql` backups.
-- **Download a DuckDB schema** (#1528, formerly *Query in DuckDB*; on Connect since #1549) — a one-click download of `views.sql`: a ready-made
+- **Download a DuckDB schema** (#1528, formerly *Query in DuckDB*; on Backups since #1581, below the snapshot listing) — a one-click download of `views.sql`: a ready-made
   DuckDB schema over the selected server's own Parquet — one
   `state_<schema>_<table>` view per table in the newest baseline snapshot, plus
   an `events` view across every archive source registered in `archive_state`
@@ -694,7 +699,7 @@ way to learn the derived `state_*` names — built the whole catalog and hit tha
 budget, and the page's own example named `events`.
 
 Query the same Parquet in your own DuckDB instead. **Download a DuckDB schema**
-on the **Connect** page writes a `views.sql` over the same files, with no row
+on the **Backups** page writes a `views.sql` over the same files, with no row
 cap, no time limit and nothing running in the daemon. See
 [Query in DuckDB](https://www.dbtrail.com/docs/guides/query-in-duckdb/).
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -502,10 +502,10 @@ inconclusive results land, and drill into a mismatch — see
 
 **SQL over your Parquet** is not answered by the daemon. The console's SQL page
 was removed in 0.75.0 (see [The SQL panel
-(removed)](console.md#the-sql-panel-removed)). Open **Connect**, click **Open in
-DuckDB...** on the **Download a DuckDB schema** card, and run the file in your
-own DuckDB: no row cap, no time limit, and nothing executing inside the process
-that captures.
+(removed)](console.md#the-sql-panel-removed)). Open **Backups**, click
+**Download views.sql** on the **Download a DuckDB schema** card below the
+snapshot listing, and run the file in your own DuckDB: no row cap, no time
+limit, and nothing executing inside the process that captures.
 
 Notes:
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -246,7 +246,7 @@ What a stale compose file costs:
 | the console state paths on the `bintrail-state` volume | your console username and password, the servers you added, and the AI connection token live inside the container, so the next `up -d` that recreates it deletes them | **Silent.** The console comes back asking you to create a password, exactly like a fresh install, and reports no loss. Fix this one first |
 | the read-only index mount plus `BINTRAIL_INDEX_DATADIR_RO` | free disk space for the index cannot be measured | The preflight and the Retention page report it as not measurable |
 | the `iceberg-export` profile and its volume | there is no one-shot Iceberg export to run | `docker compose --profile iceberg-export run ...` says the service does not exist |
-| `BINTRAIL_CONSOLE_SQL_PANEL` (the current file does not set it) | nothing: the SQL page was removed in 0.75.0 | Remove the variable. It is read for one release and warns; download a DuckDB schema from **Connect** and query the same Parquet yourself |
+| `BINTRAIL_CONSOLE_SQL_PANEL` (the current file does not set it) | nothing: the SQL page was removed in 0.75.0 | Remove the variable. It is read for one release and warns; download a DuckDB schema from **Backups** and query the same Parquet yourself |
 
 Two things make this easier to catch:
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -522,7 +522,7 @@ readable by any DuckDB, Spark, Trino or Athena with no dbtrail involved.
 **Files, queried by name.** `bintrail views` writes a DuckDB schema over them:
 one `state_<schema>_<table>` view per table in the newest baseline, plus — with
 `--include-events` — an `events` view across every archive (the console's
-**SQL → Download a DuckDB schema** card downloads the same file). The change log
+**Backups → Download a DuckDB schema** card downloads the same file). The change log
 is opt-in because defining that view opens one Parquet footer per archived file
 before it returns a row, a cost that grows with the archive.
 

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -34,11 +34,21 @@ const SERVER_KEY = "bintrail_console_server";
 const ONBOARD_KEY = "bintrail_console_onboarded";
 
 // The generated DuckDB views file, named in two places that must not drift:
-// the Connect AI panel that produces it, and the Backups lane that sends a
-// reader there to get it. Shared rather than guarded -- a constant cannot
-// disagree with itself, and a test comparing two literals only reports the
-// drift after someone ships it.
+// the card that builds it (mounted on Backups by renderBaselines, with
+// buildConnect's serve-only fallback, #1581) and the take-away lane that
+// points a reader down the page to it. Shared rather than guarded -- a
+// constant cannot disagree with itself, and a test comparing two literals
+// only reports the drift after someone ships it.
 const DUCKDB_VIEWS_FILE = "views.sql";
+
+// The card's own class, shared by duckdbPanel (which wears it) and the
+// take-away lane's jump (which resolves it) -- the LOCATION analog of the
+// filename constant above, and for the same reason: two literals drift the
+// first time the card is restyled, and the jump's `if (c)` null-guard would
+// turn that drift into a dead button with no error and no toast. style.css
+// addresses the card by this class too, so renaming it is a three-surface
+// change however it is spelled.
+const DUCKDB_CARD_CLASS = "cn-dk";
 
 // Export columns. connection_id is INCLUDED (epic #701 D1 — no longer a
 // gated field on the events API; CSV mirrors the JSON view exactly).
@@ -889,13 +899,16 @@ function navigate(route, params, push = true) {
   // snapshot listing and the verification runner). Same treatment, so a
   // bookmark to either lands on Overview rather than an empty page.
   if ((route === "baselines" || route === "verification") && !capsCache.monitor) route = "overview";
-  // The SQL page was removed (#1549). Rewritten to Connect rather than to
-  // Overview, and rewritten rather than aliased, for the same reasons /storage
-  // is: the address bar stops naming a page that no longer exists, and the
-  // reader who bookmarked it wanted SQL over this Parquet — Connect is where
-  // the schema for their own DuckDB now lives, which Overview would not tell
-  // them.
-  if (route === "sql") { route = "connect"; history.replaceState({}, "", "/connect"); }
+  // The SQL page was removed (#1549). Rewritten rather than aliased, for the
+  // same reasons /storage is: the address bar stops naming a page that no
+  // longer exists, and the reader who bookmarked it wanted SQL over this
+  // Parquet — so land where the DuckDB schema card actually is (#1581):
+  // Backups when that page exists, Connect on the serve-only fallback. A
+  // fixed /connect target would send a watch reader to a page the card left.
+  if (route === "sql") {
+    route = capsCache.monitor ? "baselines" : "connect";
+    history.replaceState({}, "", "/" + route);
+  }
   const qs = params && Object.keys(params).length
     ? "?" + new URLSearchParams(params).toString() : "";
   if (push) history.pushState({ route }, "", "/" + route + qs);
@@ -4383,10 +4396,10 @@ function duckdbPanel() {
   // and bars are drawn in). On Backups every sibling panel is the same bare
   // section, so the shape needs no translation. The cn- class prefix is a
   // birthmark, not a location: style.css addresses the card by it.
-  const card = el("section", { class: "ov-panel cn-dk", style: "margin-top:18px" });
+  const card = el("section", { class: "ov-panel " + DUCKDB_CARD_CLASS, style: "margin-top:18px" });
   card.append(el("div", { class: "ov-panel-head" },
     el("h2", { class: "ov-panel-title", text: "Download a DuckDB schema" })));
-  const body = el("div", { class: "cn-dk-body" });
+  const body = el("div", { class: DUCKDB_CARD_CLASS + "-body" });
   card.append(body);
   const shape = duckdbShape();
   body.append(shape.el);
@@ -5812,8 +5825,8 @@ function backupTakeAway(cur, b, sqlSt) {
 }
 
 // backupFilesShape draws the count instead of stating it: on the DuckDB lane
-// two tiles when Connect AI can produce the views file and one when it
-// cannot, one on the MySQL lane. A reader who takes nothing else off
+// two tiles when the card below the list can produce the views file and one
+// when it cannot, one on the MySQL lane. A reader who takes nothing else off
 // this panel should still leave knowing that much. Built with el() and CSS
 // like duckdbShape(), never svgEl -- that path is for static icon constants.
 function backupFilesShape(files) {
@@ -5888,7 +5901,7 @@ function backupDuckLane(b) {
     // is motion, and this codebase spends motion only under the
     // prefers-reduced-motion discipline (#1392); a jump the reader asked for
     // needs no easing to be understood.
-    views.onclick = () => { const c = $(".cn-dk"); if (c) c.scrollIntoView(); };
+    views.onclick = () => { const c = $("." + DUCKDB_CARD_CLASS); if (c) c.scrollIntoView(); };
     go.append(views);
   }
   lane.append(go, msg);

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -45,9 +45,10 @@ const DUCKDB_VIEWS_FILE = "views.sql";
 // take-away lane's jump (which resolves it) -- the LOCATION analog of the
 // filename constant above, and for the same reason: two literals drift the
 // first time the card is restyled, and the jump's `if (c)` null-guard would
-// turn that drift into a dead button with no error and no toast. style.css
-// addresses the card by this class too, so renaming it is a three-surface
-// change however it is spelled.
+// turn that drift into a dead button with no error and no toast. The bare
+// class is a pure JS/e2e query hook; what style.css addresses is the DERIVED
+// `-body` class (the card body's padding), so a rename also walks through
+// there and through the e2e's selectors.
 const DUCKDB_CARD_CLASS = "cn-dk";
 
 // Export columns. connection_id is INCLUDED (epic #701 D1 — no longer a
@@ -899,12 +900,14 @@ function navigate(route, params, push = true) {
   // snapshot listing and the verification runner). Same treatment, so a
   // bookmark to either lands on Overview rather than an empty page.
   if ((route === "baselines" || route === "verification") && !capsCache.monitor) route = "overview";
-  // The SQL page was removed (#1549). Rewritten rather than aliased, for the
-  // same reasons /storage is: the address bar stops naming a page that no
-  // longer exists, and the reader who bookmarked it wanted SQL over this
-  // Parquet — so land where the DuckDB schema card actually is (#1581):
-  // Backups when that page exists, Connect on the serve-only fallback. A
+  // The SQL page was removed (#1549). A stale route string handed to
+  // navigate() lands where the DuckDB schema card actually is (#1581):
+  // Backups when that page exists, Connect on the serve-only fallback — a
   // fixed /connect target would send a watch reader to a page the card left.
+  // Scope honesty: this covers navigate() callers only. A direct load or
+  // popstate of /sql goes through renderRoute(), whose switch has no "sql"
+  // arm and falls back to Overview with the URL untouched — the same
+  // pre-#1581 shape /storage has. Retargeted here, not extended.
   if (route === "sql") {
     route = capsCache.monitor ? "baselines" : "connect";
     history.replaceState({}, "", "/" + route);
@@ -4395,7 +4398,8 @@ function duckdbPanel() {
   // orange-tint, under the 1.02 identity floor, exactly the fill the tiles
   // and bars are drawn in). On Backups every sibling panel is the same bare
   // section, so the shape needs no translation. The cn- class prefix is a
-  // birthmark, not a location: style.css addresses the card by it.
+  // birthmark, not a location: style.css styles the derived -body class, and
+  // the bare class is the query hook the lane's jump and the e2e resolve.
   const card = el("section", { class: "ov-panel " + DUCKDB_CARD_CLASS, style: "margin-top:18px" });
   card.append(el("div", { class: "ov-panel-head" },
     el("h2", { class: "ov-panel-title", text: "Download a DuckDB schema" })));

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -3947,6 +3947,13 @@ async function renderBaselines() {
     const restoreCard = backupRestoreCard(cur, baselines, restoreSt);
     if (restoreCard) v.append(restoreCard);
     v.append(baselinesPanel(baselines, servers, { serversErr: serversErr }));
+    // Directly under the list, reading as "and this is how you open them"
+    // (#1581): views.sql describes the snapshots listed above, and the
+    // .tar.gz of those same files downloads from this page, so the two
+    // halves of one task sit together. Below the list, not at the top -- on
+    // first visit the list is the page's answer, and this card is the
+    // follow-through for a reader who just took a copy.
+    if (capsCache.views) v.append(duckdbPanel());
     // Below the list: what these backups can become, for a reader who has
     // one and wants it in front of a reporting engine (#1466).
     const iceberg = icebergExportPanel(cur, baselines);
@@ -4363,19 +4370,19 @@ function duckdbNameList(names) {
 //
 // It is NOT the console SQL page, which #1549 removed: nothing here executes.
 // The title is load-bearing beyond this panel and must not be renamed casually
-// (it was "Query in DuckDB" until #1528).
+// (it was "Query in DuckDB" until #1528). Mounted on Backups since #1581,
+// under the snapshot listing the file describes; buildConnect keeps it as the
+// fallback route when /baselines does not exist (serve, no monitor).
 function duckdbPanel() {
-  // A section, not a .cn-card. sqlClientPanel already drew this line for the
-  // identical case: "the three numbered cards are the Connect AI how-to, and
-  // this is a different client". A schema file for the reader's own DuckDB is
-  // one step further out — it never talks to this console at all.
-  //
-  // Staying in the grid was not a styling choice to undo later: .cards tints
-  // every child by position, so the card took amber and read as a fourth step
-  // in a page that promises three. And the tint was eating the drawing —
-  // style.css records --surface-3 at 1.021 against orange-tint, under the 1.02
-  // identity floor, which is exactly the fill the tiles and bars are drawn in.
-  // Out here they get their hairline back.
+  // A section, not a .cn-card, wherever it mounts. On Connect, sqlClientPanel
+  // already drew this line for the identical case: "the three numbered cards
+  // are the Connect AI how-to, and this is a different client" — and .cards
+  // tints every child by position, so inside the grid the card took amber and
+  // its tint ate the drawing (style.css records --surface-3 at 1.021 against
+  // orange-tint, under the 1.02 identity floor, exactly the fill the tiles
+  // and bars are drawn in). On Backups every sibling panel is the same bare
+  // section, so the shape needs no translation. The cn- class prefix is a
+  // birthmark, not a location: style.css addresses the card by it.
   const card = el("section", { class: "ov-panel cn-dk", style: "margin-top:18px" });
   card.append(el("div", { class: "ov-panel-head" },
     el("h2", { class: "ov-panel-title", text: "Download a DuckDB schema" })));
@@ -5785,9 +5792,9 @@ async function startBackupRestore(id, at, btn, msgEl) {
 // -- and had to open two folds to learn there was an answer at all.
 //
 // The two lanes are deliberately NOT symmetrical, and the drawing is what
-// says so before any text does. DuckDB takes two files and one of them is
-// not on this page (the views file moved to Connect AI in #1549), so that
-// lane points at both. MySQL takes one file that does not exist until you
+// says so before any text does. DuckDB takes two files — the data here, and
+// the views file the card below the list produces (#1581) — so that lane
+// points at both. MySQL takes one file that does not exist until you
 // pick a moment, so that lane asks for the moment. Dressing them as a
 // matched pair would be a lie about the work each one is.
 function backupTakeAway(cur, b, sqlSt) {
@@ -5842,15 +5849,15 @@ function backupLane(title, files, tail) {
 // so the DATA half is gated on there being a backup and nothing else.
 //
 // The VIEWS half is a different promise and needs its own gate. It is not
-// produced here: the button sends the reader to Connect AI, where the panel
-// is gated on capsCache.views, and viewsAvailable() is false whenever the
-// selected server has archived data turned off (a checkbox on this console's
-// own server form), among other reasons. Ungated, this lane drew a views.sql
-// tile and a button leading to a page where that filename does not appear --
-// no error, no toast. views_api.go puts it plainly: "a button that only 404s
-// is a lie, and this codebase already refuses that trade for reconstruct and
-// verify." Naming the file from a shared constant pinned its NAME; only this
-// pins its EXISTENCE.
+// produced by this lane: the button jumps to the card below the list, which
+// renderBaselines mounts under the same capsCache.views, and viewsAvailable()
+// is false whenever the selected server has archived data turned off (a
+// checkbox on this console's own server form), among other reasons. Ungated,
+// this lane drew a views.sql tile and a button pointing at a card that is not
+// rendered -- no error, no toast. views_api.go puts it plainly: "a button
+// that only 404s is a lie, and this codebase already refuses that trade for
+// reconstruct and verify." Naming the file from a shared constant pinned its
+// NAME; only this pins its EXISTENCE.
 function backupDuckLane(b) {
   if (!b || b.error || !b.configured) return null;
   const snaps = (b.snapshots || []);
@@ -5876,7 +5883,12 @@ function backupDuckLane(b) {
   const go = el("div", { class: "bk-lane-go" }, dl);
   if (hasViews) {
     const views = el("button", { class: "btn btn-ghost", type: "button", text: "Get " + DUCKDB_VIEWS_FILE });
-    views.onclick = () => navigate("connect");
+    // A jump, not a navigation: the card that produces the file sits on THIS
+    // page since #1581, below the list. Instant on purpose -- smooth scrolling
+    // is motion, and this codebase spends motion only under the
+    // prefers-reduced-motion discipline (#1392); a jump the reader asked for
+    // needs no easing to be understood.
+    views.onclick = () => { const c = $(".cn-dk"); if (c) c.scrollIntoView(); };
     go.append(views);
   }
   lane.append(go, msg);
@@ -7118,24 +7130,16 @@ function buildConnect(servers, tokStatus, minted, fbStatus) {
   cards.append(mcpTokenCard(tokStatus, minted));
   cards.append(mcpEndpointCard(servers));
   cards.append(bundleCard());
-  // The DuckDB schema download lives here (#1549), not on /sql where #1543 put
-  // it. Two reasons, both mechanical rather than editorial:
-  //
-  // GET /api/views.sql requires settings:read, and its only door there was a
-  // nav item gated data-perm="query:execute" — so a settings:read role could
-  // not reach the download the server would have authorized, and a
-  // query:execute role without settings:read got a button that 403s. This page
-  // carries no data-perm, and every endpoint it already calls (/api/mcp-token,
-  // /api/flashback) requires the same settings:read.
-  //
-  // And the card was mounted inside the SQL page, which the `sql` capability
-  // gated. Turning that page off left `views` on with no UI route at all —
-  // punishing exactly the operator who declined server-side execution, whose
-  // file executes nothing. That page is now gone entirely, so this is the only
-  // route to the download. Appended LAST so the .cards nth-child(4n+1) tint
-  // keeps landing on the same card it does today.
+  // The DuckDB schema card lives on Backups since #1581, beside the snapshot
+  // listing it describes. It renders HERE only when that page does not exist:
+  // /baselines is capability-gated on monitor, so on a serve-only console the
+  // `views` capability would otherwise have no UI route at all — the exact
+  // regression #1549 fixed when the SQL page took the card down with it. The
+  // perm story that once anchored it here holds on both pages: GET
+  // /api/views.sql and GET /api/baselines require the same settings:read,
+  // and neither nav item carries a data-perm gate.
   v.append(cards);
-  if (capsCache.views) v.append(duckdbPanel());
+  if (capsCache.views && !capsCache.monitor) v.append(duckdbPanel());
   if (capsCache.mcp) v.append(otherClientsPanel(servers));
   v.append(sqlClientPanel(servers, fbStatus));
   viewEnter();

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -2875,8 +2875,8 @@ button { font-family: inherit; }
 
 /* The drawing: one tile per DOWNLOAD, not per file -- the Parquet tile is a
    whole folder arriving as one .tar.gz, so counting files would be wrong by
-   hundreds. TWO on the DuckDB lane (when Connect AI can produce the views
-   file) and ONE on the
+   hundreds. TWO on the DuckDB lane (when the schema card below the list can
+   produce the views file, #1581) and ONE on the
    MySQL lane, and that count is the whole message -- it says "this takes two
    files" before any sentence does. Drawn with el() and these classes, never
    svgEl (that path is for static icon constants). */

--- a/internal/console/assets_backuprefresh_test.go
+++ b/internal/console/assets_backuprefresh_test.go
@@ -279,11 +279,13 @@ func TestStorageSplit_eachHalfHoldsOnlyItsOwnConcern(t *testing.T) {
 		t.Error("nothing handles the old /storage route, so existing links break")
 	}
 	// And the DuckDB schema download has to be mounted SOMEWHERE, not merely
-	// absent from the two halves above. Its home is Backups since #1581 (see
-	// TestDuckDBCardMountsOnBackupsWithConnectFallback); what THIS pins is the
-	// serve-only fallback buildConnect keeps, the #1549 lesson: /sql gated it
-	// on a capability and a permission that are not the download's own, so
-	// BINTRAIL_CONSOLE_SQL_PANEL=0 left `views` on with no route to it.
+	// absent from the two halves above. Its home is Backups since #1581; this
+	// only pins that buildConnect still CALLS duckdbPanel at all — the gate on
+	// that call (`views && !monitor`, the serve-only fallback) is pinned
+	// exact-string by TestDuckDBCardMountsOnBackupsWithConnectFallback, not
+	// here. The #1549 lesson behind keeping any Connect mount: /sql gated the
+	// card on a capability and a permission that are not the download's own,
+	// so BINTRAIL_CONSOLE_SQL_PANEL=0 left `views` on with no route to it.
 	//
 	// Named explicitly rather than searched file-wide, because the failure
 	// this guards is the card existing while nothing calls it.

--- a/internal/console/assets_backuprefresh_test.go
+++ b/internal/console/assets_backuprefresh_test.go
@@ -279,14 +279,17 @@ func TestStorageSplit_eachHalfHoldsOnlyItsOwnConcern(t *testing.T) {
 		t.Error("nothing handles the old /storage route, so existing links break")
 	}
 	// And the DuckDB schema download has to be mounted SOMEWHERE, not merely
-	// absent from the two halves above. Connect since #1549: /sql gated it on
-	// a capability and a permission that are not the download's own, so
+	// absent from the two halves above. Its home is Backups since #1581 (see
+	// TestDuckDBCardMountsOnBackupsWithConnectFallback); what THIS pins is the
+	// serve-only fallback buildConnect keeps, the #1549 lesson: /sql gated it
+	// on a capability and a permission that are not the download's own, so
 	// BINTRAIL_CONSOLE_SQL_PANEL=0 left `views` on with no route to it.
 	//
 	// Named explicitly rather than searched file-wide, because the failure
 	// this guards is the card existing while nothing calls it.
 	if !strings.Contains(jsFunctionBody(t, js, "buildConnect"), "duckdbPanel(") {
-		t.Error("buildConnect does not mount duckdbCard, so the schema download is unreachable")
+		t.Error("buildConnect no longer mounts duckdbPanel, so a serve-only console (views on, " +
+			"monitor off — no /baselines page) has no route to the schema download")
 	}
 	// And it must not go back to the SQL page, which #1549 removed entirely.
 	// Asserted as the page's ABSENCE rather than as "renderSQL does not mount

--- a/internal/console/assets_duckdbcard_test.go
+++ b/internal/console/assets_duckdbcard_test.go
@@ -156,6 +156,36 @@ func TestDuckDBCardStaysNearlyTextless(t *testing.T) {
 	}
 }
 
+// The card mounts on Backups (#1581): the .tar.gz is the data and views.sql
+// is how you open it, so the two halves of one task share a page — below the
+// list, where it reads as "and this is how you open them". Connect AI keeps
+// it ONLY when the Backups page does not exist: /baselines is
+// capability-gated on monitor, so a serve-only console with views on would
+// otherwise have no UI route to the download at all, the regression #1549
+// fixed when the SQL page took the card down with it.
+func TestDuckDBCardMountsOnBackupsWithConnectFallback(t *testing.T) {
+	js := readAsset(t, "app.js")
+	backups := stripJSLineComments(functionBody(t, js, "async function renderBaselines("))
+	mount := strings.Index(backups, "if (capsCache.views) v.append(duckdbPanel())")
+	list := strings.Index(backups, "baselinesPanel(")
+	switch {
+	case mount < 0:
+		t.Fatal("renderBaselines does not mount duckdbPanel gated on capsCache.views; the views " +
+			"download has left the page that lists the snapshots its file describes")
+	case list < 0:
+		t.Fatal("renderBaselines no longer mounts baselinesPanel")
+	case mount < list:
+		t.Error("the DuckDB card renders ABOVE the backups list. It is the follow-through for a " +
+			"reader who just took a copy, and belongs under the listing, not at the top of the page")
+	}
+	connect := stripJSLineComments(functionBody(t, js, "function buildConnect("))
+	if !strings.Contains(connect, "if (capsCache.views && !capsCache.monitor) v.append(duckdbPanel())") {
+		t.Error("buildConnect no longer keeps the serve-only fallback (views on, monitor off). On a " +
+			"console without /baselines the views capability has no UI route at all — the exact " +
+			"regression #1549 fixed")
+	}
+}
+
 // functionBody returns the text of one top-level function in app.js, from its
 // declaration to the next top-level declaration.
 //

--- a/internal/console/assets_takeaway_test.go
+++ b/internal/console/assets_takeaway_test.go
@@ -53,26 +53,27 @@ func TestTakeAwayLaneCountIsDerivedNotWritten(t *testing.T) {
 	}
 }
 
-// The views half is a promise this page cannot keep on its own: the file is
-// produced by the Connect AI panel, which is gated on capsCache.views.
-// Ungated here, the lane drew a views.sql tile and a button leading to a page
-// where that filename does not appear -- exactly the trade views_api.go says
-// this codebase refuses ("a button that only 404s is a lie").
+// The views half is a promise this lane does not keep on its own: the file is
+// produced by the card renderBaselines mounts below the list (#1581), gated
+// on capsCache.views. Ungated here, the lane drew a views.sql tile and a
+// button pointing at a card that is not rendered -- exactly the trade
+// views_api.go says this codebase refuses ("a button that only 404s is a
+// lie").
 func TestDuckLaneGatesTheFileItDoesNotProduce(t *testing.T) {
 	js := readAsset(t, "app.js")
 	lane := stripJSLineComments(functionBody(t, js, "function backupDuckLane("))
 	if !strings.Contains(lane, "capsCache.views") {
 		t.Fatal("the DuckDB lane no longer checks capsCache.views, so it can promise a views file " +
-			"that Connect AI will not render")
+			"that no card on the page will produce")
 	}
 	// Both halves must sit behind it, and "behind" means INSIDE the branch,
 	// not merely later in the file. Comparing byte offsets was the first cut
 	// and it passed a mutation that gated the tile and left the button loose:
 	// the button still came after `const hasViews = ...`.
-	for _, half := range []string{"DUCKDB_VIEWS_FILE, cap:", `navigate("connect")`} {
+	for _, half := range []string{"DUCKDB_VIEWS_FILE, cap:", "scrollIntoView"} {
 		if !guardedByHasViews(lane, half) {
 			t.Errorf("%q is not inside an `if (hasViews)` branch. A gated tile beside an ungated "+
-				"button still sends the reader to a page with no views file on it", half)
+				"button still points the reader at a card that is not on the page", half)
 		}
 	}
 }
@@ -102,15 +103,15 @@ func guardedByHasViews(body, needle string) bool {
 	return seen
 }
 
-// The views file is named on two surfaces: the Connect AI panel that builds
-// it, and the Backups lane that sends a reader there to get it. They share a
+// The views file is named on two surfaces: the card that builds it, and the
+// take-away lane that points a reader down the page to get it. They share a
 // constant so they cannot drift; this pins that neither re-hardcodes it.
 func TestViewsFileIsNamedFromOneConstant(t *testing.T) {
 	js := stripJSLineComments(readAsset(t, "app.js"))
 	decl := regexp.MustCompile(`const DUCKDB_VIEWS_FILE = "([^"]+)"`).FindStringSubmatch(js)
 	if decl == nil {
-		t.Fatal("DUCKDB_VIEWS_FILE is gone: the Backups lane sends readers to Connect AI for that " +
-			"file by name, and two literals in two panels drift the moment one is renamed")
+		t.Fatal("DUCKDB_VIEWS_FILE is gone: the take-away lane names that file when it points at " +
+			"the card, and two literals in two panels drift the moment one is renamed")
 	}
 	// Counted as a bare substring, not as a standalone "views.sql" literal: a
 	// real re-hardcode embeds the name in a longer string (text: "Get

--- a/internal/console/assets_takeaway_test.go
+++ b/internal/console/assets_takeaway_test.go
@@ -121,7 +121,29 @@ func TestViewsFileIsNamedFromOneConstant(t *testing.T) {
 	if n := strings.Count(body, decl[1]); n != 1 {
 		t.Errorf("%q appears %d times outside a comment line; only its own declaration may spell "+
 			"it out. Everywhere else it must come from DUCKDB_VIEWS_FILE, or the Backups lane can "+
-			"promise a file Connect AI no longer produces", decl[1], n)
+			"promise a file the schema card no longer produces", decl[1], n)
+	}
+
+	// The card's CLASS has the same two-surface problem in the same file: the
+	// panel wears it, and the take-away lane's jump resolves it — through an
+	// `if (c)` null-guard, so a drift is a dead button with no error and no
+	// toast, not a crash. Same rule, same shape: one declaration, everything
+	// else through the constant.
+	cardDecl := regexp.MustCompile(`const DUCKDB_CARD_CLASS = "([^"]+)"`).FindStringSubmatch(js)
+	if cardDecl == nil {
+		t.Fatal("DUCKDB_CARD_CLASS is gone: the take-away lane resolves the card by that class, " +
+			"and two literals drift the first time the card is restyled")
+	}
+	if n := strings.Count(js, cardDecl[1]); n != 1 {
+		t.Errorf("%q appears %d times outside a comment line; only the DUCKDB_CARD_CLASS "+
+			"declaration may spell it out, or the lane's jump can resolve a class the card "+
+			"no longer wears", cardDecl[1], n)
+	}
+	for _, fn := range []string{"function duckdbPanel(", "function backupDuckLane("} {
+		if !strings.Contains(stripJSLineComments(functionBody(t, js, fn)), "DUCKDB_CARD_CLASS") {
+			t.Errorf("%s no longer goes through DUCKDB_CARD_CLASS; the card and the jump "+
+				"that targets it must share one spelling", fn)
+		}
 	}
 }
 

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -2374,11 +2374,11 @@ try {
   (mysql && mysql.tiles === 1 && mysql.lead.startsWith("One download"))
     ? ok("take-away: the MySQL lane draws one download and says so")
     : bad("take-away: the MySQL lane draws one download and says so", JSON.stringify(mysql));
-  // The views half is a promise this page cannot keep alone: the file comes
-  // from the Connect AI panel, which is gated on the same capability.
+  // The views half is a promise this lane does not keep alone: the file comes
+  // from the card below the list (#1581), gated on the same capability.
   (duck && duck.views === lanes.views && duck.tiles === (lanes.views ? 2 : 1))
-    ? ok("take-away: the views file is offered only when Connect AI can produce it")
-    : bad("take-away: the views file is offered only when Connect AI can produce it", JSON.stringify({ caps: lanes.views, duck: duck }));
+    ? ok("take-away: the views file is offered only when the schema card can produce it")
+    : bad("take-away: the views file is offered only when the schema card can produce it", JSON.stringify({ caps: lanes.views, duck: duck }));
 
   // The GATED arm, fixture-driven through the real builder. The assertions
   // above run on a stack whose views capability is ON, so the one-tile arm --

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -2416,6 +2416,40 @@ try {
     ? ok("take-away: with the capability on, the same builder draws both downloads")
     : bad("take-away: with the capability on, the same builder draws both downloads", JSON.stringify(duckOff.on));
 
+  // The Download-a-DuckDB-schema card itself, which #1581 moved to this page
+  // from Connect AI. These are the drawing and budget checks that ran on the
+  // Connect scenario while the card lived there; the page changed, the
+  // contract did not. Placement is part of the contract: below the list, the
+  // card reads as "and this is how you open them" — above it, it shoves the
+  // listing (the page's answer) below the fold.
+  const dk = await page.evaluate(() => {
+    const c = document.querySelector(".view .cn-dk");
+    if (!c) return { present: false };
+    const kids = Array.from(document.querySelector(".view").children);
+    const list = kids.findIndex((n) => /^Backups\b/.test((n.querySelector(".ov-panel-title") || {}).textContent || ""));
+    return {
+      present: true,
+      // The card's own budget (300): enough for a title, one control and a
+      // button, and not enough to start explaining. It holds on THIS page or
+      // the move quietly re-opened the prose door #1549 closed.
+      chars: c.innerText.length,
+      tiles: c.querySelectorAll(".dk-shape .dk-tile").length,
+      bars: c.querySelectorAll(".dk-shape .dk-bar").length,
+      lit: c.querySelectorAll(".dk-shape .dk-part:not(.dk-off)").length,
+      belowList: list >= 0 && kids.indexOf(c) > list,
+    };
+  });
+  (dk.present && dk.chars > 0 && dk.chars <= 300)
+    ? ok("backups: the DuckDB schema card renders here under its 300-character budget")
+    : bad("backups: the DuckDB schema card renders here under its 300-character budget", JSON.stringify(dk));
+  (dk.present && dk.tiles > 0 && dk.bars > dk.tiles && dk.lit === 1)
+    ? ok("backups: the DuckDB card draws the shape, with the change log unlit until asked for")
+    : bad("backups: the DuckDB card draws the shape, with the change log unlit until asked for",
+        JSON.stringify({ tiles: dk.tiles, bars: dk.bars, lit: dk.lit }));
+  (dk.present && dk.belowList)
+    ? ok("backups: the DuckDB card sits below the snapshot listing")
+    : bad("backups: the DuckDB card sits below the snapshot listing", JSON.stringify(dk));
+
   // Paging, EXECUTED through the real panel. The Go guards test the window
   // function and the clamp in isolation and read the call site as text; their
   // COMPOSITION is what a literal page argument breaks, and only rendering
@@ -4201,19 +4235,10 @@ try {
       // The 404-honesty rule's photographable half: this run is the
       // unversioned arm, where a direct release-asset link can only 404.
       downloadLinks: document.querySelectorAll('.view a[href*="/releases/download/"]').length,
-      // The DuckDB card carries its OWN budget (300), tighter than the view's,
-      // because it is the card that explains itself by drawing rather than by
-      // prose. Located by its title so a restyle does not silently unhook the
-      // measurement; a card that cannot be found reads as -1, never as 0,
-      // which would pass the budget by measuring nothing.
-      duckCardChars: (() => {
-        const c = Array.from(document.querySelectorAll(".view .card, .view .ov-panel"))
-          .find((n) => /Download a DuckDB schema/.test(n.textContent || ""));
-        return c ? c.innerText.length : -1;
-      })(),
-      duckDrawn: document.querySelectorAll(".view .dk-shape .dk-tile").length,
-      duckBars: document.querySelectorAll(".view .dk-shape .dk-bar").length,
-      duckLit: document.querySelectorAll(".view .dk-shape .dk-part:not(.dk-off)").length,
+      // The DuckDB schema card moved to Backups (#1581). On this stack the
+      // monitor capability is on, so the serve-only fallback must NOT render
+      // here — one surface at a time, never a duplicate.
+      duckHere: !!document.querySelector(".view .cn-dk"),
     };
   });
   (cn.badges === "123")
@@ -4225,20 +4250,12 @@ try {
   (cn.visibleChars > 0 && cn.visibleChars < 1500 && cn.fine >= 1)
     ? ok("connect: visible text stays under budget with fine print folded")
     : bad("connect: visible text stays under budget with fine print folded", "chars " + cn.visibleChars + " fine " + cn.fine);
-  // The card's own budget. 300 characters is roughly fifty words: enough for a
-  // title, one control and a button, and not enough to start explaining. The
-  // card used to carry three checkboxes and three multi-line caveats.
-  (cn.duckCardChars > 0 && cn.duckCardChars <= 300)
-    ? ok("connect: the DuckDB card stays under 300 visible characters")
-    : bad("connect: the DuckDB card stays under 300 visible characters", "chars " + cn.duckCardChars);
-  // And it is under budget because it DRAWS, not because the prose was folded
-  // out of sight. Folding passes a character count while leaving the same wall
-  // one click away, so the drawing has to be on screen for the budget to mean
-  // anything. The change-log strip starts dark: exactly one half is lit.
-  (cn.duckDrawn > 0 && cn.duckBars > cn.duckDrawn && cn.duckLit === 1)
-    ? ok("connect: the DuckDB card draws the shape, with the change log unlit until asked for")
-    : bad("connect: the DuckDB card draws the shape, with the change log unlit until asked for",
-        JSON.stringify({ tiles: cn.duckDrawn, bars: cn.duckBars, lit: cn.duckLit }));
+  // The DuckDB schema card lives on Backups since #1581; with monitor on,
+  // the Connect fallback must stay unmounted. Asserted here, photographed on
+  // the Backups scenario (which carries the drawing and budget checks).
+  (!cn.duckHere)
+    ? ok("connect: the DuckDB schema card is on Backups, not duplicated here")
+    : bad("connect: the DuckDB schema card is on Backups, not duplicated here", "the .cn-dk card rendered on /connect with monitor on");
   // "shown only once" is carried by the fresh state and the managed state
   // (except managed read_only, which drops the Lost-it clause and the phrase
   // with it); this run exercises the fresh one (no scenario mints a token).

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -4237,8 +4237,11 @@ try {
       downloadLinks: document.querySelectorAll('.view a[href*="/releases/download/"]').length,
       // The DuckDB schema card moved to Backups (#1581). On this stack the
       // monitor capability is on, so the serve-only fallback must NOT render
-      // here — one surface at a time, never a duplicate.
+      // here — one surface at a time, never a duplicate. views is the anchor
+      // that keeps the negative assertion honest: absent because the gate
+      // withheld it, not because the capability was off all along.
       duckHere: !!document.querySelector(".view .cn-dk"),
+      duckViewsCap: !!capsCache.views,
     };
   });
   (cn.badges === "123")
@@ -4253,9 +4256,10 @@ try {
   // The DuckDB schema card lives on Backups since #1581; with monitor on,
   // the Connect fallback must stay unmounted. Asserted here, photographed on
   // the Backups scenario (which carries the drawing and budget checks).
-  (!cn.duckHere)
+  (cn.duckViewsCap && !cn.duckHere)
     ? ok("connect: the DuckDB schema card is on Backups, not duplicated here")
-    : bad("connect: the DuckDB schema card is on Backups, not duplicated here", "the .cn-dk card rendered on /connect with monitor on");
+    : bad("connect: the DuckDB schema card is on Backups, not duplicated here",
+        JSON.stringify({ views: cn.duckViewsCap, rendered: cn.duckHere }));
   // "shown only once" is carried by the fresh state and the managed state
   // (except managed read_only, which drops the Lost-it clause and the phrase
   // with it); this run exercises the fresh one (no scenario mints a token).


### PR DESCRIPTION
closes #1581

## Summary
- `duckdbPanel()` mounts on the Backups page, directly below the snapshot listing, where it reads as "and this is how you open them" — the `.tar.gz` is the data and `views.sql` is how you open it, so the two halves of one task share a page.
- Connect AI keeps the card **only** when the Backups page does not exist (`serve`: `views` on, `monitor` off). `/baselines` is capability-gated on `monitor`, so removing the card outright would leave the `views` capability with no UI route — the regression #1549 fixed. One surface at a time, never a duplicate.
- The take-away lane's "Get views.sql" button jumps to the card on the same page (instant `scrollIntoView`, no smooth-motion) instead of `navigate("connect")`.
- Same download route and query parameters; nothing server-side changes. RBAC story holds: `GET /api/views.sql` and `GET /api/baselines` both require `settings:read`, and neither nav item carries a `data-perm` gate.
- Go guards updated (`TestDuckLaneGatesTheFileItDoesNotProduce` needle, new `TestDuckDBCardMountsOnBackupsWithConnectFallback`; both seen red under the reverted mounts before green). The e2e card assertions (300-char budget, drawing shape, one-lit-half) moved from the Connect scenario to the Backups scenario, plus a below-the-list placement check; Connect now asserts the card is absent with monitor on.
- Docs: `console.md`, `guide.md`, `docker.md` now name Backups as the card's page (docker.md also names the real button, "Download views.sql").

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] `node --check` on the e2e scenario file
- [x] Mutation red-checks on both new mount guards