### PR TITLE
Split carried-forward reuses that saved no disk from those that did

### DIFF
--- a/consoleapp/baseline_job_guard.go
+++ b/consoleapp/baseline_job_guard.go
@@ -131,6 +131,6 @@ func (s *baselineSupervisor) recoverBaselineJob(kind baselineJobKind, serverID, 
 	// progress to the status API ({state:"failed", rows:12000} looks
 	// half-done). Same reasoning the sql export's ordinary failure path
 	// spells out. Since and At are kept — they identify the run.
-	st.Tables, st.Refused, st.Carried, st.Uploaded = 0, 0, 0, 0
+	st.Tables, st.Refused, st.Carried, st.CarriedCopied, st.Uploaded = 0, 0, 0, 0, 0
 	st.Rows, st.Bytes = 0, 0
 }

--- a/consoleapp/baseline_job_guard_test.go
+++ b/consoleapp/baseline_job_guard_test.go
@@ -241,6 +241,34 @@ func TestRecoverBaselineJob_doesNotRewriteAFinishedRun(t *testing.T) {
 	}
 }
 
+// TestRecoverBaselineJob_reportsNothingFromAPanickedRun: "nothing was
+// published, so report nothing" is the guard's own comment, and it holds only
+// while the zeroing list enumerates EVERY count on BaselineStatus. The counts
+// here are seeded on a running slot precisely because production never writes
+// them there today: the day something does, a field missing from the list
+// leaks a partial count next to state:"failed" — the shape the comment calls
+// half-done — and carried_copied surviving while carried is zeroed is a wire
+// shape no consumer expects (copied > reused).
+func TestRecoverBaselineJob_reportsNothingFromAPanickedRun(t *testing.T) {
+	sup := newBaselineSupervisor(context.Background(), t.TempDir(), baseline.DefaultLockMode)
+	sup.refreshes["a"] = &console.BaselineStatus{State: "running", Since: nowStamp(),
+		Tables: 7, Refused: 1, Carried: 3, CarriedCopied: 2, Uploaded: 4, Rows: 12000, Bytes: 5}
+
+	func() {
+		defer sup.recoverBaselineJob(baselineJobRefresh, "a", "srv")
+		panic("raised mid-run with counts on the slot")
+	}()
+
+	got := sup.RefreshStatus("a")
+	if got.State != "failed" {
+		t.Fatalf("state = %q, want failed", got.State)
+	}
+	if got.Tables != 0 || got.Refused != 0 || got.Carried != 0 || got.CarriedCopied != 0 ||
+		got.Uploaded != 0 || got.Rows != 0 || got.Bytes != 0 {
+		t.Fatalf("counts survived the panic guard: %+v; a partial count reads as progress", got)
+	}
+}
+
 // TestRecoverBaselineJob_passesThroughWithoutAPanic: the guard runs on the
 // success path of every job too, and must be inert there.
 func TestRecoverBaselineJob_passesThroughWithoutAPanic(t *testing.T) {

--- a/consoleapp/baseline_refresh_loop.go
+++ b/consoleapp/baseline_refresh_loop.go
@@ -515,7 +515,7 @@ func dirExists(path string) bool {
 // both callers sit behind a `go` and a live fold, so nothing at the unit tier
 // could reach them, and dropping the reused count from either copy compiled and
 // passed the whole suite. It is also the deduplication: two copies of a
-// four-field assignment is exactly how one of them silently loses a field.
+// five-count assignment is exactly how one of them silently loses a field.
 func applyFoldStatus(st *console.BaselineStatus, tables, refused int, reuse reuseTally, err error) {
 	st.FinishedAt = nowStamp()
 	st.Tables = tables

--- a/consoleapp/baseline_refresh_loop.go
+++ b/consoleapp/baseline_refresh_loop.go
@@ -121,7 +121,7 @@ func (s *baselineSupervisor) runRefresh(req refreshRequest, at time.Time, interv
 	// snapshot directory holds anything this run did not write, and once the
 	// fold has run its own files are in there too. See claimSnapshotDir.
 	unclaimed := claimSnapshotDir(refreshSnapshotDir(req, at))
-	tables, refused, carried, err := s.executeRefresh(req, at)
+	tables, refused, reuse, err := s.executeRefresh(req, at)
 	// Publishing is not finished until the snapshot is where this server's
 	// backups live. A fold that wrote a perfect local snapshot for a server
 	// whose destination is S3 has produced a copy on one box, which is not
@@ -146,7 +146,8 @@ func (s *baselineSupervisor) runRefresh(req refreshRequest, at time.Time, interv
 	took := time.Since(elapsed)
 	s.recordRun(req.ServerID, req.ServerName, console.BaselineRunRecord{
 		Kind: console.BaselineRunRefresh, Trigger: req.Trigger, StartedAt: started.Format(time.RFC3339),
-		SnapshotTime: publishedSnapshotTime(at, err), Tables: tables, Refused: refused, Carried: carried,
+		SnapshotTime: publishedSnapshotTime(at, err), Tables: tables, Refused: refused,
+		Carried: reuse.reused, CarriedCopied: reuse.copied,
 		// Zero means "nothing was sent" for a server with no destination AND
 		// "these files reached the bucket" otherwise, so the count is what
 		// makes a successful upload visible at all: without it the only
@@ -168,7 +169,7 @@ func (s *baselineSupervisor) runRefresh(req refreshRequest, at time.Time, interv
 		st = &console.BaselineStatus{}
 		s.refreshes[req.ServerID] = st
 	}
-	applyFoldStatus(st, tables, refused, carried, err)
+	applyFoldStatus(st, tables, refused, reuse, err)
 	if err != nil {
 		// The refusal itself was already reported above, before this lock was
 		// taken. What happens HERE is deliberately nothing: no duration report.
@@ -181,7 +182,8 @@ func (s *baselineSupervisor) runRefresh(req refreshRequest, at time.Time, interv
 		// advice above the actual cause.
 		return
 	}
-	pub := []any{"server", req.ServerName, "id", req.ServerID, "tables", tables, "reused", carried}
+	pub := []any{"server", req.ServerName, "id", req.ServerID, "tables", tables,
+		"reused", reuse.reused, "reused_copied", reuse.copied}
 	// A reused count of zero reads as "nothing happened to be unchanged", which
 	// is indistinguishable from "this path cannot reuse anything" — and on an
 	// S3 source it is always the second (carryForwardEligible refuses any
@@ -514,11 +516,12 @@ func dirExists(path string) bool {
 // could reach them, and dropping the reused count from either copy compiled and
 // passed the whole suite. It is also the deduplication: two copies of a
 // four-field assignment is exactly how one of them silently loses a field.
-func applyFoldStatus(st *console.BaselineStatus, tables, refused, carried int, err error) {
+func applyFoldStatus(st *console.BaselineStatus, tables, refused int, reuse reuseTally, err error) {
 	st.FinishedAt = nowStamp()
 	st.Tables = tables
 	st.Refused = refused
-	st.Carried = carried
+	st.Carried = reuse.reused
+	st.CarriedCopied = reuse.copied
 	// Set on BOTH branches, never left from a previous run: this is what the
 	// scheduled watcher reads to decide whether a full backup is still owed,
 	// and a stale true there is a skipped backup.
@@ -550,7 +553,7 @@ func applyFoldStatus(st *console.BaselineStatus, tables, refused, carried int, e
 // OPPOSITE for Parallelism (zero means runtime.NumCPU()) and for
 // WarnEventThreshold (zero means the volume warning never fires). Those two are
 // therefore set explicitly in refreshFoldConfig; see the constants above it.
-func (s *baselineSupervisor) executeRefresh(req refreshRequest, at time.Time) (tables, refused, carried int, err error) {
+func (s *baselineSupervisor) executeRefresh(req refreshRequest, at time.Time) (tables, refused int, reuse reuseTally, err error) {
 	// Listed where the fold READS (refreshFoldConfig's BaselineSrc), not where
 	// it writes. On an S3-backed server those differ, and listing the local
 	// directory here would refuse with "no baseline snapshot" on exactly the
@@ -560,10 +563,10 @@ func (s *baselineSupervisor) executeRefresh(req refreshRequest, at time.Time) (t
 	src := baselineFoldSource(req)
 	tableList, err := newestSnapshotTables(s.ctx, src)
 	if err != nil {
-		return 0, 0, 0, fmt.Errorf("list the snapshot to refresh: %w", err)
+		return 0, 0, reuseTally{}, fmt.Errorf("list the snapshot to refresh: %w", err)
 	}
 	if len(tableList) == 0 {
-		return 0, 0, 0, fmt.Errorf("no baseline snapshot to refresh under %s", src)
+		return 0, 0, reuseTally{}, fmt.Errorf("no baseline snapshot to refresh under %s", src)
 	}
 	return s.foldSnapshot(req, at, tableList)
 }
@@ -654,7 +657,18 @@ func refreshFoldConfig(req refreshRequest, at time.Time, tableList []string) rec
 	}
 }
 
-// countCarried counts the tables a fold published by reusing the previous
+// reuseTally counts one fold's carried tables, split by whether the bytes
+// were actually shared (#1578). reused is every table published by reuse
+// (the fold and the source read were saved either way); copied is the subset
+// written as a full copy because the file could not be hard linked — no disk
+// was saved for those, and a surface that renders "reused" as a disk saving
+// must subtract them or it confirms a saving the daemon log denies.
+type reuseTally struct {
+	reused int
+	copied int
+}
+
+// countReuse tallies the tables a fold published by reusing the previous
 // snapshot's file.
 //
 // A separate function for the same reason refreshFoldConfig is one: this is the
@@ -662,13 +676,16 @@ func refreshFoldConfig(req refreshRequest, at time.Time, tableList []string) rec
 // inside foldSnapshot nothing could reach it without standing up an index and a
 // baseline. Returning len(reports) here, or 0, compiles and passes every test
 // that does not call this directly.
-func countCarried(reports []*reconstruct.TableReport) (carried int) {
+func countReuse(reports []*reconstruct.TableReport) (tally reuseTally) {
 	for _, rep := range reports {
 		if rep != nil && rep.CarriedForward {
-			carried++
+			tally.reused++
+			if !rep.CarriedByLink {
+				tally.copied++
+			}
 		}
 	}
-	return carried
+	return tally
 }
 
 // foldSnapshot is the fold both the periodic refresh and the point-in-time
@@ -679,7 +696,7 @@ func countCarried(reports []*reconstruct.TableReport) (carried int) {
 // It is read out of the per-table reports rather than inferred from the
 // setting, because asking for reuse is not getting it: a table with changes,
 // with a capture gap, or on the S3 path is folded anyway.
-func (s *baselineSupervisor) foldSnapshot(req refreshRequest, at time.Time, tableList []string) (tables, refused, carried int, err error) {
+func (s *baselineSupervisor) foldSnapshot(req refreshRequest, at time.Time, tableList []string) (tables, refused int, reuse reuseTally, err error) {
 	reports, failures, runErr := foldTables(s.ctx, refreshFoldConfig(req, at, tableList))
 	return foldOutcome(tableList, reports, failures, runErr)
 }
@@ -737,12 +754,12 @@ var (
 // the equivalent end-to-end behaviour is pinned at the integration tier by
 // internal/reconstruct's TestReconstructParquet_doesNotCarryForwardUnlessAsked.
 func foldOutcome(tableList []string, reports []*reconstruct.TableReport,
-	failures []reconstruct.TableFailure, runErr error) (tables, refused, carried int, err error) {
-	carried = countCarried(reports)
+	failures []reconstruct.TableFailure, runErr error) (tables, refused int, reuse reuseTally, err error) {
+	reuse = countReuse(reports)
 	if runErr != nil {
-		return len(tableList), len(failures), carried, runErr
+		return len(tableList), len(failures), reuse, runErr
 	}
-	return len(tableList), 0, carried, nil
+	return len(tableList), 0, reuse, nil
 }
 
 // startBaselineRefreshLoop launches the opt-in periodic baseline refresh

--- a/consoleapp/baseline_refresh_loop.go
+++ b/consoleapp/baseline_refresh_loop.go
@@ -144,16 +144,15 @@ func (s *baselineSupervisor) runRefresh(req refreshRequest, at time.Time, interv
 	// instead measures how long it takes to spawn a goroutine, which is
 	// microseconds no matter what the refresh costs.
 	took := time.Since(elapsed)
-	s.recordRun(req.ServerID, req.ServerName, console.BaselineRunRecord{
+	s.recordRun(req.ServerID, req.ServerName, foldRunCounts(console.BaselineRunRecord{
 		Kind: console.BaselineRunRefresh, Trigger: req.Trigger, StartedAt: started.Format(time.RFC3339),
-		SnapshotTime: publishedSnapshotTime(at, err), Tables: tables, Refused: refused,
-		Carried: reuse.reused, CarriedCopied: reuse.copied,
+		SnapshotTime: publishedSnapshotTime(at, err),
 		// Zero means "nothing was sent" for a server with no destination AND
 		// "these files reached the bucket" otherwise, so the count is what
 		// makes a successful upload visible at all: without it the only
 		// evidence the snapshot got there is the absence of a failure line.
 		Uploaded: uploaded,
-	}, err)
+	}, tables, refused, reuse), err)
 	if err != nil {
 		// Reported and reclaimed OUTSIDE s.mu. Deleting a directory is
 		// filesystem work of unbounded duration, and s.mu is the lock every
@@ -505,6 +504,18 @@ func snapshotPublished(dir string) bool {
 func dirExists(path string) bool {
 	info, err := os.Stat(path)
 	return err == nil && info.IsDir()
+}
+
+// foldRunCounts writes a finished fold's counts onto its history record —
+// applyFoldStatus's sibling for the DURABLE copy, and split out for the same
+// reason stated on it below: both callers (runRefresh, runRestore) sit behind
+// a `go` and a live fold, so zeroing CarriedCopied in either record literal
+// compiled and passed the whole suite while the run-history note quietly went
+// back to rendering copied reuses as disk savings (#1578).
+func foldRunCounts(rec console.BaselineRunRecord, tables, refused int, reuse reuseTally) console.BaselineRunRecord {
+	rec.Tables, rec.Refused = tables, refused
+	rec.Carried, rec.CarriedCopied = reuse.reused, reuse.copied
+	return rec
 }
 
 // applyFoldStatus writes a finished fold's outcome onto the status the console

--- a/consoleapp/baseline_refresh_loop_test.go
+++ b/consoleapp/baseline_refresh_loop_test.go
@@ -553,29 +553,37 @@ func TestRefreshFoldConfig_carriesTheSettingAndKeepsGapsStrict(t *testing.T) {
 	}
 }
 
-// TestCountCarried: the reuse count is the only confirmation an operator gets
+// TestCountReuse: the reuse tally is the only confirmation an operator gets
 // that the opt-in did anything, so it is derived from the per-table reports and
 // never from the setting. Asking for reuse is not getting it: a table with
-// changes, with a capture gap, or on the S3 path is folded anyway.
-func TestCountCarried(t *testing.T) {
-	rep := func(carried bool) *reconstruct.TableReport {
-		return &reconstruct.TableReport{CarriedForward: carried}
+// changes, with a capture gap, or on the S3 path is folded anyway. The copied
+// half narrows further: a reuse that fell back to a byte copy saved no disk,
+// and folding it into the reused count is how the console came to confirm a
+// saving the daemon log denied (#1578).
+func TestCountReuse(t *testing.T) {
+	rep := func(carried, linked bool) *reconstruct.TableReport {
+		return &reconstruct.TableReport{CarriedForward: carried, CarriedByLink: linked}
 	}
 	cases := []struct {
 		name    string
 		reports []*reconstruct.TableReport
-		want    int
+		want    reuseTally
 	}{
-		{"nothing folded", nil, 0},
-		{"every table rewritten", []*reconstruct.TableReport{rep(false), rep(false)}, 0},
-		{"every table reused", []*reconstruct.TableReport{rep(true), rep(true), rep(true)}, 3},
-		{"mixed, which is the normal case", []*reconstruct.TableReport{rep(true), rep(false), rep(true)}, 2},
-		{"a nil report is not a reuse", []*reconstruct.TableReport{rep(true), nil}, 1},
+		{"nothing folded", nil, reuseTally{}},
+		{"every table rewritten", []*reconstruct.TableReport{rep(false, false), rep(false, false)}, reuseTally{}},
+		{"every table reused by link", []*reconstruct.TableReport{rep(true, true), rep(true, true), rep(true, true)}, reuseTally{reused: 3}},
+		{"mixed, which is the normal case", []*reconstruct.TableReport{rep(true, true), rep(false, false), rep(true, true)}, reuseTally{reused: 2}},
+		{"a nil report is not a reuse", []*reconstruct.TableReport{rep(true, true), nil}, reuseTally{reused: 1}},
+		{"a copied reuse counts in BOTH halves", []*reconstruct.TableReport{rep(true, false), rep(true, true)}, reuseTally{reused: 2, copied: 1}},
+		// CarriedByLink without CarriedForward is a shape fulltable.go never
+		// emits; if it ever appears, a link that was not a reuse must not
+		// subtract from anything.
+		{"linked-but-not-carried is not a reuse", []*reconstruct.TableReport{rep(false, true)}, reuseTally{}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := countCarried(tc.reports); got != tc.want {
-				t.Errorf("countCarried = %d, want %d", got, tc.want)
+			if got := countReuse(tc.reports); got != tc.want {
+				t.Errorf("countReuse = %+v, want %+v", got, tc.want)
 			}
 		})
 	}
@@ -670,42 +678,45 @@ func TestEnvBoolOr(t *testing.T) {
 // and passed the whole suite, because the only caller needs a live index and a
 // real baseline.
 func TestFoldOutcome(t *testing.T) {
-	rep := func(carried bool) *reconstruct.TableReport {
-		return &reconstruct.TableReport{CarriedForward: carried}
+	rep := func(carried, linked bool) *reconstruct.TableReport {
+		return &reconstruct.TableReport{CarriedForward: carried, CarriedByLink: linked}
 	}
 	tables := []string{"shop.orders", "shop.users", "shop.audit"}
 
 	t.Run("clean run reports every table and the reused subset", func(t *testing.T) {
-		gotT, gotR, gotC, err := foldOutcome(tables,
-			[]*reconstruct.TableReport{rep(true), rep(false), rep(true)}, nil, nil)
+		// One of the two reuses is a COPY (no link), so the tally must carry
+		// both halves through this hop or the console's "saved no disk"
+		// qualifier never renders (#1578).
+		gotT, gotR, reuse, err := foldOutcome(tables,
+			[]*reconstruct.TableReport{rep(true, true), rep(false, false), rep(true, false)}, nil, nil)
 		if err != nil {
 			t.Fatalf("err = %v, want nil", err)
 		}
-		if gotT != 3 || gotR != 0 || gotC != 2 {
-			t.Errorf("tables=%d refused=%d carried=%d, want 3/0/2", gotT, gotR, gotC)
+		if gotT != 3 || gotR != 0 || reuse != (reuseTally{reused: 2, copied: 1}) {
+			t.Errorf("tables=%d refused=%d reuse=%+v, want 3/0/{reused:2 copied:1}", gotT, gotR, reuse)
 		}
 	})
 
 	t.Run("a clean run that reused nothing reports zero, not the total", func(t *testing.T) {
-		_, _, gotC, _ := foldOutcome(tables,
-			[]*reconstruct.TableReport{rep(false), rep(false), rep(false)}, nil, nil)
-		if gotC != 0 {
-			t.Errorf("carried=%d, want 0: every table was rewritten", gotC)
+		_, _, reuse, _ := foldOutcome(tables,
+			[]*reconstruct.TableReport{rep(false, false), rep(false, false), rep(false, false)}, nil, nil)
+		if reuse != (reuseTally{}) {
+			t.Errorf("reuse=%+v, want zero: every table was rewritten", reuse)
 		}
 	})
 
 	t.Run("a failed run still reports what the fold did", func(t *testing.T) {
 		want := errors.New("capture gap")
-		gotT, gotR, gotC, err := foldOutcome(tables,
-			[]*reconstruct.TableReport{rep(true)},
+		gotT, gotR, reuse, err := foldOutcome(tables,
+			[]*reconstruct.TableReport{rep(true, true)},
 			[]reconstruct.TableFailure{{}, {}}, want)
 		if !errors.Is(err, want) {
 			t.Fatalf("err = %v, want the run error", err)
 		}
 		// Publication is all-or-nothing, so nothing was published; the counts
 		// still describe the attempt, and refused comes from the failures.
-		if gotT != 3 || gotR != 2 || gotC != 1 {
-			t.Errorf("tables=%d refused=%d carried=%d, want 3/2/1", gotT, gotR, gotC)
+		if gotT != 3 || gotR != 2 || reuse != (reuseTally{reused: 1}) {
+			t.Errorf("tables=%d refused=%d reuse=%+v, want 3/2/{reused:1}", gotT, gotR, reuse)
 		}
 	})
 
@@ -727,15 +738,16 @@ func TestFoldOutcome(t *testing.T) {
 func TestApplyFoldStatus(t *testing.T) {
 	t.Run("a clean run reports every count and clears the previous error", func(t *testing.T) {
 		st := &console.BaselineStatus{State: "failed", LastError: "the previous run's gap"}
-		applyFoldStatus(st, 7, 0, 3, nil)
+		applyFoldStatus(st, 7, 0, reuseTally{reused: 3, copied: 2}, nil)
 		if st.State != "succeeded" {
 			t.Errorf("State = %q, want succeeded", st.State)
 		}
 		if st.LastError != "" {
 			t.Errorf("LastError = %q, want cleared: a stale error outlives the run that caused it", st.LastError)
 		}
-		if st.Tables != 7 || st.Refused != 0 || st.Carried != 3 {
-			t.Errorf("tables=%d refused=%d carried=%d, want 7/0/3", st.Tables, st.Refused, st.Carried)
+		if st.Tables != 7 || st.Refused != 0 || st.Carried != 3 || st.CarriedCopied != 2 {
+			t.Errorf("tables=%d refused=%d carried=%d copied=%d, want 7/0/3/2",
+				st.Tables, st.Refused, st.Carried, st.CarriedCopied)
 		}
 		if st.FinishedAt == "" {
 			t.Error("FinishedAt is empty, so the console cannot say when this ran")
@@ -744,7 +756,7 @@ func TestApplyFoldStatus(t *testing.T) {
 
 	t.Run("a failed run keeps the counts and names the error", func(t *testing.T) {
 		st := &console.BaselineStatus{State: "running"}
-		applyFoldStatus(st, 7, 2, 1, errors.New("capture gap at 2026-01-01T00:00:00Z"))
+		applyFoldStatus(st, 7, 2, reuseTally{reused: 1}, errors.New("capture gap at 2026-01-01T00:00:00Z"))
 		if st.State != "failed" {
 			t.Errorf("State = %q, want failed", st.State)
 		}
@@ -757,12 +769,14 @@ func TestApplyFoldStatus(t *testing.T) {
 	})
 
 	t.Run("reused zero is written, not skipped", func(t *testing.T) {
-		// The field is omitempty on the wire, so a stale non-zero left behind
-		// by the PREVIOUS run would keep rendering. Assignment, not accumulation.
-		st := &console.BaselineStatus{Carried: 9}
-		applyFoldStatus(st, 2, 0, 0, nil)
-		if st.Carried != 0 {
-			t.Errorf("Carried = %d, want 0: the previous run's reuse count survived into this one", st.Carried)
+		// Both fields are omitempty on the wire, so a stale non-zero left
+		// behind by the PREVIOUS run would keep rendering. Assignment, not
+		// accumulation.
+		st := &console.BaselineStatus{Carried: 9, CarriedCopied: 4}
+		applyFoldStatus(st, 2, 0, reuseTally{}, nil)
+		if st.Carried != 0 || st.CarriedCopied != 0 {
+			t.Errorf("Carried=%d CarriedCopied=%d, want 0/0: the previous run's reuse counts survived into this one",
+				st.Carried, st.CarriedCopied)
 		}
 	})
 }

--- a/consoleapp/baseline_refresh_loop_test.go
+++ b/consoleapp/baseline_refresh_loop_test.go
@@ -730,6 +730,29 @@ func TestFoldOutcome(t *testing.T) {
 	})
 }
 
+// TestFoldRunCounts: the DURABLE half of a fold's outcome — the history
+// record the Backups page reads long after the live status is overwritten.
+// Both callers sit behind a `go` and a live fold, so this mapping is the one
+// hop of the reuseTally chain the unit tier can reach; zeroing CarriedCopied
+// in either record literal used to pass the whole suite.
+func TestFoldRunCounts(t *testing.T) {
+	base := console.BaselineRunRecord{Kind: console.BaselineRunRefresh, Uploaded: 4}
+	got := foldRunCounts(base, 7, 2, reuseTally{reused: 3, copied: 1})
+	if got.Tables != 7 || got.Refused != 2 || got.Carried != 3 || got.CarriedCopied != 1 {
+		t.Errorf("counts = tables:%d refused:%d carried:%d copied:%d, want 7/2/3/1",
+			got.Tables, got.Refused, got.Carried, got.CarriedCopied)
+	}
+	if got.Kind != console.BaselineRunRefresh || got.Uploaded != 4 {
+		t.Errorf("the mapping disturbed fields it does not own: %+v", got)
+	}
+	// Zeroes are written, not skipped: the fields are omitempty on the wire
+	// and the record is built fresh, but the mapping must not depend on that.
+	zero := foldRunCounts(console.BaselineRunRecord{Tables: 9, Carried: 5, CarriedCopied: 5}, 0, 0, reuseTally{})
+	if zero.Tables != 0 || zero.Carried != 0 || zero.CarriedCopied != 0 {
+		t.Errorf("zero counts did not overwrite: %+v", zero)
+	}
+}
+
 // TestApplyFoldStatus: what the console polls after a fold finishes.
 //
 // Both callers sit behind a `go` and a live fold, so this was unreachable at

--- a/consoleapp/baseline_restore.go
+++ b/consoleapp/baseline_restore.go
@@ -52,11 +52,10 @@ func (s *baselineSupervisor) runRestore(req console.BaselineRestoreRequest) {
 	defer s.recoverBaselineJob(baselineJobRestore, req.ServerID, req.ServerName)
 	started := time.Now().UTC()
 	tables, refused, reuse, err := s.executeRestore(req)
-	s.recordRun(req.ServerID, req.ServerName, console.BaselineRunRecord{
+	s.recordRun(req.ServerID, req.ServerName, foldRunCounts(console.BaselineRunRecord{
 		Kind: console.BaselineRunRestore, StartedAt: started.Format(time.RFC3339),
-		SnapshotTime: publishedSnapshotTime(req.At, err), Tables: tables, Refused: refused,
-		Carried: reuse.reused, CarriedCopied: reuse.copied,
-	}, err)
+		SnapshotTime: publishedSnapshotTime(req.At, err),
+	}, tables, refused, reuse), err)
 
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/consoleapp/baseline_restore.go
+++ b/consoleapp/baseline_restore.go
@@ -51,10 +51,11 @@ func (s *baselineSupervisor) RestoreStatus(serverID string) console.BaselineStat
 func (s *baselineSupervisor) runRestore(req console.BaselineRestoreRequest) {
 	defer s.recoverBaselineJob(baselineJobRestore, req.ServerID, req.ServerName)
 	started := time.Now().UTC()
-	tables, refused, carried, err := s.executeRestore(req)
+	tables, refused, reuse, err := s.executeRestore(req)
 	s.recordRun(req.ServerID, req.ServerName, console.BaselineRunRecord{
 		Kind: console.BaselineRunRestore, StartedAt: started.Format(time.RFC3339),
-		SnapshotTime: publishedSnapshotTime(req.At, err), Tables: tables, Refused: refused, Carried: carried,
+		SnapshotTime: publishedSnapshotTime(req.At, err), Tables: tables, Refused: refused,
+		Carried: reuse.reused, CarriedCopied: reuse.copied,
 	}, err)
 
 	s.mu.Lock()
@@ -64,7 +65,7 @@ func (s *baselineSupervisor) runRestore(req console.BaselineRestoreRequest) {
 		st = &console.BaselineStatus{}
 		s.restores[req.ServerID] = st
 	}
-	applyFoldStatus(st, tables, refused, carried, err)
+	applyFoldStatus(st, tables, refused, reuse, err)
 	if err != nil {
 		// Warn, never Error: a refusal (gap, schema change) is the fail-closed
 		// contract working, and the operator picks another moment.
@@ -73,20 +74,21 @@ func (s *baselineSupervisor) runRestore(req console.BaselineRestoreRequest) {
 		return
 	}
 	slog.Info("baseline restore: published", "server", req.ServerName, "id", req.ServerID,
-		"tables", tables, "reused", carried, "at", req.At.UTC().Format(time.RFC3339))
+		"tables", tables, "reused", reuse.reused, "reused_copied", reuse.copied,
+		"at", req.At.UTC().Format(time.RFC3339))
 }
 
 // executeRestore folds toward the chosen instant. The table list comes from
 // the snapshot FindBaseline will anchor on (newest at-or-before At), NOT the
 // newest snapshot overall: restoring to a moment before the newest snapshot
 // must fold the older snapshot's tables.
-func (s *baselineSupervisor) executeRestore(req console.BaselineRestoreRequest) (tables, refused, carried int, err error) {
+func (s *baselineSupervisor) executeRestore(req console.BaselineRestoreRequest) (tables, refused int, reuse reuseTally, err error) {
 	tableList, err := reconstruct.SnapshotTablesAt(s.ctx, req.BaselineDir, req.At)
 	if err != nil {
-		return 0, 0, 0, fmt.Errorf("list the snapshot to restore from: %w", err)
+		return 0, 0, reuseTally{}, fmt.Errorf("list the snapshot to restore from: %w", err)
 	}
 	if len(tableList) == 0 {
-		return 0, 0, 0, fmt.Errorf("no backup exists at or before %s; a restore folds an existing backup forward, so pick a moment after your oldest backup", req.At.UTC().Format("2006-01-02 15:04:05"))
+		return 0, 0, reuseTally{}, fmt.Errorf("no backup exists at or before %s; a restore folds an existing backup forward, so pick a moment after your oldest backup", req.At.UTC().Format("2006-01-02 15:04:05"))
 	}
 	return s.foldSnapshot(restoreFoldRequest(req), req.At.UTC(), tableList)
 }

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -4087,9 +4087,10 @@ function rotationCard(rot) {
 //
 // The saving also stopped being stated unconditionally. carryForward falls
 // back to a COPY when os.Link fails, and fulltable.go marks the table carried
-// either way, so the console reports "reused" for a run that saved nothing;
-// only the daemon log dissents. The guarantee the reader needs, that the
-// backup is still complete, is what stays absolute.
+// either way; carried_copied (#1578) carries the split to this page, and the
+// run notes qualify their "reused" counts with reusedCopiedNote so a run
+// that saved nothing no longer reads as a saving. The guarantee the reader
+// needs, that the backup is still complete, is what stays absolute.
 //
 // No command, flag or path appears in any visible string here. A reader
 // clicking buttons who is shown a flag is being told the real answer lives
@@ -4586,6 +4587,17 @@ function archivingPanel(servers, serversErr) {
   return panel;
 }
 
+// reusedCopiedNote qualifies a "reused" count with the reuses that were
+// written as full byte copies. The bare counter reads as a disk saving, and
+// for a copied reuse that saving did not happen: the fold was skipped but
+// every byte was written again (no hard link; the daemon log names the
+// cause). Confirming a saving the daemon log denies is the bug this splits
+// away (#1578).
+function reusedCopiedNote(copied) {
+  if (!copied) return "";
+  return " (" + copied + " of them written as full copies, which saved no disk; the daemon log says why)";
+}
+
 // baselineRefreshNote renders the last automatic refresh for the selected
 // server.
 function baselineRefreshNote(rf) {
@@ -4608,7 +4620,7 @@ function baselineRefreshNote(rf) {
       const rewritten = Math.max(0, (rf.tables || 0) - reused);
       text = "Automatic refresh" + (when ? " at " + when : "") + ": " +
         rewritten + " table(s) refreshed" +
-        (reused ? ", " + reused + " unchanged and reused" : "") + ".";
+        (reused ? ", " + reused + " unchanged and reused" + reusedCopiedNote(rf.carried_copied || 0) : "") + ".";
       break;
     case "failed":
       // published means the fold finished and marked the snapshot, and only
@@ -5648,7 +5660,7 @@ function backupScheduleCard(cur, b) {
         const reused = run.carried || 0;
         body.append(el("p", { class: "form-hint", text:
           "Last scheduled backup finished " + when + " (" + what + "): " + (run.tables || 0) + " table(s)" +
-          (reused ? ", " + reused + " unchanged and reused" : "") +
+          (reused ? ", " + reused + " unchanged and reused" + reusedCopiedNote(run.carried_copied || 0) : "") +
           (run.uploaded ? ", " + run.uploaded + " file(s) uploaded" : "") + "." }));
       } else {
         alarm = true;
@@ -5776,7 +5788,7 @@ function backupRestoreCard(cur, b, restoreSt) {
     // number nothing on this page confirms the setting did anything.
     body.append(el("p", { class: "form-hint", text:
       "Last restore finished" + (rst.at ? ": the backup at " + utcLabel(rst.at) : "") + " is in the list below." +
-      (rst.carried ? " " + rst.carried + " table(s) reused an unchanged file." : "") }));
+      (rst.carried ? " " + rst.carried + " table(s) reused an unchanged file" + reusedCopiedNote(rst.carried_copied || 0) + "." : "") }));
   }
   details.append(body);
   return details;

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -4595,7 +4595,7 @@ function archivingPanel(servers, serversErr) {
 // away (#1578).
 function reusedCopiedNote(copied) {
   if (!copied) return "";
-  return " (" + copied + " of them written as full copies, which saved no disk; the daemon log says why)";
+  return " (" + copied + " of them written in full, which saved no disk; the daemon log says why)";
 }
 
 // baselineRefreshNote renders the last automatic refresh for the selected

--- a/internal/console/assets_backuprefresh_test.go
+++ b/internal/console/assets_backuprefresh_test.go
@@ -171,7 +171,7 @@ func TestBaselineRefreshNote_partitionsTheTables(t *testing.T) {
 func TestBackupRefreshWireNamesMatchTheFrontend(t *testing.T) {
 	js := readAsset(t, "app.js")
 
-	raw, err := json.Marshal(BaselineStatus{State: "succeeded", Tables: 3, Carried: 2})
+	raw, err := json.Marshal(BaselineStatus{State: "succeeded", Tables: 3, Carried: 2, CarriedCopied: 1})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -183,7 +183,13 @@ func TestBackupRefreshWireNamesMatchTheFrontend(t *testing.T) {
 		t.Fatalf("BaselineStatus no longer serialises a \"carried\" key (got %s); the console reads rf.carried "+
 			"and would silently stop showing reused tables", raw)
 	}
-	for _, ref := range []string{"rf.carried", "rst.carried"} {
+	// carried_copied is the honesty half of the pair (#1578): without it every
+	// reuse renders as a disk saving, including the copies that saved none.
+	if _, ok := wire["carried_copied"]; !ok {
+		t.Fatalf("BaselineStatus no longer serialises \"carried_copied\" (got %s); copied reuses would "+
+			"silently render as disk savings again", raw)
+	}
+	for _, ref := range []string{"rf.carried", "rst.carried", "rf.carried_copied", "rst.carried_copied", "run.carried_copied"} {
 		if !strings.Contains(js, ref) {
 			t.Errorf("app.js does not read %s, so the reused count never reaches the page", ref)
 		}

--- a/internal/console/assets_backuprefresh_test.go
+++ b/internal/console/assets_backuprefresh_test.go
@@ -354,6 +354,28 @@ func TestBackupRefreshCard_titleSaysWhatItDoes(t *testing.T) {
 	}
 }
 
+// TestReusedCopiedNote_saysWhatACopyCost pins the only user-visible half of
+// #1578: every layer under the render (carryForward's bool, the fold wiring,
+// countReuse, applyFoldStatus, the wire names) is guarded, but the string the
+// reporter actually reads was not — emptying reusedCopiedNote restored the
+// exact bug (a copied reuse rendering as a disk saving) with the whole Go
+// suite green, because the wire-name guard only checks the fields are READ.
+func TestReusedCopiedNote_saysWhatACopyCost(t *testing.T) {
+	body := jsFunctionBody(t, readAsset(t, "app.js"), "reusedCopiedNote")
+	// The zero arm: no copies, no qualifier — the unqualified "reused" note
+	// is then the correct claim.
+	if !strings.Contains(body, `if (!copied) return "";`) {
+		t.Error("reusedCopiedNote no longer returns empty for zero copies; every reuse would carry a false qualifier")
+	}
+	// The non-empty arm carries the counter and the two load-bearing claims:
+	// no disk was saved, and the cause is in the daemon log.
+	for _, want := range []string{`+ copied +`, "which saved no disk", "the daemon log says why"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("reusedCopiedNote lost %q; a copied reuse would render as a disk saving again (#1578)", want)
+		}
+	}
+}
+
 // TestBackupRefreshCard_prose (#1528): a line of help under a control is fine,
 // a paragraph means the control explains itself instead of being clear. The
 // on-state used to carry the shared-bytes consequence of a hard link in the

--- a/internal/console/assets_backupschedule_test.go
+++ b/internal/console/assets_backupschedule_test.go
@@ -16,7 +16,7 @@ func TestBackupScheduleWireNamesMatchTheFrontend(t *testing.T) {
 	raw, err := json.Marshal(backupScheduleDTO{
 		Every: "1d", At: "03:00", NextRun: "x", NextMethod: BackupMethodRefresh, NextMethodWhy: "w", NextMethodError: "e",
 		Runnable: false, Reason: "r", Running: true, HistoryUnavailable: true,
-		LastRun:      &backupScheduleRunDTO{Method: BackupMethodRefresh, FinishedAt: "f", Error: "e", Tables: 1, Carried: 1, Uploaded: 1},
+		LastRun:      &backupScheduleRunDTO{Method: BackupMethodRefresh, FinishedAt: "f", Error: "e", Tables: 1, Carried: 1, CarriedCopied: 1, Uploaded: 1},
 		LastSkipped:  &backupScheduleSkipDTO{At: "a", Reason: "r"},
 		LastFallback: &backupScheduleSkipDTO{At: "a", Reason: "r"},
 	})
@@ -36,7 +36,7 @@ func TestBackupScheduleWireNamesMatchTheFrontend(t *testing.T) {
 		}
 	}
 	run := wire["last_run"].(map[string]any)
-	for _, key := range []string{"method", "finished_at", "ok", "error", "tables", "carried", "uploaded"} {
+	for _, key := range []string{"method", "finished_at", "ok", "error", "tables", "carried", "carried_copied", "uploaded"} {
 		if _, ok := run[key]; !ok {
 			t.Errorf("last_run does not serialise %q (got %s)", key, raw)
 		}

--- a/internal/console/backup_schedule_api.go
+++ b/internal/console/backup_schedule_api.go
@@ -67,7 +67,10 @@ type backupScheduleRunDTO struct {
 	Rows         int64  `json:"rows,omitempty"`
 	Uploaded     int    `json:"uploaded,omitempty"`
 	Carried      int    `json:"carried,omitempty"`
-	Refused      int    `json:"refused,omitempty"`
+	// CarriedCopied narrows Carried to full-byte-copy reuses (no disk saved)
+	// — see BaselineStatus.CarriedCopied.
+	CarriedCopied int `json:"carried_copied,omitempty"`
+	Refused       int `json:"refused,omitempty"`
 }
 
 type backupScheduleSkipDTO struct {
@@ -166,17 +169,18 @@ func (s *Server) backupScheduleDTO(ctx context.Context, e ServerEntry, now time.
 
 func scheduleRunFromRecord(run *BaselineRunRecord) *backupScheduleRunDTO {
 	return &backupScheduleRunDTO{
-		Method:       runMethod(run.Kind),
-		StartedAt:    run.StartedAt,
-		FinishedAt:   run.FinishedAt,
-		OK:           run.Error == "",
-		Error:        run.Error,
-		SnapshotTime: run.SnapshotTime,
-		Tables:       run.Tables,
-		Rows:         run.Rows,
-		Uploaded:     run.Uploaded,
-		Carried:      run.Carried,
-		Refused:      run.Refused,
+		Method:        runMethod(run.Kind),
+		StartedAt:     run.StartedAt,
+		FinishedAt:    run.FinishedAt,
+		OK:            run.Error == "",
+		Error:         run.Error,
+		SnapshotTime:  run.SnapshotTime,
+		Tables:        run.Tables,
+		Rows:          run.Rows,
+		Uploaded:      run.Uploaded,
+		Carried:       run.Carried,
+		CarriedCopied: run.CarriedCopied,
+		Refused:       run.Refused,
 	}
 }
 
@@ -198,17 +202,18 @@ func scheduleRunFromStatus(st BackupScheduleState) *backupScheduleRunDTO {
 		snapshot = cur.At
 	}
 	return &backupScheduleRunDTO{
-		Method:       st.LastMethod,
-		StartedAt:    st.LastStartedAt,
-		FinishedAt:   cur.FinishedAt,
-		OK:           ok,
-		Error:        cur.LastError,
-		SnapshotTime: snapshot,
-		Tables:       cur.Tables,
-		Rows:         cur.Rows,
-		Uploaded:     cur.Uploaded,
-		Carried:      cur.Carried,
-		Refused:      cur.Refused,
+		Method:        st.LastMethod,
+		StartedAt:     st.LastStartedAt,
+		FinishedAt:    cur.FinishedAt,
+		OK:            ok,
+		Error:         cur.LastError,
+		SnapshotTime:  snapshot,
+		Tables:        cur.Tables,
+		Rows:          cur.Rows,
+		Uploaded:      cur.Uploaded,
+		Carried:       cur.Carried,
+		CarriedCopied: cur.CarriedCopied,
+		Refused:       cur.Refused,
 	}
 }
 

--- a/internal/console/backup_schedule_api_test.go
+++ b/internal/console/backup_schedule_api_test.go
@@ -290,7 +290,7 @@ func TestBackupScheduleAPI_lastRunAndSkipComeFromTheHistory(t *testing.T) {
 	h := srv.baselineHistory
 	if err := h.Append(BaselineRunRecord{ServerID: id, Kind: BaselineRunRefresh, Trigger: BaselineRunTriggerScheduled,
 		StartedAt: "2026-08-28T09:00:00Z", FinishedAt: "2026-08-28T09:04:00Z", SnapshotTime: "2026-08-28T09:00:00Z",
-		Tables: 12, Carried: 3}); err != nil {
+		Tables: 12, Carried: 3, CarriedCopied: 2}); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := h.AppendSkip(BaselineRunRecord{ServerID: id, Kind: BaselineRunDump, SkipReason: "busy",
@@ -302,7 +302,8 @@ func TestBackupScheduleAPI_lastRunAndSkipComeFromTheHistory(t *testing.T) {
 	_, body := doServersReqHeader(t, srv, "GET", "/api/baselines", "", id)
 	got := scheduleOf(t, body)
 	if got == nil || got.LastRun == nil || got.LastRun.Method != BackupMethodRefresh || !got.LastRun.OK ||
-		got.LastRun.Tables != 12 || got.LastRun.Carried != 3 || got.LastRun.SnapshotTime != "2026-08-28T09:00:00Z" {
+		got.LastRun.Tables != 12 || got.LastRun.Carried != 3 || got.LastRun.CarriedCopied != 2 ||
+		got.LastRun.SnapshotTime != "2026-08-28T09:00:00Z" {
 		t.Fatalf("last_run = %+v", got)
 	}
 	if got.LastSkipped == nil || got.LastSkipped.Reason != "busy" || got.LastSkipped.At != "2026-08-28T15:00:00Z" {

--- a/internal/console/baseline_history.go
+++ b/internal/console/baseline_history.go
@@ -58,11 +58,14 @@ type BaselineRunRecord struct {
 	// which the next run overwrites: whether a run cost a full rewrite is
 	// exactly the thing an operator looks back at when sizing a disk or an
 	// interval, and by then the live status is gone.
-	Carried  int    `json:"carried,omitempty"`
-	Rows     int64  `json:"rows,omitempty"`
-	Uploaded int    `json:"uploaded,omitempty"`
-	Refused  int    `json:"refused,omitempty"`
-	Error    string `json:"error,omitempty"`
+	Carried int `json:"carried,omitempty"`
+	// CarriedCopied narrows Carried to the reuses published as full byte
+	// copies (no hard link, no disk saved) — see BaselineStatus.CarriedCopied.
+	CarriedCopied int    `json:"carried_copied,omitempty"`
+	Rows          int64  `json:"rows,omitempty"`
+	Uploaded      int    `json:"uploaded,omitempty"`
+	Refused       int    `json:"refused,omitempty"`
+	Error         string `json:"error,omitempty"`
 }
 
 type baselineHistoryFile struct {

--- a/internal/console/baseline_trigger.go
+++ b/internal/console/baseline_trigger.go
@@ -176,8 +176,12 @@ type BaselineStatus struct {
 	// ONLY confirmation the operator gets that the reuse setting did anything:
 	// without it a run that reused every file and a run that rewrote every
 	// file report identically.
-	Carried int   `json:"carried,omitempty"`
-	Rows    int64 `json:"rows,omitempty"`
+	Carried int `json:"carried,omitempty"`
+	// CarriedCopied narrows Carried to the reuses that fell back to a full
+	// byte copy (no hard link, so no disk saved). Without the split the UI
+	// confirmed a disk saving the daemon log denied (#1578).
+	CarriedCopied int   `json:"carried_copied,omitempty"`
+	Rows          int64 `json:"rows,omitempty"`
 	// Bytes is the finished artifact's on-disk weight (sql-export builds
 	// only) — the UI's download confirm and Ready line read it.
 	Bytes    int64 `json:"bytes,omitempty"`

--- a/internal/reconstruct/carryforward.go
+++ b/internal/reconstruct/carryforward.go
@@ -99,16 +99,21 @@ import (
 // over it, which is a long way from here.
 var linkFile = os.Link
 
-func carryForward(ctx context.Context, srcPath, snapshotDir, schema, table string) error {
+// carryForward reports HOW it published as well as whether it did: linked is
+// true only when the destination shares the source's inode, which is the only
+// arm that saves disk. The copy arm is still a reuse (no fold ran, no source
+// was read), but every byte was written again — collapsing the two is how the
+// console came to confirm a disk saving the daemon log denied (#1578).
+func carryForward(ctx context.Context, srcPath, snapshotDir, schema, table string) (linked bool, err error) {
 	if err := ctx.Err(); err != nil {
-		return err
+		return false, err
 	}
 	if err := baselineintegrity.ValidateLocalFile(srcPath); err != nil {
-		return fmt.Errorf("validate the snapshot being carried forward: %w", err)
+		return false, fmt.Errorf("validate the snapshot being carried forward: %w", err)
 	}
 	dst := filepath.Join(snapshotDir, schema, table+".parquet")
 	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-		return err
+		return false, err
 	}
 	// Remove before writing, and the reason is the COPY path rather than the
 	// link path. os.Create truncates, and after a carry-forward the destination
@@ -117,11 +122,11 @@ func carryForward(ctx context.Context, srcPath, snapshotDir, schema, table strin
 	// share before anything is written. (os.Link would also fail with EEXIST,
 	// though reconstruct's leftovers refusal already rules that out.)
 	if err := os.Remove(dst); err != nil && !os.IsNotExist(err) {
-		return err
+		return false, err
 	}
 	linkErr := linkFile(srcPath, dst)
 	if linkErr == nil {
-		return nil
+		return true, nil
 	}
 	// The copy is the designed fallback, not a failure, so the error is never
 	// returned. The LEVEL splits by cause, because the two causes are worlds
@@ -139,7 +144,7 @@ func carryForward(ctx context.Context, srcPath, snapshotDir, schema, table strin
 			"Reusing an unchanged table is meant to avoid rewriting it; a copy still writes every byte.",
 			"src", srcPath, "dst", dst, "error", linkErr)
 	}
-	return copyFile(srcPath, dst)
+	return false, copyFile(srcPath, dst)
 }
 
 // carryForwardEligible reports whether a table can be published by carrying its

--- a/internal/reconstruct/carryforward_provenance_test.go
+++ b/internal/reconstruct/carryforward_provenance_test.go
@@ -82,7 +82,7 @@ func TestCarryForward_readsBackAsCarriedNotAsItsAncestor(t *testing.T) {
 	src := writeProvenanceSnapshot(t, root, oldStamp, baseline.ProducerReconstruct)
 
 	newDir := filepath.Join(root, newStamp)
-	if err := carryForward(context.Background(), src, newDir, "demo", "orders"); err != nil {
+	if _, err := carryForward(context.Background(), src, newDir, "demo", "orders"); err != nil {
 		t.Fatalf("carryForward: %v", err)
 	}
 	dst := filepath.Join(newDir, "demo", "orders.parquet")

--- a/internal/reconstruct/carryforward_test.go
+++ b/internal/reconstruct/carryforward_test.go
@@ -65,12 +65,19 @@ func TestCarryForward_linksWhenItCanAndTheBytesSurvive(t *testing.T) {
 	}
 	dstSnap := filepath.Join(root, "new")
 
-	if err := carryForward(context.Background(), src, dstSnap, "demo", "orders"); err != nil {
+	linked, err := carryForward(context.Background(), src, dstSnap, "demo", "orders")
+	if err != nil {
 		t.Fatalf("carryForward: %v", err)
 	}
+	// The returned report must AGREE with the filesystem: the console renders
+	// it as "no disk saved" when false, so a link reported as a copy tells the
+	// operator the opposite of what happened (#1578).
+	if !linked {
+		t.Error("carryForward linked (the inodes below agree) but reported linked=false")
+	}
 	dst := filepath.Join(dstSnap, "demo", "orders.parquet")
-	// Compare INODES rather than a returned bool. The saving this exists for is
-	// the bytes not copied, and only the filesystem knows whether they were.
+	// Compare INODES rather than only the returned bool. The saving this exists
+	// for is the bytes not copied, and only the filesystem knows whether they were.
 	assertSharesInode(t, src, dst, "fell back to a copy inside one temp dir, where a hard link should succeed")
 	got, err := os.ReadFile(dst)
 	if err != nil {
@@ -142,8 +149,12 @@ func TestCarryForward_replacesALeftoverWithoutTruncatingASharedInode(t *testing.
 		t.Skipf("no hard links on this filesystem: %v", err)
 	}
 
-	if err := carryForward(context.Background(), src, dstSnap, "demo", "orders"); err != nil {
+	linked, err := carryForward(context.Background(), src, dstSnap, "demo", "orders")
+	if err != nil {
 		t.Fatalf("carryForward over a leftover: %v", err)
+	}
+	if !linked {
+		t.Error("the retry linked below but reported linked=false")
 	}
 	assertSharesInode(t, src, dst, "the retry fell back to a copy: without the unlink, os.Link fails on "+
 		"the leftover and the saving this exists for is silently lost")
@@ -179,7 +190,7 @@ func TestCarryForward_refusesAFileItsManifestDisagreesWith(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := carryForward(context.Background(), src, filepath.Join(root, "new"), "demo", "orders")
+	_, err := carryForward(context.Background(), src, filepath.Join(root, "new"), "demo", "orders")
 	if err == nil {
 		t.Fatal("carried a file forward that does not match its own manifest; a corrupt snapshot would " +
 			"be re-certified under the new snapshot's manifest and look healthy")
@@ -265,8 +276,14 @@ func TestCarryForward_copiesWhenItCannotLink(t *testing.T) {
 	linkFile = func(string, string) error { return syscall.EXDEV }
 
 	dstSnap := filepath.Join(root, "new")
-	if err := carryForward(context.Background(), src, dstSnap, "demo", "orders"); err != nil {
+	linked, err := carryForward(context.Background(), src, dstSnap, "demo", "orders")
+	if err != nil {
 		t.Fatalf("carryForward with links unavailable: %v", err)
+	}
+	// linked=false is what routes the console's "saved no disk" qualifier: a
+	// copy reported as a link is exactly the false saving #1578 closes.
+	if linked {
+		t.Error("the copy fallback reported linked=true, so the console would confirm a disk saving that never happened")
 	}
 	dst := filepath.Join(dstSnap, "demo", "orders.parquet")
 	got, err := os.ReadFile(dst)

--- a/internal/reconstruct/export_test.go
+++ b/internal/reconstruct/export_test.go
@@ -1,0 +1,14 @@
+package reconstruct
+
+// StubLinkFileForTest swaps the hard-link primitive carryForward tries first,
+// so an external test can force the copy fallback through the REAL fold. Every
+// test machine has one filesystem, so without the stub os.Link always succeeds
+// and the fold-level copy arm never executes anywhere (the same blindness that
+// let `return nil` replace the copy and pass both tiers — see linkFile's doc).
+// Test-only by construction: _test.go files never build into the shipped
+// package.
+func StubLinkFileForTest(fn func(oldname, newname string) error) (restore func()) {
+	prev := linkFile
+	linkFile = fn
+	return func() { linkFile = prev }
+}

--- a/internal/reconstruct/fulltable.go
+++ b/internal/reconstruct/fulltable.go
@@ -255,6 +255,14 @@ type TableReport struct {
 	// and reading them as "the table is empty" would be wrong. See carryForward
 	// for why an untouched table's anchor stays valid.
 	CarriedForward bool
+	// CarriedByLink narrows CarriedForward to the arm that shares the
+	// previous file's inode — the only one that saves disk (#1578). A carried
+	// table with this false was published by a full COPY (no-link filesystem,
+	// a permission fault, or a cross-device output): still a reuse — no fold
+	// ran, no source was read — but every byte was written again, and a
+	// consumer that renders "reused" as a disk saving must count THIS, not
+	// CarriedForward, or it confirms a saving the daemon log denies.
+	CarriedByLink bool
 }
 
 // shouldWarnEvents reports whether a fetched event count should trigger the
@@ -1131,23 +1139,23 @@ func ReconstructTable(
 	// it returns the finding and lets the run proceed. See carryForwardEligible
 	// for why a known gap disqualifies a table from being carried at all.
 	if carryForwardEligible(cfg.CarryForwardUnchanged, cfg.OutputFormat, baselinePath, len(changes), capGap) {
-		cerr := carryForward(ctx, baselinePath, cfg.snapshotDir, schema, table)
+		linked, cerr := carryForward(ctx, baselinePath, cfg.snapshotDir, schema, table)
 		if cerr != nil {
 			return nil, fmt.Errorf("carry %s.%s forward unchanged: %w", schema, table, cerr)
 		}
 		rep.CarriedForward = true
+		rep.CarriedByLink = linked
 		// Relative to the snapshot dir, matching what mergeBaselineIntoParquet
 		// sets for a table it writes: one field cannot mean two things, and
 		// consumers join it themselves (internal/cli/drill.go does).
 		rep.Files = []string{filepath.Join(schema, table+".parquet")}
 		rep.Duration = time.Since(start)
-		// CarriedForward is set unconditionally above and deliberately does NOT
-		// distinguish a link from a copy: it means "published by reuse rather
-		// than by folding", which is true either way, and it is what the
-		// unchanged verdict and the console's reused count are derived from.
-		// carryForward logs the link-versus-copy split itself, with the cause.
+		// CarriedForward stays "published by reuse rather than by folding",
+		// true for the copy arm too; the link-versus-copy split rides
+		// CarriedByLink (#1578) so the console's disk claim can count only
+		// the arm that saved disk. carryForward logs the cause of a copy.
 		slog.Info("table carried forward unchanged", "schema", schema, "table", table,
-			"reason", "no events in the window")
+			"reason", "no events in the window", "linked", linked)
 		return rep, nil
 	}
 

--- a/internal/reconstruct/parquet_snapshot_1169_integration_test.go
+++ b/internal/reconstruct/parquet_snapshot_1169_integration_test.go
@@ -436,6 +436,14 @@ func TestReconstructParquet_carriesForwardATableWithNoEvents(t *testing.T) {
 		t.Fatal("a table with no events in the window was folded and re-emitted; the rewrite it did not " +
 			"need is exactly the cost this avoids")
 	}
+	// One TempDir means one filesystem, so this reuse MUST be a hard link, and
+	// the report must say so: CarriedByLink is what the console's disk-saving
+	// claim counts (#1578), and the inode comparison below is what keeps this
+	// assertion honest rather than a copy of the code's own answer.
+	if !reports[0].CarriedByLink {
+		t.Error("a linked carry-forward reported CarriedByLink=false; the console would deny a disk " +
+			"saving the filesystem made")
+	}
 	if len(reports[0].Files) != 1 {
 		t.Fatalf("a carried-forward table published %d files, want 1", len(reports[0].Files))
 	}
@@ -457,6 +465,72 @@ func TestReconstructParquet_carriesForwardATableWithNoEvents(t *testing.T) {
 	dst := publishedUnder(t, root, reports[0].Files[0], src)
 	if a, b := carriedInode(t, src), carriedInode(t, dst); a != b {
 		t.Errorf("the carried file is a copy, not a link (inodes %d vs %d): the bytes were written again", a, b)
+	}
+}
+
+// The copy fallback through the REAL fold: same fixture as the test above with
+// the link primitive stubbed to fail, which is the only way the fold-level copy
+// arm ever executes on a one-filesystem test machine. The stake is the WIRING
+// in fulltable.go (`rep.CarriedByLink = linked`, not a constant): the unit test
+// on carryForward pins the function's answer, and without this test a hardcoded
+// `= true` at the call site would pass every tier while the console confirms a
+// disk saving for every copied reuse (#1578).
+func TestReconstructParquet_copiedCarryForwardReportsNoLink(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+
+	db, dbName := testutil.CreateTestDB(t)
+	if err := indexer.CreateIndexTables(ctx, db, 48, false, nil); err != nil {
+		t.Fatalf("CreateIndexTables: %v", err)
+	}
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	const schema = "shop"
+	base := time.Now().UTC().Truncate(time.Hour)
+	seedOrdersSnapshot(t, db, schema, base)
+
+	root := t.TempDir()
+	seedSourceBaseline(t, root, base, schema)
+
+	// A neighbour keeps the window covered, same as the link-arm test.
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200,
+		base.Add(time.Minute).Format("2006-01-02 15:04:05"), nil,
+		schema, "customers", 1, "1", nil, nil, []byte(`{"id":1,"name":"n"}`))
+
+	restore := reconstruct.StubLinkFileForTest(func(string, string) error { return syscall.EXDEV })
+	defer restore()
+
+	reports, err := reconstruct.ReconstructTables(ctx, reconstruct.FullTableConfig{
+		IndexDSN:              testutil.BaseDSN() + "/" + dbName,
+		BaselineSrc:           root,
+		Tables:                []string{schema + ".orders"},
+		At:                    base.Add(30 * time.Minute),
+		OutputDir:             root,
+		OutputFormat:          reconstruct.OutputFormatParquet,
+		CarryForwardUnchanged: true,
+	})
+	if err != nil {
+		t.Fatalf("ReconstructTables with links unavailable: %v", err)
+	}
+	if len(reports) != 1 {
+		t.Fatalf("got %d reports, want 1", len(reports))
+	}
+	// Still a reuse: the fold was skipped either way, and the copy arm is the
+	// designed fallback, not a failure.
+	if !reports[0].CarriedForward {
+		t.Fatal("the copy fallback stopped counting as a carry-forward; the fold ran for a table with no events")
+	}
+	if reports[0].CarriedByLink {
+		t.Error("a COPIED carry-forward reported CarriedByLink=true; the console would confirm a disk " +
+			"saving that never happened, which is the exact bug #1578 closes")
+	}
+	// The filesystem agrees: distinct inodes, so the report is measuring the
+	// publish, not echoing the setting.
+	src := filepath.Join(root, base.Format("2006-01-02T15-04-05Z"), schema, "orders.parquet")
+	dst := publishedUnder(t, root, reports[0].Files[0], src)
+	if a, b := carriedInode(t, src), carriedInode(t, dst); a == b {
+		t.Errorf("the stubbed link still shared an inode (%d): the stub never took, so this test pinned nothing", a)
 	}
 }
 


### PR DESCRIPTION
closes #1578

## Summary
- `carryForward` now reports **how** it published, not just whether: `linked` is true only when the destination shares the source's inode, which is the only arm that saves disk. The copy fallback is still a reuse (no fold ran) but writes every byte again.
- `TableReport.CarriedByLink` records the split at the fold; the consoleapp fold threads a `reuseTally{reused, copied}` through `foldOutcome`/`applyFoldStatus`/`recordRun` for both the refresh loop and point-in-time restore.
- New wire field `carried_copied` on `BaselineStatus`, `BaselineRunRecord` and the schedule run DTO (all `omitempty`, additive).
- The three Backups-page notes (automatic refresh, scheduled run, restore) qualify their reused counts: "(N of them written as full copies, which saves no disk; the daemon log says why)". Before this, the console confirmed a disk saving for runs whose daemon log said the opposite.
- The card comment that documented this exact residual is updated in the same change.

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] `go vet` and `go vet -tags integration` on touched packages
- [x] Guard red-checks: seven value mutations (link arm reporting false, copy arm reporting true, inverted `CarriedByLink` tally condition, zeroed `CarriedCopied` in `applyFoldStatus`, renamed wire tag, dropped `rf.carried_copied` read, hardcoded `rep.CarriedByLink` both ways at the fold call site) each fail exactly one new assertion; restored and re-greened.
- [x] Fold-level integration tests (Docker MySQL): existing carried-forward test now asserts `CarriedByLink=true`; new `TestReconstructParquet_copiedCarryForwardReportsNoLink` stubs the link primitive (test-only `StubLinkFileForTest` seam) to force the copy fallback through the real fold and asserts `CarriedForward && !CarriedByLink` with distinct inodes.
