### PR TITLE
console: one settings page for backup and snapshot parameters

### DIFF
--- a/consoleapp/backup_settings_wiring_test.go
+++ b/consoleapp/backup_settings_wiring_test.go
@@ -1,0 +1,54 @@
+package consoleapp
+
+import (
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
+)
+
+// TestUpConsoleConfig_backupSettingsDefaultsReachTheConsole pins the read path
+// of the Backups & snapshots settings page (#1582): daemon flags and env ->
+// console.Config -> the read-only rows. The page's whole promise is that each
+// row shows what the daemon was TOLD, verbatim; deleting the
+// BackupSettingsDefaults block in upConsoleConfig would leave every row
+// rendering "not set" over a fully configured daemon, which reads as an
+// unconfigured install to the operator standing in front of it.
+func TestUpConsoleConfig_backupSettingsDefaultsReachTheConsole(t *testing.T) {
+	const dsn = "user:pass@tcp(127.0.0.1:3306)/binlog_index"
+	opts := consoleOpts{Listen: "127.0.0.1:8090", Token: "tok"}
+
+	prevRetain, prevEvery := upConsoleBaselineRetain, upBaselineRefreshEvery
+	prevLock, prevTrig := upConsoleBaselineLockMode, upConsoleBaselineTrigger
+	prevStage, prevVI, prevVT := upBaselineStageDir, upVerifyInterval, upVerifyTables
+	t.Cleanup(func() {
+		upConsoleBaselineRetain, upBaselineRefreshEvery = prevRetain, prevEvery
+		upConsoleBaselineLockMode, upConsoleBaselineTrigger = prevLock, prevTrig
+		upBaselineStageDir, upVerifyInterval, upVerifyTables = prevStage, prevVI, prevVT
+	})
+
+	upConsoleBaselineRetain, upBaselineRefreshEvery = "7d", "6h"
+	upConsoleBaselineLockMode, upConsoleBaselineTrigger = baseline.LockModeNoLock, true
+	upBaselineStageDir, upVerifyInterval, upVerifyTables = "/stage", "24h", "shop.orders"
+
+	cfg, err := upConsoleConfig(nil, dsn, opts)
+	if err != nil {
+		t.Fatalf("upConsoleConfig: %v", err)
+	}
+	got := cfg.BackupSettingsDefaults
+	want := map[string]struct{ got, want string }{
+		"BaselineRetain": {got.BaselineRetain, "7d"},
+		"RefreshEvery":   {got.RefreshEvery, "6h"},
+		"LockMode":       {got.LockMode, string(baseline.LockModeNoLock)},
+		"StagingDir":     {got.StagingDir, "/stage"},
+		"VerifyInterval": {got.VerifyInterval, "24h"},
+		"VerifyTables":   {got.VerifyTables, "shop.orders"},
+	}
+	for name, w := range want {
+		if w.got != w.want {
+			t.Errorf("%s = %q, want %q: the daemon value did not reach the console verbatim", name, w.got, w.want)
+		}
+	}
+	if !got.TriggerOn {
+		t.Error("TriggerOn = false, want true")
+	}
+}

--- a/consoleapp/watch.go
+++ b/consoleapp/watch.go
@@ -1466,6 +1466,14 @@ func upConsoleOpts() consoleOpts {
 // (baselineConfigured in internal/console/server.go, which owns dir-over-s3
 // precedence) reduces to baseline presence. Extracted for testability (dbName
 // extraction + DSN validation).
+// errString renders a possibly-nil error for a wire field.
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
 func upConsoleConfig(db *sql.DB, indexDSN string, opts consoleOpts) (console.Config, error) {
 	cfg, err := mysql.ParseDSN(indexDSN)
 	if err != nil {
@@ -1514,6 +1522,7 @@ func upConsoleConfig(db *sql.DB, indexDSN string, opts consoleOpts) (console.Con
 			BaselineRetain: upConsoleBaselineRetain,
 			RefreshEvery:   upBaselineRefreshEvery,
 			LockMode:       string(upConsoleBaselineLockMode),
+			LockModeErr:    errString(upConsoleBaselineLockModeErr),
 			TriggerOn:      upConsoleBaselineTrigger,
 			StagingDir:     upBaselineStageDir,
 			VerifyInterval: upVerifyInterval,

--- a/consoleapp/watch.go
+++ b/consoleapp/watch.go
@@ -1506,6 +1506,19 @@ func upConsoleConfig(db *sql.DB, indexDSN string, opts consoleOpts) (console.Con
 		// told, reported when no console override is saved. Enabled is the
 		// loop's boot-time liveness, so the panel can say a saved setting is
 		// dormant instead of implying it is live.
+		// The Backups & snapshots settings page's read-only rows (#1582):
+		// what this daemon was told, verbatim, each under the exact flag or
+		// env name the page shows beside it. Values, not re-derivations — the
+		// page's whole job is saying where the effective value came from.
+		BackupSettingsDefaults: console.BackupSettingsDefaults{
+			BaselineRetain: upConsoleBaselineRetain,
+			RefreshEvery:   upBaselineRefreshEvery,
+			LockMode:       string(upConsoleBaselineLockMode),
+			TriggerOn:      upConsoleBaselineTrigger,
+			StagingDir:     upBaselineStageDir,
+			VerifyInterval: upVerifyInterval,
+			VerifyTables:   upVerifyTables,
+		},
 		BaselineRefreshDefaults: console.BaselineRefreshDefaults{
 			CarryForwardUnchanged: upBaselineCarryForward,
 			// Enabled is the OR because the restore consumes this setting too

--- a/docs/console.md
+++ b/docs/console.md
@@ -210,7 +210,10 @@ and searching events:
    downloadable; its status names the previous build's directory until that
    removal succeeds. The This daemon page shows what is staged while it
    exists, previous builds that could not be removed included.
-8. **Settings** (under `watch` only) — **Retention** (rotation policy and
+8. **Settings** (under `watch` only) — **Backups & snapshots** (every
+   parameter that shapes a backup or a snapshot, with its provenance — see
+   [The Backups & snapshots settings page](#the-backups--snapshots-settings-page)),
+   **Retention** (rotation policy and
    per-source S3 archiving), **This daemon** (AWS credential signals, staged
    downloads and a usage-telemetry opt-out — see
    [The Retention and This daemon pages](#the-retention-and-this-daemon-pages))
@@ -506,6 +509,34 @@ The Backups summary card that used to point here from Storage is gone (#1543):
 Backups has its own entry in the same sidebar, and the pointer only existed
 because the page it pointed away from was a drawer.
 
+### The Backups & snapshots settings page
+
+One page owns every parameter that shapes a backup or a snapshot (#1582),
+because no two of them were configured the same way: some are daemon flags,
+some are environment variables, some live per server in the registry, and the
+precedence between them — per server, then daemon flag, then nothing — was
+real and invisible. A server backed by the daemon's `--baseline-dir` showed
+an empty Backup dir field, indistinguishable from a server with no backup
+location at all.
+
+- **This daemon** — the nine daemon-wide values (`--baseline-dir`,
+  `--baseline-s3`, `--baseline-retain`, `--baseline-refresh-interval`,
+  `BINTRAIL_CONSOLE_BASELINE_LOCK_MODE`, `BINTRAIL_CONSOLE_BASELINE_TRIGGER`,
+  `BINTRAIL_CONSOLE_BASELINE_STAGING`, `--verify-interval`,
+  `--verify-tables`), each shown verbatim with the exact flag or variable
+  name and a "restart to change" chip on the row. Read-only on purpose: the
+  console never edits the process's command line or environment.
+- **Backups & disk space** — the carry-forward toggle, moved here from the
+  Backups page; it applies live, which is why it is a card with buttons and
+  not a chipped row.
+- **Per server** — each registry server's Backup dir, Backup S3 and archive
+  toggle, editable in place, with a provenance line: its own location, the
+  daemon default it falls back to, or nothing. The per-server fields left the
+  server edit form for this page (the form still round-trips them, so an
+  unrelated edit cannot wipe them). A server whose scheduled backups can only
+  run as full reads (an S3 prefix and no local folder — folding writes files)
+  says so on its row.
+
 ### The Retention and This daemon pages
 
 Under `watch` the sidebar grows two settings pages. They were one page,
@@ -528,9 +559,10 @@ Storage, which had become a drawer: seven cards from five unrelated concerns
 - **Staged downloads**, and **Usage telemetry**, both described below.
 
 Two cards left the page entirely. **Backups & disk space** moved to the
-Backups page, beside the **Scheduled backups** it was being confused with:
-those two names both promised "backups, automatically" from different pages,
-for unrelated settings, and side by side the difference needs no paragraph.
+Backups page beside **Scheduled backups** (#1543), and from there to the
+**Backups & snapshots** settings page (#1582), which owns settings the way
+the Backups page owns the work — schedules, runs and downloads stay beside
+the data they report on.
 **Download a DuckDB schema** moved to the SQL page, from there to
 **Connect** (#1549) — `GET /api/views.sql` requires `settings:read`, while the
 SQL page is gated on `query:execute` and on the `sql` capability, so the
@@ -545,12 +577,12 @@ not exist) the card still renders on Connect. The old `/storage` link still
 works and lands on Retention.
 
 - **Backups & disk space** (#1528/#1543, formerly *File reuse for unchanged
-  tables*, and before that *Automatic backup refresh*) — the one behaviour
-  behind
+  tables*, and before that *Automatic backup refresh*; on the **Backups &
+  snapshots** settings page since #1582) — the one behaviour behind
   `--baseline-carry-forward-unchanged`: whether a table with no changes in the
   window keeps its previous Parquet file instead of being written again. It has
   no timetable in it, which the first name promised and which **Scheduled
-  backups**, now directly above it, actually is. The saving is real and it is
+  backups** on the Backups page actually is. The saving is real and it is
   not free, which is what the name says: where the filesystem allows a hard
   link, two backups then share the same bytes on disk, so deleting the older
   one frees nothing while the newer one still points at it, and a `du` per

--- a/docs/console.md
+++ b/docs/console.md
@@ -210,9 +210,11 @@ and searching events:
    downloadable; its status names the previous build's directory until that
    removal succeeds. The This daemon page shows what is staged while it
    exists, previous builds that could not be removed included.
-8. **Settings** (under `watch` only) — **Backups & snapshots** (every
-   parameter that shapes a backup or a snapshot, with its provenance — see
-   [The Backups & snapshots settings page](#the-backups--snapshots-settings-page)),
+8. **Settings** — **Backups & snapshots** (every parameter that shapes a
+   backup or a snapshot, with its provenance — see
+   [The Backups & snapshots settings page](#the-backups--snapshots-settings-page);
+   on `serve` only the editable per-server half renders, since this page is
+   the one editor of a server's backup location), and under `watch` only:
    **Retention** (rotation policy and
    per-source S3 archiving), **This daemon** (AWS credential signals, staged
    downloads and a usage-telemetry opt-out — see
@@ -535,7 +537,13 @@ location at all.
   server edit form for this page (the form still round-trips them, so an
   unrelated edit cannot wipe them). A server whose scheduled backups can only
   run as full reads (an S3 prefix and no local folder — folding writes files)
-  says so on its row.
+  says so on its row, and a stored schedule that cannot run at all (say, its
+  backup location was cleared after the schedule was saved) shows the refusal
+  instead of the promise.
+
+The per-server half is the whole page on the standalone `serve` console: the
+daemon cards describe loops only `watch` runs, but the backup location is
+registry state, and this page is its only editor.
 
 ### The Retention and This daemon pages
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -480,10 +480,11 @@ Each run creates a new snapshot under
 `bintrail-state` volume), with the source's binlog coordinates embedded so
 reconstruct knows where deltas begin. Then point the console at it:
 
-- **Servers added from the UI**: Manage servers → Edit → Advanced →
-  **Baseline dir** = `/var/lib/bintrail/baselines` (a *container* path — the
-  `watch` daemon reads it, not your host). The server's Time-travel tab
-  lights up, and its row shows a TT chip under Manage servers.
+- **Servers added from the UI**: Backups & snapshots (left nav) → the
+  server's row → **Backup dir** = `/var/lib/bintrail/baselines` (a
+  *container* path — the `watch` daemon reads it, not your host). The
+  server's Time-travel tab lights up, and its row shows a TT chip under
+  Manage servers.
 - **The boot `SOURCE_DSN` entry**: set `BASELINE_DIR=/var/lib/bintrail/baselines`
   in `.env` and `docker compose up -d` again.
 

--- a/docs/dump-and-baseline.md
+++ b/docs/dump-and-baseline.md
@@ -438,7 +438,7 @@ These properties are deliberate:
   | `bintrail baseline refresh` | `--carry-forward-unchanged` |
   | `bintrail reconstruct --output-format parquet` | `--carry-forward-unchanged` |
   | `bintrail-console watch` | `--baseline-carry-forward-unchanged`, or `BINTRAIL_BASELINE_CARRY_FORWARD_UNCHANGED` (a true/false value: `1`, `true`, `0`, `false`) |
-  | Console | Backups, the **Backups & disk space** card, beside the schedule |
+  | Console | Backups & snapshots (left nav), the **Backups & disk space** card |
 
   The console setting overrides the daemon flag and applies on the next cycle without a restart. Once you have saved one there, the card grows a **Use the default** button that clears it again.
 

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -82,7 +82,10 @@ const ROUTES = ["overview", "events", "schema-changes", "timetravel", "recover",
   // recovery artifacts, not settings, and the snapshot list is unbounded in
   // practice — it pushed verification, the panel that answers "are my backups
   // restorable", roughly two screens below the fold.
-  "baselines", "verification"];
+  "baselines", "verification",
+  // The Backups & snapshots settings page (#1582): every parameter that
+  // shapes a backup or a snapshot, with its provenance.
+  "backup-settings"];
 
 // DOCS_PAGES maps a route to its page on www.dbtrail.com/docs (#1450), the
 // separately authored docs site. NOT this repo's docs/*.md: the site does not
@@ -899,7 +902,7 @@ function navigate(route, params, push = true) {
   // Protect shares that gate: both routes read watch-daemon state (the
   // snapshot listing and the verification runner). Same treatment, so a
   // bookmark to either lands on Overview rather than an empty page.
-  if ((route === "baselines" || route === "verification") && !capsCache.monitor) route = "overview";
+  if ((route === "baselines" || route === "verification" || route === "backup-settings") && !capsCache.monitor) route = "overview";
   // The SQL page was removed (#1549). A stale route string handed to
   // navigate() lands where the DuckDB schema card actually is (#1581):
   // Backups when that page exists, Connect on the serve-only fallback — a
@@ -953,6 +956,7 @@ function renderRoute() {
     case "status": return renderStatus();
     case "retention": return renderRetention();
     case "daemon": return renderDaemon();
+    case "backup-settings": return renderBackupSettings();
     case "baselines": return renderBaselines();
     case "verification": return renderVerification();
     case "connect": return renderConnect();
@@ -3891,13 +3895,9 @@ async function renderBaselines() {
   // Independent degradation, as on Storage: a panel renders its own failure
   // note rather than one error blanking the page.
   const asErr = (err) => ({ error: (err && err.message) || String(err) });
-  const [serversRes, baselines, backupRefresh] = await Promise.all([
+  const [serversRes, baselines] = await Promise.all([
     api("/api/servers").catch(asErr),
     api("/api/baselines").catch(asErr),
-    // File reuse moved here from Storage (#1528/#1543): it decides how a
-    // backup is PRODUCED, so it belongs beside the schedule it was being
-    // confused with, not on a page about where old data goes.
-    api("/api/baseline-refresh").catch(asErr),
   ]);
   if (gen !== serverGen || vgen !== viewGen) return;
   // Run states for the selected server: only the endpoints this daemon
@@ -3954,12 +3954,9 @@ async function renderBaselines() {
     // anything.
     const scheduleCard = backupScheduleCard(cur, baselines);
     if (scheduleCard) v.append(scheduleCard);
-    // Directly under the schedule, because the two were the pair #1528 named:
-    // "Automatic backup refresh" and "Scheduled backups" both promised
-    // "backups, automatically" from different pages, for unrelated settings.
-    // Side by side, under names that say what each does, the difference needs
-    // no paragraph.
-    v.append(el("div", { class: "cards" }, backupRefreshCard(backupRefresh)));
+    // The carry-forward card ("Backups & disk space") moved to the Backups &
+    // snapshots settings page (#1582): it is a setting, and this page keeps
+    // the WORK — schedules, runs, downloads — beside the data it reports on.
     const restoreCard = backupRestoreCard(cur, baselines, restoreSt);
     if (restoreCard) v.append(restoreCard);
     v.append(baselinesPanel(baselines, servers, { serversErr: serversErr }));
@@ -4195,6 +4192,180 @@ async function saveBackupRefresh(body) {
     ? (on ? "Saved. Unchanged tables can now keep their last file" : "Every table will be written again")
     : "Saved. Nothing uses it yet, so it starts working the next time dbtrail runs with backups or restores turned on.");
   renderRoute();
+}
+
+// ── Backups & snapshots settings (#1582) ────────────────────────────────────
+//
+// The one page that owns backup and snapshot parameters. Its job is
+// PROVENANCE: the precedence (per server, then daemon flag, then nothing) is
+// real and used to be invisible — a server backed by the daemon's backup
+// folder showed an empty field, indistinguishable from a server with no
+// backup location at all. Daemon-wide values render read-only with the exact
+// name to change and a restart chip ON the row, never as a prose paragraph;
+// per-server values edit in place.
+
+async function renderBackupSettings() {
+  if (!capsCache.monitor) { history.replaceState({}, "", "/overview"); renderRoute(); return; }
+  const gen = serverGen, vgen = viewGen;
+  viewLoading();
+  const asErr = (err) => ({ error: (err && err.message) || String(err) });
+  const [settings, refresh] = await Promise.all([
+    api("/api/backup-settings").catch(asErr),
+    api("/api/baseline-refresh").catch(asErr),
+  ]);
+  if (gen !== serverGen || vgen !== viewGen) return;
+  try {
+    buildBackupSettings(settings, refresh);
+  } catch (err) {
+    const v = VIEW(); clear(v); v.append(pageHead("Backups & snapshots", null)); renderError(v, err);
+  }
+}
+
+function buildBackupSettings(settings, refresh) {
+  const v = VIEW(); clear(v);
+  v.append(pageHead("Backups & snapshots", el("p", { class: "page-sub" },
+    "Every setting that shapes a backup or a snapshot, and where each value comes from.")));
+  const broken = settings && settings.error;
+  if (broken) v.append(el("div", { class: "error-box", text: "Could not load settings: " + settings.error }));
+  const cards = el("div", { class: "cards" });
+  // The carry-forward card moved here from the Backups page: it is a setting,
+  // and this page is where settings live; the Backups page keeps the work
+  // (schedules, runs, downloads) beside the data it reports on.
+  cards.append(backupRefreshCard(refresh));
+  if (!broken) cards.append(backupDaemonCard(settings.daemon || []));
+  v.append(cards);
+  if (!broken) v.append(backupServersPanel(settings));
+  viewEnter();
+}
+
+// What each daemon-wide key means, in words a reader who never saw the flag
+// can act on. The flag itself rides beside the value in the (CLI: ...) form.
+const BACKUP_DAEMON_ROWS = {
+  baseline_dir: "Backup folder for servers without their own",
+  baseline_s3: "Backup S3 for servers without their own",
+  baseline_retain: "Delete local snapshots older than",
+  refresh_every: "Rebuild the newest backup every",
+  lock_mode: "How a dump holds the database still",
+  trigger: "Create-backup button",
+  staging_dir: "Staging folder for .sql builds",
+  verify_interval: "Verify every",
+  verify_tables: "Verify only these tables",
+};
+
+// backupDaemonCard renders the values this process was started with. All of
+// them need a restart to change, and each row says so itself — a chip on the
+// control, not a sentence above it — beside the exact flag or variable name.
+function backupDaemonCard(rows) {
+  const card = el("div", { class: "card" });
+  card.append(el("div", { class: "card-title", text: "This daemon" }));
+  card.append(el("p", { class: "stg-hint", text:
+    "What this process was started with. These change on the command line or in the environment, and take effect when it restarts." }));
+  for (const row of rows) {
+    const label = BACKUP_DAEMON_ROWS[row.key] || row.key;
+    let value = row.value;
+    if (row.on != null) value = row.on ? "On" : "Off";
+    const r = el("div", { class: "bks-row" },
+      el("span", { class: "bks-label", text: label }),
+      el("span", { class: "bks-value" + (value ? "" : " muted"), text: value || "not set" }));
+    // The restart split lives ON the control, not in prose: a chip per row.
+    if (row.needs_restart) r.append(el("span", { class: "tag-pill bks-restart", text: "restart to change" }));
+    r.append(el("span", { class: "bks-cli", text: "(CLI: " + row.cli + ")" }));
+    card.append(r);
+  }
+  return card;
+}
+
+// backupServersPanel is the per-server half: the editable backup location and
+// archive toggle, each with the provenance the servers API never showed.
+function backupServersPanel(settings) {
+  const panel = el("section", { class: "ov-panel" });
+  panel.append(el("div", { class: "ov-panel-head" },
+    el("h2", { class: "ov-panel-title", text: "Per server" })));
+  const servers = settings.servers || [];
+  if (!servers.length) {
+    panel.append(el("p", { class: "form-hint", text: "No servers in the registry yet. Add one on the Servers page." }));
+    return panel;
+  }
+  if (settings.registry_read_only) {
+    panel.append(el("p", { class: "form-msg err", text:
+      "The server registry was written by a newer version and is read-only here; values are shown but cannot be saved." }));
+  }
+  for (const srv of servers) panel.append(backupServerRow(srv, settings.registry_read_only));
+  return panel;
+}
+
+function backupServerRow(srv, readOnly) {
+  const box = el("div", { class: "bks-server" });
+  box.append(el("h3", { class: "bks-server-name", text: srv.name || srv.id }));
+  const grid = el("div", { class: "form-grid" });
+  const dir = el("input", { class: "input", name: "baseline_dir", value: srv.baseline_dir || "", placeholder: "(none)" });
+  const s3 = el("input", { class: "input", name: "baseline_s3", value: srv.baseline_s3 || "", placeholder: "s3://bucket/prefix/" });
+  grid.append(
+    el("label", { class: "field" }, el("span", { class: "field-label", text: "Backup dir" }), dir),
+    el("label", { class: "field" }, el("span", { class: "field-label", text: "Backup S3" }), s3));
+  box.append(grid);
+  const noArch = el("input", { type: "checkbox", name: "no_archive" });
+  noArch.checked = !!srv.no_archive;
+  box.append(el("label", { class: "check" }, noArch,
+    el("span", { text: "Don't automatically include archived data in queries" })));
+
+  // Provenance, the row's reason to exist: which location is actually in
+  // force, and whose choice it was.
+  const src = srv.source;
+  let where;
+  if (src === "server") {
+    where = "This server names its own backup location.";
+  } else if (src === "default") {
+    const eff = srv.resolved_dir || srv.resolved_s3;
+    where = "Using the daemon default: " + eff + ". A value saved here replaces it for this server.";
+  } else {
+    where = "No backup location. Time-travel, restores and scheduled backups have nothing to read or write.";
+  }
+  box.append(el("p", { class: "form-hint", text: where }));
+
+  if (srv.schedule_every) {
+    box.append(el("p", { class: "form-hint", text:
+      "Scheduled backups: every " + srv.schedule_every + (srv.schedule_at ? " at " + srv.schedule_at : "") +
+      ". The schedule is managed on the Backups page." }));
+    // The motivating case, said where the setting lives: with no local
+    // folder the scheduled run cannot update from the recorded changes, so
+    // every run reads the database in full. Derived from the same shape the
+    // Backups page's next-run line reports; config-only here, because a
+    // settings listing must not dial every server to predict a run.
+    if (!srv.resolved_dir && srv.resolved_s3) {
+      box.append(el("p", { class: "form-hint", text:
+        "As set up, each scheduled run takes a full backup from your database: updating from the recorded changes writes files, which needs a Backup dir." }));
+    }
+  } else {
+    box.append(el("p", { class: "form-hint", text: "No scheduled backups. Set one on the Backups page." }));
+  }
+
+  const msg = el("p", { class: "form-msg err" });
+  msg.hidden = true;
+  const save = el("button", { class: "btn btn-sm", type: "button", text: "Save" });
+  save.disabled = !!readOnly;
+  if (readOnly) { dir.disabled = s3.disabled = noArch.disabled = true; }
+  save.onclick = async () => {
+    save.disabled = true;
+    msg.hidden = true;
+    try {
+      await api("/api/backup-settings/servers/" + encodeURIComponent(srv.id), {
+        method: "PUT",
+        body: { baseline_dir: dir.value.trim(), baseline_s3: s3.value.trim(), no_archive: noArch.checked },
+      });
+    } catch (err) {
+      msg.textContent = (err && err.message) || String(err);
+      msg.hidden = false;
+      save.disabled = false;
+      return;
+    }
+    toast("Saved for " + (srv.name || srv.id));
+    // Repaint from the server's answer, not from what was clicked: the
+    // provenance line depends on the resolution the daemon just recomputed.
+    renderRoute();
+  };
+  box.append(el("div", { class: "stg-cardfoot" }, save), msg);
+  return box;
 }
 
 function credentialsCard(storage) {
@@ -8256,11 +8427,16 @@ function buildServerForm() {
   idxGrid.append(srvField("User", "user", { placeholder: "bintrail" }));
   idxGrid.append(srvField("Password", "password", { type: "password", autocomplete: "new-password" }));
   idxGrid.append(srvField("Index database", "dbname", { placeholder: "binlog_index" }));
-  idxGrid.append(srvField("Backup dir", "baseline_dir", { placeholder: "(optional) enables Time-travel" }));
-  idxGrid.append(srvField("Backup S3", "baseline_s3", { placeholder: "s3://bucket/prefix/" }));
   idx.append(idxGrid);
-  idx.append(el("label", { class: "check", style: "margin-top:10px" },
-    el("input", { type: "checkbox", name: "no_archive" }), el("span", { text: "Don't automatically include archived data in queries" })));
+  // The backup location and the archive toggle are EDITED on the Backups &
+  // snapshots settings page (#1582); this form carries them as hidden
+  // passthroughs because PUT /api/servers/{id} REPLACES the entry — dropping
+  // the fields from the request would silently wipe a server's backup
+  // configuration on every unrelated edit. The prefill list below fills them
+  // like any other field.
+  idx.append(el("input", { type: "hidden", name: "baseline_dir" }));
+  idx.append(el("input", { type: "hidden", name: "baseline_s3" }));
+  idx.append(el("input", { type: "checkbox", name: "no_archive", hidden: true }));
   adv.append(idx);
   form.append(adv);
 
@@ -8293,7 +8469,10 @@ function showServerForm(prefill) {
   // round-trips as host/dbname in the DTO), so "collapsed by default"
   // means a fresh add; editing any saved entry shows its index.
   const adv = $("#server-advanced", form);
-  const hasIndexFields = !!(prefill && (prefill.host || prefill.dbname || prefill.baseline_dir || prefill.baseline_s3 || prefill.no_archive));
+  // baseline_dir/baseline_s3/no_archive left this form for the Backups &
+  // snapshots settings page (#1582); they no longer open the fold, which
+  // now only shows connection fields.
+  const hasIndexFields = !!(prefill && (prefill.host || prefill.dbname));
   // Keep "bring your own index (optional)" COLLAPSED for a monitored source:
   // its index DSN is auto-derived and round-trips as host/dbname, so expanding
   // it — e.g. when a failed-preflight error card opens the form — would show
@@ -8494,6 +8673,7 @@ function cmdkCommands() {
   if (capsCache.reconstruct) cmds.push({ group: "Navigate", label: "Time-travel", run: () => navigate("timetravel") });
   if (capsCache.monitor) cmds.push({ group: "Navigate", label: "Backups", run: () => navigate("baselines") });
   if (capsCache.monitor) cmds.push({ group: "Navigate", label: "Verification", run: () => navigate("verification") });
+  if (capsCache.monitor) cmds.push({ group: "Navigate", label: "Backups & snapshots settings", run: () => navigate("backup-settings") });
   if (capsCache.monitor) cmds.push({ group: "Navigate", label: "Retention", run: () => navigate("retention") });
   if (capsCache.monitor) cmds.push({ group: "Navigate", label: "This daemon", run: () => navigate("daemon") });
   cmds.push({ group: "Navigate", label: "Access profiles", run: () => navigate("access-profiles") });

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -902,7 +902,11 @@ function navigate(route, params, push = true) {
   // Protect shares that gate: both routes read watch-daemon state (the
   // snapshot listing and the verification runner). Same treatment, so a
   // bookmark to either lands on Overview rather than an empty page.
-  if ((route === "baselines" || route === "verification" || route === "backup-settings") && !capsCache.monitor) route = "overview";
+  if ((route === "baselines" || route === "verification") && !capsCache.monitor) route = "overview";
+  // backup-settings stays reachable without monitor: the per-server backup
+  // location is registry state serve edits too, and this page is its only
+  // editor since the server form's fields became passthroughs (#1582). The
+  // daemon cards inside it are gated instead.
   // The SQL page was removed (#1549). A stale route string handed to
   // navigate() lands where the DuckDB schema card actually is (#1581):
   // Backups when that page exists, Connect on the serve-only fallback — a
@@ -4205,13 +4209,14 @@ async function saveBackupRefresh(body) {
 // per-server values edit in place.
 
 async function renderBackupSettings() {
-  if (!capsCache.monitor) { history.replaceState({}, "", "/overview"); renderRoute(); return; }
   const gen = serverGen, vgen = viewGen;
   viewLoading();
   const asErr = (err) => ({ error: (err && err.message) || String(err) });
+  // The refresh card describes the watch daemon's loop; on serve there is no
+  // loop, no card, and nothing to fetch.
   const [settings, refresh] = await Promise.all([
     api("/api/backup-settings").catch(asErr),
-    api("/api/baseline-refresh").catch(asErr),
+    capsCache.monitor ? api("/api/baseline-refresh").catch(asErr) : Promise.resolve(null),
   ]);
   if (gen !== serverGen || vgen !== viewGen) return;
   try {
@@ -4227,13 +4232,19 @@ function buildBackupSettings(settings, refresh) {
     "Every setting that shapes a backup or a snapshot, and where each value comes from.")));
   const broken = settings && settings.error;
   if (broken) v.append(el("div", { class: "error-box", text: "Could not load settings: " + settings.error }));
-  const cards = el("div", { class: "cards" });
-  // The carry-forward card moved here from the Backups page: it is a setting,
-  // and this page is where settings live; the Backups page keeps the work
-  // (schedules, runs, downloads) beside the data it reports on.
-  cards.append(backupRefreshCard(refresh));
-  if (!broken) cards.append(backupDaemonCard(settings.daemon || []));
-  v.append(cards);
+  // The daemon-side cards are monitor-gated, not the page: serve runs no
+  // refresh loop and its daemon rows would render as an unconfigured
+  // install. The per-server panel below is the page's serve-reachable half —
+  // the only editor of the registry's backup fields.
+  if (capsCache.monitor) {
+    const cards = el("div", { class: "cards" });
+    // The carry-forward card moved here from the Backups page: it is a setting,
+    // and this page is where settings live; the Backups page keeps the work
+    // (schedules, runs, downloads) beside the data it reports on.
+    cards.append(backupRefreshCard(refresh));
+    if (!broken) cards.append(backupDaemonCard(settings.daemon || []));
+    v.append(cards);
+  }
   if (!broken) v.append(backupServersPanel(settings));
   viewEnter();
 }
@@ -4271,6 +4282,14 @@ function backupDaemonCard(rows) {
     if (row.needs_restart) r.append(el("span", { class: "tag-pill bks-restart", text: "restart to change" }));
     r.append(el("span", { class: "bks-cli", text: "(CLI: " + row.cli + ")" }));
     card.append(r);
+    // A rejected value outranks the fallback the row shows: rendering only
+    // the default on the one row whose real state is "your value was
+    // refused" is the opposite of provenance. The consequence rides in the
+    // server's err string, so this stays honest for any row that gains one.
+    if (row.err) {
+      card.append(el("p", { class: "form-msg err", text:
+        "The configured value was rejected and is not in force: " + row.err }));
+    }
   }
   return card;
 }
@@ -4335,12 +4354,19 @@ function backupServerRow(srv, readOnly) {
     box.append(el("p", { class: "form-hint", text:
       "Scheduled backups: every " + srv.schedule_every + (srv.schedule_at ? " at " + srv.schedule_at : "") +
       ". The schedule is managed on the Backups page." }));
-    // The motivating case, said where the setting lives: with no local
-    // folder the scheduled run cannot update from the recorded changes, so
-    // every run reads the database in full. Derived from the same shape the
-    // Backups page's next-run line reports; config-only here, because a
-    // settings listing must not dial every server to predict a run.
-    if (!srv.resolved_dir && srv.resolved_s3) {
+    if (srv.schedule_refusal) {
+      // The refusal beats the prediction: the schedule reads the RAW entry,
+      // so clearing the dir on this very page leaves a stored schedule that
+      // will refuse every slot — saying "every 6h" alone promises runs that
+      // will not happen.
+      box.append(el("p", { class: "form-msg err", text:
+        "The schedule cannot run as things stand: " + srv.schedule_refusal }));
+    } else if (!srv.resolved_dir && srv.resolved_s3) {
+      // The motivating case, said where the setting lives: with no local
+      // folder the scheduled run cannot update from the recorded changes, so
+      // every run reads the database in full. Derived from the same shape the
+      // Backups page's next-run line reports; config-only here, because a
+      // settings listing must not dial every server to predict a run.
       box.append(el("p", { class: "form-hint", text:
         "As set up, each scheduled run takes a full backup from your database: updating from the recorded changes writes files, which needs a Backup dir." }));
     }
@@ -8681,7 +8707,7 @@ function cmdkCommands() {
   if (capsCache.reconstruct) cmds.push({ group: "Navigate", label: "Time-travel", run: () => navigate("timetravel") });
   if (capsCache.monitor) cmds.push({ group: "Navigate", label: "Backups", run: () => navigate("baselines") });
   if (capsCache.monitor) cmds.push({ group: "Navigate", label: "Verification", run: () => navigate("verification") });
-  if (capsCache.monitor) cmds.push({ group: "Navigate", label: "Backups & snapshots settings", run: () => navigate("backup-settings") });
+  cmds.push({ group: "Navigate", label: "Backups & snapshots settings", run: () => navigate("backup-settings") });
   if (capsCache.monitor) cmds.push({ group: "Navigate", label: "Retention", run: () => navigate("retention") });
   if (capsCache.monitor) cmds.push({ group: "Navigate", label: "This daemon", run: () => navigate("daemon") });
   cmds.push({ group: "Navigate", label: "Access profiles", run: () => navigate("access-profiles") });

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -4316,8 +4316,16 @@ function backupServerRow(srv, readOnly) {
   if (src === "server") {
     where = "This server names its own backup location.";
   } else if (src === "default") {
+    // The daemon default backs the READ paths only. Create backup, restores
+    // and the schedule read the server's raw entry on purpose (the default is
+    // a shared store; folding this server's index onto another server's
+    // snapshots would publish a backup that belongs to neither, see
+    // baseline_trigger.go), so claiming the default "is in force" here told
+    // the operator their backups were covered when the write paths would
+    // refuse.
     const eff = srv.resolved_dir || srv.resolved_s3;
-    where = "Using the daemon default: " + eff + ". A value saved here replaces it for this server.";
+    where = "Using the daemon default: " + eff + ". It covers Time-travel, verification and .sql exports; " +
+      "backups, restores and the schedule need a value saved here for this server.";
   } else {
     where = "No backup location. Time-travel, restores and scheduled backups have nothing to read or write.";
   }
@@ -4719,7 +4727,7 @@ function baselineConfigHint(cur, serversErr) {
   if (cur.kind === "ephemeral") {
     return "Restart the daemon with --baseline-dir or --baseline-s3 (compose: BASELINE_DIR in .env).";
   }
-  return "Set Backup dir or S3 under Manage servers → Edit → Advanced.";
+  return "Set Backup dir or S3 on the Backups & snapshots page.";
 }
 
 function formatAge(hours) {
@@ -6374,7 +6382,7 @@ function verifyRegions(servers, opts) {
   control.append(help);
   if (!configured) {
     control.append(el("p", { class: "form-hint", text:
-      "No backup set up for this server yet. The two snapshot modes need one (Manage servers → Edit → Advanced, then create at least two snapshots). \"Check recovery inputs\" works without one: it only reads the index." }));
+      "No backup set up for this server yet. The two snapshot modes need one (Backups & snapshots page, then create at least two snapshots). \"Check recovery inputs\" works without one: it only reads the index." }));
   }
 
   // ── Region 2: what is running or just ran ──

--- a/internal/console/assets/index.html
+++ b/internal/console/assets/index.html
@@ -129,6 +129,10 @@
                by the question each half answers: what happens to your data
                over time, and what this daemon is touching. /storage stays a
                known route in app.js and rewrites to /retention. -->
+          <a class="nav-item" data-route="backup-settings" href="/backup-settings" data-capability="monitor">
+            <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12"/><path d="M7 10l5 5 5-5"/><rect x="3" y="17" width="18" height="4" rx="1"/></svg></span>
+            <span>Backups &amp; snapshots</span>
+          </a>
           <a class="nav-item" data-route="retention" href="/retention" data-capability="monitor">
             <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="8" ry="3"/><path d="M4 5v14c0 1.66 3.58 3 8 3s8-1.34 8-3V5"/><path d="M4 12c0 1.66 3.58 3 8 3s8-1.34 8-3"/></svg></span>
             <span>Retention</span>

--- a/internal/console/assets/index.html
+++ b/internal/console/assets/index.html
@@ -125,14 +125,20 @@
             <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 11h-6"/><path d="M19 8v6"/></svg></span>
             <span>Access profiles</span>
           </a>
+          <!-- Backups & snapshots (#1582) is NOT monitor-gated, for the same
+               reason Access profiles is not: the per-server backup location
+               is registry state the standalone serve edits too, and the
+               server Edit form no longer carries those fields — this page is
+               their only editor. The daemon-side cards inside it ARE
+               monitor-gated (serve runs no loops). -->
+          <a class="nav-item" data-route="backup-settings" href="/backup-settings">
+            <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12"/><path d="M7 10l5 5 5-5"/><rect x="3" y="17" width="18" height="4" rx="1"/></svg></span>
+            <span>Backups &amp; snapshots</span>
+          </a>
           <!-- Storage was a drawer of five unrelated concerns (#1543). Split
                by the question each half answers: what happens to your data
                over time, and what this daemon is touching. /storage stays a
                known route in app.js and rewrites to /retention. -->
-          <a class="nav-item" data-route="backup-settings" href="/backup-settings" data-capability="monitor">
-            <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12"/><path d="M7 10l5 5 5-5"/><rect x="3" y="17" width="18" height="4" rx="1"/></svg></span>
-            <span>Backups &amp; snapshots</span>
-          </a>
           <a class="nav-item" data-route="retention" href="/retention" data-capability="monitor">
             <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="8" ry="3"/><path d="M4 5v14c0 1.66 3.58 3 8 3s8-1.34 8-3V5"/><path d="M4 12c0 1.66 3.58 3 8 3s8-1.34 8-3"/></svg></span>
             <span>Retention</span>

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -2896,3 +2896,24 @@ button { font-family: inherit; }
 .bk-file-n { font-family: var(--f-mono); font-size: 12.5px; font-weight: 500; color: var(--ink); }
 .bk-file-c { font-size: 12px; color: var(--ink-3); }
 .bk-shape-plus { align-self: center; font-size: 15px; color: var(--ink-4); }
+
+/* Backups & snapshots settings (#1582). The daemon card's rows carry four
+   facts each — meaning, value, the restart chip, and the flag to change —
+   which the two-column .kv cannot hold: a grid puts the flag on its own line
+   under the label, so the value column stays scannable. */
+.bks-row {
+  display: grid; grid-template-columns: 1fr auto auto; gap: 2px 10px;
+  align-items: baseline; padding: 10px 0; border-bottom: 1px dotted var(--line);
+}
+.bks-row:last-child { border-bottom: none; }
+.bks-label { font-size: 13px; color: var(--ink-2); }
+.bks-value {
+  font-family: var(--f-mono); font-size: 13px; color: var(--ink);
+  font-weight: 500; text-align: right; overflow-wrap: anywhere;
+}
+.bks-value.muted { color: var(--ink-3); font-weight: 400; }
+.bks-restart { font-size: 10px; white-space: nowrap; }
+.bks-cli { grid-column: 1; font-size: 11px; color: var(--ink-3); font-family: var(--f-mono); }
+.bks-server { padding: 14px 0; border-bottom: 1px dotted var(--line); }
+.bks-server:last-child { border-bottom: none; padding-bottom: 4px; }
+.bks-server-name { margin: 0 0 10px; font-size: 14px; font-weight: 600; }

--- a/internal/console/assets_backuprefresh_test.go
+++ b/internal/console/assets_backuprefresh_test.go
@@ -207,7 +207,7 @@ func TestBackupRefreshWireNamesMatchTheFrontend(t *testing.T) {
 	}
 }
 
-// TestBackupsPageStillMountsTheRefreshCard: the card can be unmounted, or its
+// TestSettingsPageMountsTheRefreshCard: the card can be unmounted, or its
 // fetch removed, with the whole suite green.
 //
 // The two guards above check what the card renders once it is called. Neither
@@ -215,28 +215,24 @@ func TestBackupRefreshWireNamesMatchTheFrontend(t *testing.T) {
 // and dropping the fetch makes it render its error branch forever. A setting
 // an operator cannot reach is the same as a setting that does not exist.
 //
-// It moved from Storage to Backups (#1543), beside the schedule it was being
-// confused with, which is the pairing #1528 asked for. The guard follows the
-// card rather than the page, and it checks the page it is ON so the move
-// cannot be half-done: a card mounted on neither page passes a guard that
-// only asks "does some function call it".
-func TestBackupsPageStillMountsTheRefreshCard(t *testing.T) {
+// The card moved from Storage to Backups (#1543) and from there to the
+// Backups & snapshots settings page (#1582), which owns settings the way the
+// Backups page owns the work. The guard follows the card rather than the
+// page, and it checks BOTH halves of a move so it cannot be half-done: the
+// new page mounts and feeds it, and the old page no longer does — a control
+// that renders twice saves to one store from two places, and one of them is
+// always stale.
+func TestSettingsPageMountsTheRefreshCard(t *testing.T) {
 	js := readAsset(t, "app.js")
-	body := jsFunctionBody(t, js, "renderBaselines")
+	body := jsFunctionBody(t, js, "renderBackupSettings") + jsFunctionBody(t, js, "buildBackupSettings")
 	if !strings.Contains(body, "backupRefreshCard(") {
-		t.Error("the Backups page no longer mounts backupRefreshCard, so the reuse setting has no UI at all")
-	}
-	// Beside the schedule, not somewhere else on the page: the whole reason
-	// for the move is that the two controls have to be read together.
-	sched, reuse := strings.Index(body, "backupScheduleCard("), strings.Index(body, "backupRefreshCard(")
-	if sched < 0 {
-		t.Fatal("the schedule card is gone from the Backups page; this guard can no longer check the pairing")
-	}
-	if reuse < sched && reuse >= 0 {
-		t.Error("file reuse is mounted above the schedule; #1528 pairs them in that order so the timetable reads first")
+		t.Error("the Backups & snapshots settings page no longer mounts backupRefreshCard, so the reuse setting has no UI at all")
 	}
 	if !strings.Contains(body, `api("/api/baseline-refresh")`) {
-		t.Error("the Backups page does not fetch /api/baseline-refresh, so the card can only ever render its error branch")
+		t.Error("the settings page does not fetch /api/baseline-refresh, so the card can only ever render its error branch")
+	}
+	if strings.Contains(jsFunctionBody(t, js, "renderBaselines"), "backupRefreshCard(") {
+		t.Error("the Backups page still mounts backupRefreshCard; the card moved to the settings page, one surface at a time")
 	}
 }
 

--- a/internal/console/assets_backupsettings_test.go
+++ b/internal/console/assets_backupsettings_test.go
@@ -1,0 +1,113 @@
+package console
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The Backups & snapshots settings page (#1582): wire names, coverage of the
+// daemon rows, the move of the per-server fields out of the server form, and
+// the passthrough that makes the move safe.
+
+// TestBackupSettingsWireNamesMatchTheFrontend pins the JSON keys the Go DTOs
+// emit against what the page reads. A renamed tag on either side renders a
+// page of blanks with the whole suite green otherwise.
+func TestBackupSettingsWireNamesMatchTheFrontend(t *testing.T) {
+	js := readAsset(t, "app.js")
+	page := jsFunctionBody(t, js, "buildBackupSettings") +
+		jsFunctionBody(t, js, "backupDaemonCard") +
+		jsFunctionBody(t, js, "backupServersPanel") +
+		jsFunctionBody(t, js, "backupServerRow")
+	for _, tag := range []string{
+		"daemon", "servers", "registry_read_only",
+		"key", "value", "cli", "needs_restart",
+		"baseline_dir", "baseline_s3", "no_archive",
+		"resolved_dir", "resolved_s3", "source",
+		"schedule_every", "schedule_at",
+	} {
+		if !strings.Contains(page, tag) {
+			t.Errorf("the page never reads %q; the server emits it and the page renders a blank instead", tag)
+		}
+	}
+}
+
+// TestBackupSettingsDaemonRowsAreAllLabeled: every key the handler emits has
+// a label in BACKUP_DAEMON_ROWS, or the page falls back to the raw key — a
+// flag name where the label's whole job is saying what the flag means.
+func TestBackupSettingsDaemonRowsAreAllLabeled(t *testing.T) {
+	js := readAsset(t, "app.js")
+	block := regexp.MustCompile(`const BACKUP_DAEMON_ROWS = \{[^}]+\}`).FindString(js)
+	if block == "" {
+		t.Fatal("BACKUP_DAEMON_ROWS is gone from app.js")
+	}
+	// The canonical key set, spelled here and in the handler; the API test
+	// pins the handler side against the CLI names.
+	for _, key := range []string{
+		"baseline_dir", "baseline_s3", "baseline_retain", "refresh_every",
+		"lock_mode", "trigger", "staging_dir", "verify_interval", "verify_tables",
+	} {
+		if !strings.Contains(block, key+":") {
+			t.Errorf("BACKUP_DAEMON_ROWS has no label for %q; the row would render its raw key", key)
+		}
+	}
+}
+
+// TestServerFormCarriesTheBackupFieldsAsPassthrough is the wipe hazard the
+// move created (#1582): PUT /api/servers/{id} REPLACES the entry, so a form
+// that stopped sending baseline_dir/baseline_s3/no_archive would silently
+// clear a server's backup configuration on every unrelated edit. The fields
+// left the visible form for the settings page; they must survive in it as
+// hidden passthroughs, prefilled and submitted like before.
+func TestServerFormCarriesTheBackupFieldsAsPassthrough(t *testing.T) {
+	js := readAsset(t, "app.js")
+	form := jsFunctionBody(t, js, "buildServerForm")
+	for _, field := range []string{`name: "baseline_dir"`, `name: "baseline_s3"`, `name: "no_archive"`} {
+		if !strings.Contains(form, field) {
+			t.Errorf("buildServerForm no longer carries %s; a plain edit now WIPES that field on the entry", field)
+		}
+	}
+	// Hidden, not visible: the settings page is the one editor. A visible
+	// duplicate saves to one store from two places, one of them stale.
+	if strings.Contains(form, `srvField("Backup dir"`) || strings.Contains(form, `srvField("Backup S3"`) {
+		t.Error("the server form still renders visible backup-location fields; they moved to the settings page")
+	}
+	body := jsFunctionBody(t, js, "serverFormBody")
+	for _, read := range []string{"f.baseline_dir.value", "f.baseline_s3.value", "f.no_archive.checked"} {
+		if !strings.Contains(body, read) {
+			t.Errorf("serverFormBody no longer sends %s; the PUT will replace the entry without it", read)
+		}
+	}
+	// And the prefill still fills the hidden halves, or the passthrough
+	// passes empty strings through — the exact wipe it exists to prevent.
+	show := jsFunctionBody(t, js, "showServerForm")
+	if !strings.Contains(show, `"baseline_dir", "baseline_s3"`) {
+		t.Error("showServerForm's prefill list no longer covers the hidden backup fields")
+	}
+	if !strings.Contains(show, "form.elements.no_archive.checked = !!prefill.no_archive") {
+		t.Error("showServerForm no longer prefills no_archive; the hidden checkbox submits unchecked for every edit")
+	}
+}
+
+// TestBackupSettingsPageIsWired: route in ROUTES, a renderRoute arm, the
+// monitor gate, and a nav item — the four halves that make a page reachable.
+func TestBackupSettingsPageIsWired(t *testing.T) {
+	js := readAsset(t, "app.js")
+	if !regexp.MustCompile(`"backup-settings"\]?`).MatchString(js) {
+		t.Fatal("backup-settings is not in ROUTES")
+	}
+	if !strings.Contains(js, `case "backup-settings": return renderBackupSettings();`) {
+		t.Error("renderRoute has no arm for backup-settings; the URL falls through to Overview")
+	}
+	if !strings.Contains(js, `route === "backup-settings") && !capsCache.monitor`) {
+		t.Error("backup-settings is not behind the monitor gate; a serve-only console would render a page about loops it does not run")
+	}
+	html := readAsset(t, "index.html")
+	if !strings.Contains(html, `data-route="backup-settings"`) {
+		t.Error("index.html has no nav item for backup-settings")
+	}
+	navRE := regexp.MustCompile(`(?s)data-route="backup-settings"[^>]*>`)
+	if nav := navRE.FindString(html); !strings.Contains(nav, `data-capability="monitor"`) {
+		t.Error("the backup-settings nav item is not capability-gated on monitor, unlike its Settings siblings")
+	}
+}

--- a/internal/console/assets_backupsettings_test.go
+++ b/internal/console/assets_backupsettings_test.go
@@ -19,15 +19,19 @@ func TestBackupSettingsWireNamesMatchTheFrontend(t *testing.T) {
 		jsFunctionBody(t, js, "backupDaemonCard") +
 		jsFunctionBody(t, js, "backupServersPanel") +
 		jsFunctionBody(t, js, "backupServerRow")
-	for _, tag := range []string{
-		"daemon", "servers", "registry_read_only",
-		"key", "value", "cli", "needs_restart",
-		"baseline_dir", "baseline_s3", "no_archive",
-		"resolved_dir", "resolved_s3", "source",
-		"schedule_every", "schedule_at",
+	// Dotted READS, not bare tokens: "value" also matches dir.value.trim()
+	// and "baseline_dir" matches the input's name: attribute, so a renamed
+	// JSON tag stayed green while the page rendered blanks. The dotted form
+	// is the actual dereference of the wire field.
+	for _, read := range []string{
+		"settings.daemon", "settings.servers", "settings.registry_read_only",
+		"row.key", "row.value", "row.on", "row.cli", "row.needs_restart", "row.err",
+		"srv.baseline_dir", "srv.baseline_s3", "srv.no_archive",
+		"srv.resolved_dir", "srv.resolved_s3", "srv.source",
+		"srv.schedule_every", "srv.schedule_at", "srv.schedule_refusal",
 	} {
-		if !strings.Contains(page, tag) {
-			t.Errorf("the page never reads %q; the server emits it and the page renders a blank instead", tag)
+		if !strings.Contains(page, read) {
+			t.Errorf("the page never reads %q; the server emits it and the page renders a blank instead", read)
 		}
 	}
 }
@@ -99,15 +103,29 @@ func TestBackupSettingsPageIsWired(t *testing.T) {
 	if !strings.Contains(js, `case "backup-settings": return renderBackupSettings();`) {
 		t.Error("renderRoute has no arm for backup-settings; the URL falls through to Overview")
 	}
-	if !strings.Contains(js, `route === "backup-settings") && !capsCache.monitor`) {
-		t.Error("backup-settings is not behind the monitor gate; a serve-only console would render a page about loops it does not run")
+	// NOT monitor-gated, deliberately (the Access profiles precedent): the
+	// server Edit form's backup fields became passthroughs, so this page is
+	// the ONLY editor of the registry's backup location — and the registry
+	// is state the standalone serve edits too. Gating the page left serve
+	// with no UI path to a backup location at all. The daemon-side cards
+	// inside the page carry the monitor gate instead.
+	if strings.Contains(js, `route === "backup-settings") && !capsCache.monitor`) ||
+		strings.Contains(js, `"backup-settings" || route`) {
+		t.Error("backup-settings is behind the monitor gate again; on serve the per-server backup " +
+			"location would have NO editor anywhere in the UI")
+	}
+	body := jsFunctionBody(t, js, "buildBackupSettings")
+	if !strings.Contains(body, "capsCache.monitor") {
+		t.Error("buildBackupSettings no longer gates the daemon-side cards on monitor; on serve the " +
+			"daemon card renders empty rows and reads as an unconfigured install")
 	}
 	html := readAsset(t, "index.html")
 	if !strings.Contains(html, `data-route="backup-settings"`) {
 		t.Error("index.html has no nav item for backup-settings")
 	}
 	navRE := regexp.MustCompile(`(?s)data-route="backup-settings"[^>]*>`)
-	if nav := navRE.FindString(html); !strings.Contains(nav, `data-capability="monitor"`) {
-		t.Error("the backup-settings nav item is not capability-gated on monitor, unlike its Settings siblings")
+	if nav := navRE.FindString(html); strings.Contains(nav, `data-capability="monitor"`) {
+		t.Error("the backup-settings nav item is capability-gated on monitor; serve users could not " +
+			"reach the only editor of the per-server backup location")
 	}
 }

--- a/internal/console/authz.go
+++ b/internal/console/authz.go
@@ -132,6 +132,11 @@ var apiRoutePerms = []routePerm{
 	// the settings surface.
 	{"GET", "/api/rotation", ext.PermSettingsRead},
 	{"PUT", "/api/rotation", ext.PermServersWrite},
+	// The Backups & snapshots settings page (#1582): the GET is the same
+	// settings tier as /api/rotation; the PUT edits a registry entry, so it
+	// carries the servers-write tier the entry's own editor does.
+	{"GET", "/api/backup-settings", ext.PermSettingsRead},
+	{"PUT", "/api/backup-settings/servers/{}", ext.PermServersWrite},
 	// Baseline refresh, graded exactly like rotation: reading the effective
 	// policy is a settings read, changing what the daemon's loop does is a
 	// control-plane write.

--- a/internal/console/authz_test.go
+++ b/internal/console/authz_test.go
@@ -71,6 +71,8 @@ var registeredAPIPatterns = []struct{ method, pattern string }{
 	{"GET", "/api/servers/{}/verify/history"},
 	{"GET", "/api/rotation"},
 	{"PUT", "/api/rotation"},
+	{"GET", "/api/backup-settings"},
+	{"PUT", "/api/backup-settings/servers/{}"},
 	{"GET", "/api/baseline-refresh"},
 	{"PUT", "/api/baseline-refresh"},
 	{"PUT", "/api/servers/{}/backup-schedule"},

--- a/internal/console/backup_schedule.go
+++ b/internal/console/backup_schedule.go
@@ -318,7 +318,7 @@ func CheckBackupSchedule(e ServerEntry, sched BackupSchedule, gates BackupSchedu
 		return nil
 	}
 	if rebuildErr := rebuildPossible(e); rebuildErr != nil {
-		return notRunnable(strings.TrimSuffix(fullErr.Error(), " (Edit → Advanced)") + "; " + rebuildErr.Error() + " (Edit → Advanced)")
+		return notRunnable(strings.TrimSuffix(fullErr.Error(), " (Backups & snapshots page)") + "; " + rebuildErr.Error() + " (Backups & snapshots page)")
 	}
 	// Only a rebuild is possible. That is a runnable schedule (it is what
 	// --baseline-refresh-interval does), but only once there is a backup to

--- a/internal/console/backup_schedule_test.go
+++ b/internal/console/backup_schedule_test.go
@@ -406,9 +406,9 @@ func TestBaselineTriggerPrecheck_sharedWithTheSchedule(t *testing.T) {
 		t.Fatal("fixture is runnable; the test needs a refused entry")
 	}
 	got := CheckBackupSchedule(e, BackupSchedule{Every: "1d"}, BackupScheduleGates{LoopRunning: true, FullBackups: true})
-	// The button's hint "(Edit → Advanced)" moves to the end of the combined
+	// The button's hint "(Backups & snapshots page)" moves to the end of the combined
 	// reason and appears once, not once per producer.
-	const hint = " (Edit → Advanced)"
+	const hint = " (Backups & snapshots page)"
 	reason := RefusalReason(got)
 	if got == nil || !strings.HasPrefix(reason, strings.TrimSuffix(want.Error(), hint)) {
 		t.Fatalf("schedule reason %v does not start with the button's %v", got, want)

--- a/internal/console/backup_settings_api.go
+++ b/internal/console/backup_settings_api.go
@@ -1,0 +1,187 @@
+package console
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+// The one settings page that owns backup and snapshot parameters (#1582).
+//
+// Two kinds of rows, split by WHERE the value lives. Daemon-wide values are
+// flags or environment on the process: they cannot change while it runs, so
+// they render read-only, each with the exact name to change and a restart
+// badge on the control. Per-server values live in the registry and are read
+// on the next run that consumes them: they edit in place, through the PUT
+// below.
+//
+// The page's real job is PROVENANCE. The precedence (per server, then daemon
+// flag, then nothing) is real and was invisible: connManager falls a server
+// with no baseline location of its own back to the daemon's --baseline-dir /
+// --baseline-s3 (withBaselineDefaults), but the servers API serializes the
+// RAW registry field — so a server backed by the daemon default showed an
+// empty field, indistinguishable from a server with no backup location at
+// all. The rows here carry both spellings and say which one is in force.
+
+// BackupSettingsDefaults carries the daemon-wide flag/env values the page
+// reports, injected by the watch daemon exactly like RotationDefaults: what
+// the process was TOLD, verbatim, so the page never re-derives it. Zero on
+// the standalone serve, whose nav hides the page (no monitor capability).
+type BackupSettingsDefaults struct {
+	BaselineRetain string // --baseline-retain
+	RefreshEvery   string // --baseline-refresh-interval
+	LockMode       string // BINTRAIL_CONSOLE_BASELINE_LOCK_MODE
+	TriggerOn      bool   // BINTRAIL_CONSOLE_BASELINE_TRIGGER
+	StagingDir     string // BINTRAIL_CONSOLE_BASELINE_STAGING
+	VerifyInterval string // --verify-interval
+	VerifyTables   string // --verify-tables
+}
+
+// backupSettingRow is one daemon-wide value on the wire: what it is, where it
+// came from, and the exact name to change it under. Every row here needs a
+// restart by construction — the live-editable settings have their own cards
+// and endpoints — so NeedsRestart is stated per row rather than assumed, to
+// keep the wire shape honest if a live-appliable row ever joins.
+type backupSettingRow struct {
+	Key          string `json:"key"`
+	Value        string `json:"value"`
+	On           *bool  `json:"on,omitempty"` // set for boolean rows; Value stays empty
+	CLI          string `json:"cli"`
+	NeedsRestart bool   `json:"needs_restart"`
+}
+
+// backupSettingsServerDTO is one server's backup configuration with its
+// provenance resolved: the raw registry halves (the editable ones) and the
+// effective location after the daemon-default fallback.
+type backupSettingsServerDTO struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	BaselineDir string `json:"baseline_dir"`
+	BaselineS3  string `json:"baseline_s3"`
+	NoArchive   bool   `json:"no_archive"`
+	ResolvedDir string `json:"resolved_dir"`
+	ResolvedS3  string `json:"resolved_s3"`
+	// Source is "server" when the entry names its own location, "default"
+	// when the daemon's --baseline-dir/--baseline-s3 back it, "none" when
+	// neither exists.
+	Source string `json:"source"`
+	// The schedule as CONFIGURED (its own endpoints own editing it; the
+	// Backups page shows the run history and the next-method prediction).
+	// Config only, on purpose: predicting the next run's method probes the
+	// source database, and a settings listing must not dial every server.
+	ScheduleEvery string `json:"schedule_every,omitempty"`
+	ScheduleAt    string `json:"schedule_at,omitempty"`
+}
+
+type backupSettingsDTO struct {
+	Daemon           []backupSettingRow        `json:"daemon"`
+	Servers          []backupSettingsServerDTO `json:"servers"`
+	RegistryReadOnly bool                      `json:"registry_read_only"`
+}
+
+// handleBackupSettingsGet serves GET /api/backup-settings: the consolidated
+// read model for the Backups & snapshots settings page.
+func (s *Server) handleBackupSettingsGet(w http.ResponseWriter, r *http.Request) {
+	d := s.backupSettingsDefaults
+	on := func(b bool) *bool { return &b }
+	dto := backupSettingsDTO{
+		RegistryReadOnly: s.cm.reg != nil && s.cm.reg.ReadOnly(),
+		Daemon: []backupSettingRow{
+			{Key: "baseline_dir", Value: s.cm.defaultBaselineDir, CLI: "--baseline-dir", NeedsRestart: true},
+			{Key: "baseline_s3", Value: s.cm.defaultBaselineS3, CLI: "--baseline-s3", NeedsRestart: true},
+			{Key: "baseline_retain", Value: d.BaselineRetain, CLI: "--baseline-retain", NeedsRestart: true},
+			{Key: "refresh_every", Value: d.RefreshEvery, CLI: "--baseline-refresh-interval", NeedsRestart: true},
+			{Key: "lock_mode", Value: d.LockMode, CLI: "BINTRAIL_CONSOLE_BASELINE_LOCK_MODE", NeedsRestart: true},
+			{Key: "trigger", On: on(d.TriggerOn), CLI: "BINTRAIL_CONSOLE_BASELINE_TRIGGER", NeedsRestart: true},
+			{Key: "staging_dir", Value: d.StagingDir, CLI: "BINTRAIL_CONSOLE_BASELINE_STAGING", NeedsRestart: true},
+			{Key: "verify_interval", Value: d.VerifyInterval, CLI: "--verify-interval", NeedsRestart: true},
+			{Key: "verify_tables", Value: d.VerifyTables, CLI: "--verify-tables", NeedsRestart: true},
+		},
+		Servers: []backupSettingsServerDTO{},
+	}
+	if s.cm.reg != nil {
+		for _, e := range s.cm.reg.List() {
+			dto.Servers = append(dto.Servers, s.backupSettingsServerDTO(e))
+		}
+	}
+	writeJSON(w, http.StatusOK, dto)
+}
+
+// backupSettingsServerDTO resolves one entry's provenance through the SAME
+// fallback the connection manager applies (withBaselineDefaults) — read from
+// it, never re-derived, so this page cannot disagree with what findBaseline
+// will actually open.
+func (s *Server) backupSettingsServerDTO(e ServerEntry) backupSettingsServerDTO {
+	resolved := s.cm.withBaselineDefaults(e)
+	dto := backupSettingsServerDTO{
+		ID:          e.ID,
+		Name:        e.Name,
+		BaselineDir: e.BaselineDir,
+		BaselineS3:  e.BaselineS3,
+		NoArchive:   e.NoArchive,
+		ResolvedDir: resolved.BaselineDir,
+		ResolvedS3:  resolved.BaselineS3,
+	}
+	switch {
+	case e.BaselineDir != "" || e.BaselineS3 != "":
+		dto.Source = "server"
+	case resolved.BaselineDir != "" || resolved.BaselineS3 != "":
+		dto.Source = "default"
+	default:
+		dto.Source = "none"
+	}
+	if e.BackupSchedule != nil {
+		dto.ScheduleEvery = e.BackupSchedule.Every
+		dto.ScheduleAt = e.BackupSchedule.At
+	}
+	return dto
+}
+
+// backupSettingsUpdateRequest is the PUT body. Pointer semantics: an omitted
+// field keeps the stored value. This endpoint patches ONLY the three backup
+// fields — unlike PUT /api/servers/{id}, which replaces the entry and
+// therefore needs every field echoed back — so a settings row can save
+// without carrying the connection form's whole state.
+type backupSettingsUpdateRequest struct {
+	BaselineDir *string `json:"baseline_dir"`
+	BaselineS3  *string `json:"baseline_s3"`
+	NoArchive   *bool   `json:"no_archive"`
+}
+
+// handleBackupSettingsServerUpdate serves PUT /api/backup-settings/servers/{id}.
+func (s *Server) handleBackupSettingsServerUpdate(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == bootServerID {
+		writeJSONError(w, http.StatusConflict,
+			"the command-line server cannot be edited; it mirrors the daemon's own flags")
+		return
+	}
+	entry, ok := s.cm.reg.Get(id)
+	if !ok {
+		writeJSONError(w, http.StatusNotFound, ErrUnknownServer.Error())
+		return
+	}
+	var req backupSettingsUpdateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeBodyDecodeError(w, err)
+		return
+	}
+	if req.BaselineDir != nil {
+		entry.BaselineDir = strings.TrimSpace(*req.BaselineDir)
+	}
+	if req.BaselineS3 != nil {
+		entry.BaselineS3 = strings.TrimSpace(*req.BaselineS3)
+	}
+	if req.NoArchive != nil {
+		entry.NoArchive = *req.NoArchive
+	}
+	if err := s.cm.reg.Update(entry); err != nil {
+		writeJSONError(w, registryErrStatus(err), err.Error())
+		return
+	}
+	// The DSN did not change, so the connection stays; the baseline and
+	// no-archive gates are derived state and must be recomputed — same tail
+	// as a baseline-only edit through the servers form.
+	s.cm.rebuildDerived(entry)
+	writeJSON(w, http.StatusOK, s.backupSettingsServerDTO(entry))
+}

--- a/internal/console/backup_settings_api.go
+++ b/internal/console/backup_settings_api.go
@@ -26,11 +26,16 @@ import (
 // BackupSettingsDefaults carries the daemon-wide flag/env values the page
 // reports, injected by the watch daemon exactly like RotationDefaults: what
 // the process was TOLD, verbatim, so the page never re-derives it. Zero on
-// the standalone serve, whose nav hides the page (no monitor capability).
+// the standalone serve, whose page hides the daemon card (no monitor
+// capability); the per-server half of the page renders there regardless.
 type BackupSettingsDefaults struct {
 	BaselineRetain string // --baseline-retain
 	RefreshEvery   string // --baseline-refresh-interval
 	LockMode       string // BINTRAIL_CONSOLE_BASELINE_LOCK_MODE
+	// LockModeErr: the env value was rejected, so LockMode holds the
+	// fallback default, which is NOT in force — MySQL dumps are refused
+	// while it stands. The page must show the rejection, not the fallback.
+	LockModeErr    string
 	TriggerOn      bool   // BINTRAIL_CONSOLE_BASELINE_TRIGGER
 	StagingDir     string // BINTRAIL_CONSOLE_BASELINE_STAGING
 	VerifyInterval string // --verify-interval
@@ -48,6 +53,12 @@ type backupSettingRow struct {
 	On           *bool  `json:"on,omitempty"` // set for boolean rows; Value stays empty
 	CLI          string `json:"cli"`
 	NeedsRestart bool   `json:"needs_restart"`
+	// Err is a per-row rejection: the configured value was refused and the
+	// shown Value is NOT in force (today: an invalid lock mode, which
+	// disables MySQL dumps while the daemon keeps running). Without it this
+	// page rendered the fallback default on the one row whose real state is
+	// "your value was rejected", which is the opposite of provenance.
+	Err string `json:"err,omitempty"`
 }
 
 // backupSettingsServerDTO is one server's backup configuration with its
@@ -71,12 +82,29 @@ type backupSettingsServerDTO struct {
 	// source database, and a settings listing must not dial every server.
 	ScheduleEvery string `json:"schedule_every,omitempty"`
 	ScheduleAt    string `json:"schedule_at,omitempty"`
+	// ScheduleRefusal is why the configured schedule cannot run as things
+	// stand (this process, this entry), empty when it can. CheckBackupSchedule
+	// is IO-free, so listing it here does not violate the no-dialing rule the
+	// prediction (next-method) obeys by staying off this DTO — and without it
+	// the row read `resolved` values while the schedule reads the raw entry,
+	// so clearing a dir here left a row promising runs that will all refuse.
+	ScheduleRefusal string `json:"schedule_refusal,omitempty"`
 }
 
 type backupSettingsDTO struct {
 	Daemon           []backupSettingRow        `json:"daemon"`
 	Servers          []backupSettingsServerDTO `json:"servers"`
 	RegistryReadOnly bool                      `json:"registry_read_only"`
+}
+
+// lockModeRowErr appends the operational consequence to a lock-mode
+// rejection: the page renders row errors generically, so the row that
+// disables dumps must say so itself.
+func lockModeRowErr(err string) string {
+	if err == "" {
+		return ""
+	}
+	return err + "; MySQL dumps are refused until it is fixed"
 }
 
 // handleBackupSettingsGet serves GET /api/backup-settings: the consolidated
@@ -91,7 +119,7 @@ func (s *Server) handleBackupSettingsGet(w http.ResponseWriter, r *http.Request)
 			{Key: "baseline_s3", Value: s.cm.defaultBaselineS3, CLI: "--baseline-s3", NeedsRestart: true},
 			{Key: "baseline_retain", Value: d.BaselineRetain, CLI: "--baseline-retain", NeedsRestart: true},
 			{Key: "refresh_every", Value: d.RefreshEvery, CLI: "--baseline-refresh-interval", NeedsRestart: true},
-			{Key: "lock_mode", Value: d.LockMode, CLI: "BINTRAIL_CONSOLE_BASELINE_LOCK_MODE", NeedsRestart: true},
+			{Key: "lock_mode", Value: d.LockMode, Err: lockModeRowErr(d.LockModeErr), CLI: "BINTRAIL_CONSOLE_BASELINE_LOCK_MODE", NeedsRestart: true},
 			{Key: "trigger", On: on(d.TriggerOn), CLI: "BINTRAIL_CONSOLE_BASELINE_TRIGGER", NeedsRestart: true},
 			{Key: "staging_dir", Value: d.StagingDir, CLI: "BINTRAIL_CONSOLE_BASELINE_STAGING", NeedsRestart: true},
 			{Key: "verify_interval", Value: d.VerifyInterval, CLI: "--verify-interval", NeedsRestart: true},
@@ -133,6 +161,11 @@ func (s *Server) backupSettingsServerDTO(e ServerEntry) backupSettingsServerDTO 
 	if e.BackupSchedule != nil {
 		dto.ScheduleEvery = e.BackupSchedule.Every
 		dto.ScheduleAt = e.BackupSchedule.At
+		// The RAW entry, matching what the loop checks (backup_schedule.go
+		// reads e.BaselineDir/e.BaselineS3, never the resolved fallback).
+		if err := CheckBackupSchedule(e, *e.BackupSchedule, s.scheduleGates()); err != nil {
+			dto.ScheduleRefusal = RefusalReason(err)
+		}
 	}
 	return dto
 }

--- a/internal/console/backup_settings_api_test.go
+++ b/internal/console/backup_settings_api_test.go
@@ -1,0 +1,195 @@
+package console
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newBackupSettingsServer builds a Server over a real registry file with the
+// daemon-wide defaults the page reports.
+func newBackupSettingsServer(t *testing.T, defaults BackupSettingsDefaults, baselineDir, baselineS3 string) *Server {
+	t.Helper()
+	reg, err := LoadRegistry(t.TempDir() + "/console-servers.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv, err := New(Config{
+		Listen: "127.0.0.1:8090", Token: "t", Registry: reg,
+		BaselineDir: baselineDir, BaselineS3: baselineS3,
+		BackupSettingsDefaults: defaults,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv
+}
+
+func backupSettingsGet(t *testing.T, srv *Server) backupSettingsDTO {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/backup-settings", nil)
+	srv.handleBackupSettingsGet(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("GET /api/backup-settings: code = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var dto backupSettingsDTO
+	if err := json.Unmarshal(rec.Body.Bytes(), &dto); err != nil {
+		t.Fatal(err)
+	}
+	return dto
+}
+
+// TestBackupSettings_provenance drives the three source states the page
+// exists to distinguish: a server with its own location, one backed by the
+// daemon default (the shape that used to render an empty field,
+// indistinguishable from unconfigured), and one with nothing.
+func TestBackupSettings_provenance(t *testing.T) {
+	srv := newBackupSettingsServer(t, BackupSettingsDefaults{}, "/data/baselines", "")
+	own, err := srv.cm.reg.Add(ServerEntry{Name: "own", DSN: "u:p@tcp(h:3306)/idx", BaselineDir: "/mine"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	backed, err := srv.cm.reg.Add(ServerEntry{Name: "backed", DSN: "u:p@tcp(h:3306)/idx2"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dto := backupSettingsGet(t, srv)
+	byID := map[string]backupSettingsServerDTO{}
+	for _, s := range dto.Servers {
+		byID[s.ID] = s
+	}
+	if got := byID[own.ID]; got.Source != "server" || got.ResolvedDir != "/mine" {
+		t.Errorf("own-location server: source=%q resolved=%q; want server + /mine", got.Source, got.ResolvedDir)
+	}
+	// The daemon-default arm: raw stays EMPTY (it is the editable half) while
+	// resolved carries what findBaseline will actually open.
+	if got := byID[backed.ID]; got.Source != "default" || got.BaselineDir != "" || got.ResolvedDir != "/data/baselines" {
+		t.Errorf("default-backed server: source=%q raw=%q resolved=%q; want default + \"\" + /data/baselines",
+			got.Source, got.BaselineDir, got.ResolvedDir)
+	}
+}
+
+func TestBackupSettings_noneWhenNothingBacksAServer(t *testing.T) {
+	srv := newBackupSettingsServer(t, BackupSettingsDefaults{}, "", "")
+	bare, err := srv.cm.reg.Add(ServerEntry{Name: "bare", DSN: "u:p@tcp(h:3306)/idx"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dto := backupSettingsGet(t, srv)
+	for _, s := range dto.Servers {
+		if s.ID == bare.ID && s.Source != "none" {
+			t.Errorf("unbacked server reports source %q; want none", s.Source)
+		}
+	}
+}
+
+// TestBackupSettings_daemonRowsCarryTheirNames pins the contract of the
+// read-only half: every row names the exact flag or variable to change, and
+// says on the row that a restart is what applies it.
+func TestBackupSettings_daemonRowsCarryTheirNames(t *testing.T) {
+	srv := newBackupSettingsServer(t, BackupSettingsDefaults{
+		BaselineRetain: "7d", RefreshEvery: "6h", LockMode: "ftwrl",
+		TriggerOn: true, StagingDir: "/stage", VerifyInterval: "24h", VerifyTables: "shop.orders",
+	}, "/data/baselines", "s3://bkt/b/")
+	dto := backupSettingsGet(t, srv)
+	want := map[string]string{
+		"baseline_dir":    "--baseline-dir",
+		"baseline_s3":     "--baseline-s3",
+		"baseline_retain": "--baseline-retain",
+		"refresh_every":   "--baseline-refresh-interval",
+		"lock_mode":       "BINTRAIL_CONSOLE_BASELINE_LOCK_MODE",
+		"trigger":         "BINTRAIL_CONSOLE_BASELINE_TRIGGER",
+		"staging_dir":     "BINTRAIL_CONSOLE_BASELINE_STAGING",
+		"verify_interval": "--verify-interval",
+		"verify_tables":   "--verify-tables",
+	}
+	got := map[string]backupSettingRow{}
+	for _, r := range dto.Daemon {
+		got[r.Key] = r
+	}
+	for key, cli := range want {
+		r, ok := got[key]
+		switch {
+		case !ok:
+			t.Errorf("daemon rows are missing %s; a setting with no row has no provenance", key)
+		case r.CLI != cli:
+			t.Errorf("%s names %q; want %q — the row's whole job is the exact name to change", key, r.CLI, cli)
+		case !r.NeedsRestart:
+			t.Errorf("%s does not carry needs_restart; the restart split lives on the row", key)
+		}
+	}
+	if r := got["trigger"]; r.On == nil || !*r.On {
+		t.Errorf("trigger row does not report On=true; booleans ride the on field, not a stringly value")
+	}
+	if r := got["baseline_retain"]; r.Value != "7d" {
+		t.Errorf("baseline_retain value = %q; want the verbatim flag value 7d", r.Value)
+	}
+}
+
+// TestBackupSettings_updatePatchesOnlyTheBackupFields is the PUT's contract:
+// pointer semantics, and everything else on the entry survives untouched —
+// unlike PUT /api/servers/{id}, which replaces the entry whole.
+func TestBackupSettings_updatePatchesOnlyTheBackupFields(t *testing.T) {
+	srv := newBackupSettingsServer(t, BackupSettingsDefaults{}, "", "")
+	entry, err := srv.cm.reg.Add(ServerEntry{
+		Name: "prod", DSN: "u:secret@tcp(h:3306)/idx",
+		SourceDSN:      "repl:secret2@tcp(src:3306)/",
+		Schemas:        "shop",
+		BackupSchedule: &BackupSchedule{Every: "6h", At: "03:00"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/api/backup-settings/servers/"+entry.ID,
+		strings.NewReader(`{"baseline_dir":" /data/bl ","no_archive":true}`))
+	req.SetPathValue("id", entry.ID)
+	srv.handleBackupSettingsServerUpdate(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("PUT: code = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var dto backupSettingsServerDTO
+	if err := json.Unmarshal(rec.Body.Bytes(), &dto); err != nil {
+		t.Fatal(err)
+	}
+	if dto.BaselineDir != "/data/bl" || !dto.NoArchive || dto.Source != "server" {
+		t.Errorf("PUT answer: dir=%q no_archive=%v source=%q; want trimmed /data/bl, true, server",
+			dto.BaselineDir, dto.NoArchive, dto.Source)
+	}
+
+	after, ok := srv.cm.reg.Get(entry.ID)
+	if !ok {
+		t.Fatal("entry vanished")
+	}
+	// The omitted pointer keeps the stored value; everything the request never
+	// mentions survives. This is the wipe hazard the endpoint exists to avoid.
+	if after.BaselineS3 != "" || after.DSN != entry.DSN || after.SourceDSN != entry.SourceDSN ||
+		after.Schemas != "shop" || after.BackupSchedule == nil || after.BackupSchedule.Every != "6h" {
+		t.Errorf("PUT touched fields it was never sent: %+v", after)
+	}
+}
+
+func TestBackupSettings_updateRefusals(t *testing.T) {
+	srv := newBackupSettingsServer(t, BackupSettingsDefaults{}, "", "")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/api/backup-settings/servers/"+bootServerID, strings.NewReader(`{}`))
+	req.SetPathValue("id", bootServerID)
+	srv.handleBackupSettingsServerUpdate(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Errorf("boot entry: code = %d, want 409 (it mirrors the daemon's own flags)", rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest("PUT", "/api/backup-settings/servers/nope", strings.NewReader(`{}`))
+	req.SetPathValue("id", "nope")
+	srv.handleBackupSettingsServerUpdate(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("unknown id: code = %d, want 404", rec.Code)
+	}
+}

--- a/internal/console/backup_settings_api_test.go
+++ b/internal/console/backup_settings_api_test.go
@@ -130,6 +130,59 @@ func TestBackupSettings_daemonRowsCarryTheirNames(t *testing.T) {
 	}
 }
 
+// TestBackupSettings_scheduleRefusalReachesTheWire: a stored schedule that
+// cannot run on this process must say so on the row (the schedule reads the
+// RAW entry, so this page's own PUT can strand one). The refusal semantics
+// live in CheckBackupSchedule's own tests; this pins the wiring — with a
+// schedule the field carries the reason, without one it stays empty.
+func TestBackupSettings_scheduleRefusalReachesTheWire(t *testing.T) {
+	srv := newBackupSettingsServer(t, BackupSettingsDefaults{}, "", "")
+	sched, err := srv.cm.reg.Add(ServerEntry{Name: "sch", DSN: "u:p@tcp(h:3306)/idx",
+		SourceDSN: "u:p@tcp(s:3306)/", BackupSchedule: &BackupSchedule{Every: "1d"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	plain, err := srv.cm.reg.Add(ServerEntry{Name: "plain", DSN: "u:p@tcp(h:3306)/idx2"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dto := backupSettingsGet(t, srv)
+	byID := map[string]backupSettingsServerDTO{}
+	for _, s := range dto.Servers {
+		byID[s.ID] = s
+	}
+	if got := byID[sched.ID]; got.ScheduleRefusal == "" {
+		t.Error("a schedule this process cannot run carries no refusal; the row promises runs that will not happen")
+	}
+	if got := byID[plain.ID]; got.ScheduleRefusal != "" {
+		t.Errorf("a server with no schedule carries a refusal %q; the field must mean the schedule, not the server", got.ScheduleRefusal)
+	}
+}
+
+// TestBackupSettings_lockModeRejectionOutranksTheFallback: when the env value
+// was rejected, the row must carry the rejection and its consequence, not
+// just the fallback default the page would otherwise present as chosen.
+func TestBackupSettings_lockModeRejectionOutranksTheFallback(t *testing.T) {
+	srv := newBackupSettingsServer(t, BackupSettingsDefaults{
+		LockMode: "ftwrl", LockModeErr: `BINTRAIL_CONSOLE_BASELINE_LOCK_MODE: unknown lock mode "nope"`,
+	}, "", "")
+	dto := backupSettingsGet(t, srv)
+	for _, r := range dto.Daemon {
+		if r.Key != "lock_mode" {
+			if r.Err != "" {
+				t.Errorf("row %s carries an err %q; only the rejected row may", r.Key, r.Err)
+			}
+			continue
+		}
+		if !strings.Contains(r.Err, `unknown lock mode "nope"`) {
+			t.Errorf("lock_mode row err = %q; the rejection never reached the page", r.Err)
+		}
+		if !strings.Contains(r.Err, "dumps are refused") {
+			t.Errorf("lock_mode row err = %q; it does not state the consequence", r.Err)
+		}
+	}
+}
+
 // TestBackupSettings_updatePatchesOnlyTheBackupFields is the PUT's contract:
 // pointer semantics, and everything else on the entry survives untouched —
 // unlike PUT /api/servers/{id}, which replaces the entry whole.

--- a/internal/console/baseline_trigger.go
+++ b/internal/console/baseline_trigger.go
@@ -116,7 +116,7 @@ func baselineTriggerPrecheck(e ServerEntry) error {
 		return errors.New("this server has no source configured; set the source connection first")
 	}
 	if e.BaselineDir == "" && e.BaselineS3 == "" {
-		return errors.New("this server has no baseline location set up; set a baseline directory or S3 location first (Edit → Advanced)")
+		return errors.New("this server has no baseline location set up; set a baseline directory or S3 location first (Backups & snapshots page)")
 	}
 	if e.IsPostgres() && (e.SourceSlot == "" || e.SourcePublication == "") {
 		return errors.New("this PostgreSQL server has no replication slot/publication configured; set them first (Edit → Source)")
@@ -294,11 +294,11 @@ func (s *Server) handleBaselineRestore(w http.ResponseWriter, r *http.Request) {
 		// belongs to neither.
 		if e.BaselineS3 != "" {
 			writeJSONError(w, http.StatusBadRequest,
-				"this server keeps its backups only in S3; point-in-time restore needs a local backup directory (Edit → Advanced)")
+				"this server keeps its backups only in S3; point-in-time restore needs a local backup directory (Backups & snapshots page)")
 			return
 		}
 		writeJSONError(w, http.StatusBadRequest,
-			"this server has no backup directory of its own; set one first (Edit → Advanced)")
+			"this server has no backup directory of its own; set one first (Backups & snapshots page)")
 		return
 	}
 	var body struct {

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -178,6 +178,12 @@ type Config struct {
 	// values, the fallback the settings panel reports when no console override
 	// is saved. Same role as RotationDefaults above.
 	BaselineRefreshDefaults BaselineRefreshDefaults
+
+	// BackupSettingsDefaults carries the daemon-wide backup/snapshot flag and
+	// env values the Backups & snapshots settings page (#1582) reports
+	// read-only: what the process was told, verbatim, with the exact name to
+	// change each one under. Same role as RotationDefaults above.
+	BackupSettingsDefaults BackupSettingsDefaults
 	// Version is the running build's version string ("0.36.0", or "dev" on
 	// unversioned builds), reported in /api/capabilities so the frontend can
 	// link release artifacts (the .mcpb bundle) matching the running binary.
@@ -290,7 +296,8 @@ type Server struct {
 	telemetry TelemetryController
 	// rotationDefaults are the daemon's --rotate-* values, the fallback GET
 	// /api/rotation reports when no console override is saved.
-	rotationDefaults RotationDefaults
+	rotationDefaults       RotationDefaults
+	backupSettingsDefaults BackupSettingsDefaults
 	// baselineRefreshDefaults is the fallback GET /api/baseline-refresh reports
 	// when no console override is saved.
 	baselineRefreshDefaults BaselineRefreshDefaults
@@ -496,6 +503,7 @@ func New(cfg Config) (*Server, error) {
 		baselineHistory:         cfg.BaselineHistory,
 		telemetry:               cfg.Telemetry,
 		rotationDefaults:        cfg.RotationDefaults,
+		backupSettingsDefaults:  cfg.BackupSettingsDefaults,
 		baselineRefreshDefaults: cfg.BaselineRefreshDefaults,
 		version:                 cfg.Version,
 		cm:                      newConnManager(cfg.Registry, profileActive),
@@ -685,6 +693,8 @@ func (s *Server) buildHandler() http.Handler {
 	// the loop that consumes it).
 	api.HandleFunc("GET /api/rotation", s.handleRotationGet)
 	api.HandleFunc("PUT /api/rotation", s.handleRotationUpdate)
+	api.HandleFunc("GET /api/backup-settings", s.handleBackupSettingsGet)
+	api.HandleFunc("PUT /api/backup-settings/servers/{id}", s.handleBackupSettingsServerUpdate)
 	// Global baseline-refresh policy. Same split as rotation: read the
 	// effective settings, PUT an override the running loop picks up next cycle.
 	api.HandleFunc("GET /api/baseline-refresh", s.handleBaselineRefreshGet)

--- a/internal/console/sql_export.go
+++ b/internal/console/sql_export.go
@@ -124,7 +124,7 @@ func (s *Server) handleSQLExportTrigger(w http.ResponseWriter, r *http.Request) 
 	}
 	if src == "" {
 		writeJSONError(w, http.StatusBadRequest,
-			"this server has no backup location set up; set a backup directory or S3 location first (Edit → Advanced)")
+			"this server has no backup location set up; set a backup directory or S3 location first (Backups & snapshots page)")
 		return
 	}
 	var body struct {

--- a/internal/console/verify_trigger.go
+++ b/internal/console/verify_trigger.go
@@ -276,7 +276,7 @@ func (s *Server) handleVerifyTrigger(w http.ResponseWriter, r *http.Request) {
 	// binlog_events and nothing else.
 	if mode != VerifyModeRecoverInputs && e.BaselineDir == "" && e.BaselineS3 == "" {
 		writeJSONError(w, http.StatusBadRequest,
-			"this server has no baseline location set up; set a baseline directory or S3 location first (Edit → Advanced)")
+			"this server has no baseline location set up; set a baseline directory or S3 location first (Backups & snapshots page)")
 		return
 	}
 	if mode == VerifyModeLiveSource && e.SourceDSN == "" {

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -4171,6 +4171,47 @@ try {
     ? ok("telemetry: the shown bytes are the daemon's sample_event verbatim")
     : bad("telemetry: the shown bytes are the daemon's sample_event verbatim", JSON.stringify({ shown: telSample.shown, fromApi: telSample.fromApi }));
 
+  // ── Scenario 17i — the Backups & snapshots settings page (#1582) ──
+  // The page's job is provenance. Driven LIVE against the watch daemon: nine
+  // daemon rows, each carrying the exact flag or variable name and a restart
+  // chip on the control (the split between applies-now and needs-restart,
+  // said on the row rather than in prose), plus the carry-forward card that
+  // moved here from the Backups page — one surface at a time, so the old
+  // page must no longer mount it.
+  await page.evaluate(() => navigate("backup-settings"));
+  await page.waitForFunction(() => location.pathname === "/backup-settings"
+    && document.querySelectorAll(".bks-row").length >= 5, { timeout: 10000 });
+  const bks = await page.evaluate(() => {
+    const rows = Array.from(document.querySelectorAll(".bks-row")).map((r) => ({
+      chip: (r.querySelector(".bks-restart") || {}).textContent || "",
+      cli: (r.querySelector(".bks-cli") || {}).textContent || "",
+      value: (r.querySelector(".bks-value") || {}).textContent || "",
+    }));
+    return {
+      rows: rows.length,
+      allChipped: rows.every((r) => r.chip === "restart to change"),
+      allNamed: rows.every((r) => /^\(CLI: (--|BINTRAIL_)/.test(r.cli)),
+      noBlanks: rows.every((r) => r.value !== ""),
+      refreshCardHere: !!document.querySelector(".view .bkr-head"),
+    };
+  });
+  (bks.rows === 9 && bks.allChipped && bks.allNamed && bks.noBlanks)
+    ? ok("backup-settings: nine daemon rows, each named, valued, and chipped on the control")
+    : bad("backup-settings: nine daemon rows, each named, valued, and chipped on the control", JSON.stringify(bks));
+  (bks.refreshCardHere)
+    ? ok("backup-settings: the carry-forward card moved here")
+    : bad("backup-settings: the carry-forward card moved here", "no .bkr-head on /backup-settings");
+  // Settled on the LISTING panel, not a timer: the whole page builds in one
+  // pass, so once the panel title is up, a mounted card would be too — a
+  // sleep could pass this vacuously against a half-rendered page.
+  await page.evaluate(() => navigate("baselines"));
+  await page.waitForFunction(() => location.pathname === "/baselines"
+    && document.querySelector(".view .ov-panel-title"), { timeout: 10000 });
+  const dupCard = await page.evaluate(() => !!document.querySelector(".view .bkr-head"));
+  (!dupCard)
+    ? ok("backups: the carry-forward card is not duplicated on the Backups page")
+    : bad("backups: the carry-forward card is not duplicated on the Backups page", "found .bkr-head on /baselines");
+
   // ── Scenario 17g — Connect AI is three short steps with a drawn dialog ──
   // The audience is Claude users, mostly non-technical. The first rewrite
   // (#1430) made the steps explicit but drowned them in prose; the verdict on

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -4179,8 +4179,11 @@ try {
   // moved here from the Backups page — one surface at a time, so the old
   // page must no longer mount it.
   await page.evaluate(() => navigate("backup-settings"));
+  // Options are the THIRD waitForFunction parameter; an options object in
+  // the arg slot is serialized to the predicate and silently discarded
+  // (#1589), leaving the 30s default in force. Stated as 30s explicitly.
   await page.waitForFunction(() => location.pathname === "/backup-settings"
-    && document.querySelectorAll(".bks-row").length >= 5, { timeout: 10000 });
+    && document.querySelectorAll(".bks-row").length >= 5, undefined, { timeout: 30000 });
   const bks = await page.evaluate(() => {
     const rows = Array.from(document.querySelectorAll(".bks-row")).map((r) => ({
       chip: (r.querySelector(".bks-restart") || {}).textContent || "",
@@ -4191,13 +4194,17 @@ try {
       rows: rows.length,
       allChipped: rows.every((r) => r.chip === "restart to change"),
       allNamed: rows.every((r) => /^\(CLI: (--|BINTRAIL_)/.test(r.cli)),
-      noBlanks: rows.every((r) => r.value !== ""),
+      // "not set" is the card's own fallback, so every row always has SOME
+      // text; the discriminating assertion is that the values the harness
+      // configured came through. run.sh starts watch with --baseline-dir,
+      // so the first row must carry a real path, not the fallback.
+      configuredValued: rows.length > 0 && rows[0].value.startsWith("/"),
       refreshCardHere: !!document.querySelector(".view .bkr-head"),
     };
   });
-  (bks.rows === 9 && bks.allChipped && bks.allNamed && bks.noBlanks)
-    ? ok("backup-settings: nine daemon rows, each named, valued, and chipped on the control")
-    : bad("backup-settings: nine daemon rows, each named, valued, and chipped on the control", JSON.stringify(bks));
+  (bks.rows === 9 && bks.allChipped && bks.allNamed && bks.configuredValued)
+    ? ok("backup-settings: nine daemon rows, each named and chipped, the configured one valued")
+    : bad("backup-settings: nine daemon rows, each named and chipped, the configured one valued", JSON.stringify(bks));
   (bks.refreshCardHere)
     ? ok("backup-settings: the carry-forward card moved here")
     : bad("backup-settings: the carry-forward card moved here", "no .bkr-head on /backup-settings");


### PR DESCRIPTION
closes #1582

## Summary
- New **Backups & snapshots** settings page (route `backup-settings`, Settings group, monitor-gated like its siblings). Its job is provenance: the precedence per-server > daemon flag > nothing is real and was invisible — `withBaselineDefaults` resolves the daemon fallback but the servers API serialized the raw field, so a server backed by `--baseline-dir` looked identical to one with no backup location.
- **This daemon card**: nine read-only rows (`--baseline-dir`, `--baseline-s3`, `--baseline-retain`, `--baseline-refresh-interval`, `BINTRAIL_CONSOLE_BASELINE_LOCK_MODE`, `BINTRAIL_CONSOLE_BASELINE_TRIGGER`, `BINTRAIL_CONSOLE_BASELINE_STAGING`, `--verify-interval`, `--verify-tables`), each with the verbatim value, the exact name to change it under (the `(CLI: ...)` convention), and a "restart to change" chip **on the row** — the applies-now vs needs-restart split said on the control, not in prose. Values injected via `console.BackupSettingsDefaults` (the `RotationDefaults` pattern), pinned by a wiring test.
- **Carry-forward card moved** here from the Backups page (its third home: Storage → Backups #1543 → here). One surface at a time; the guard checks both halves of the move.
- **Per server**: Backup dir / Backup S3 / archive toggle editable in place via `PUT /api/backup-settings/servers/{id}` — a patch endpoint with pointer keep-if-omitted semantics (unlike the entry-replacing servers PUT), plus a provenance line (own / daemon default / none) and a config-derived note when a schedule can only take full reads (S3 prefix, no local folder — folding writes files).
- **The wipe hazard the move created is guarded**: the server edit form keeps `baseline_dir`/`baseline_s3`/`no_archive` as hidden passthroughs because `PUT /api/servers/{id}` replaces the entry; dropping them would silently clear backup config on every unrelated edit. `TestServerFormCarriesTheBackupFieldsAsPassthrough` pins it.
- authz rows (`GET` settings-read; `PUT` servers-write) + mirrors; e2e scenario 17i drives the live page (nine chipped rows, the moved card, no duplicate on /baselines); docs/console.md gets the page section.

Note for the EE side (tracked separately, not in this repo): the two new routes need their `rbace2e` matrix rows.

## Test plan
- [x] `go test ./... -count=1` green; vet; `node --check` on both JS files
- [x] Mutation red-checks: provenance resolver bypassed → red; PUT made entry-wiping → red; hidden passthrough renamed → red; watch defaults dropped → red
- [x] API tests cover the three provenance states, patch semantics preserving DSN/schedule/SSL, boot/unknown refusals