### PR TITLE
MCP query: order argument (ASC/DESC), truncation warning names the kept end

### DIFF
--- a/cmd/bintrail-mcp/ceiling_test.go
+++ b/cmd/bintrail-mcp/ceiling_test.go
@@ -50,18 +50,33 @@ func TestQueryResultNotice(t *testing.T) {
 		}
 	})
 
-	// Under limit_per_pk the kept-end claim is false in BOTH directions (the
-	// per-PK cap's inner ordering is pinned DESC, so events fell off both
-	// ends); the notice must say that instead of naming an end.
-	t.Run("limit_per_pk suppresses the kept-end claim", func(t *testing.T) {
-		for _, order := range []string{"", "ASC", "DESC"} {
+	// Under limit_per_pk the cut depends on the direction. ASC (or empty):
+	// the outer limit cuts the newest end while the per-PK cap cuts old
+	// events per row, so both ends — naming a kept end would lie. DESC: the
+	// globally newest event is always bt_rn=1 in its own partition and row 0
+	// of the page, so the newest end is provably INTACT and the notice must
+	// keep saying so (claiming it was dropped is the same defect class).
+	t.Run("limit_per_pk states the double cut under ASC", func(t *testing.T) {
+		for _, order := range []string{"", "ASC"} {
 			got := queryResultNotice(false, 100, 1_000_000, 100, 100, 5, order)
 			if strings.Contains(got, "OLDEST") || strings.Contains(got, "NEWEST") {
-				t.Errorf("order=%q: a per-PK-capped truncation named a kept end: %q", order, got)
+				t.Errorf("order=%q: a per-PK-capped ASC truncation named a kept end: %q", order, got)
 			}
 			if !strings.Contains(got, "both ends") || !strings.Contains(got, "latest 5 events per row") {
 				t.Errorf("order=%q: the per-PK arm does not state the double cut: %q", order, got)
 			}
+		}
+	})
+	t.Run("limit_per_pk under DESC keeps the NEWEST claim and names the interior drop", func(t *testing.T) {
+		got := queryResultNotice(false, 100, 1_000_000, 100, 100, 5, "DESC")
+		if !strings.Contains(got, "NEWEST") {
+			t.Errorf("DESC + per-PK cap must still claim the newest end (it is provably intact): %q", got)
+		}
+		if strings.Contains(got, "both ends") {
+			t.Errorf("DESC + per-PK cap claimed a cut at the newest end that never happens: %q", got)
+		}
+		if !strings.Contains(got, "latest 5 events per row") || !strings.Contains(got, "inside the window") {
+			t.Errorf("DESC + per-PK cap does not name the interior drop: %q", got)
 		}
 	})
 

--- a/cmd/bintrail-mcp/ceiling_test.go
+++ b/cmd/bintrail-mcp/ceiling_test.go
@@ -9,7 +9,7 @@ func TestQueryResultNotice(t *testing.T) {
 	t.Run("ceiling supersedes the generic truncation notice", func(t *testing.T) {
 		// After a cap, n == limit (== ceiling), so the generic arm would also
 		// match; the ceiling message must win and must NOT say "increase the limit".
-		got := queryResultNotice(true, 5_000_000, 1_000_000, 1_000_000, 1_000_000)
+		got := queryResultNotice(true, 5_000_000, 1_000_000, 1_000_000, 1_000_000, "")
 		if !strings.Contains(got, "exceeds the MCP query ceiling") {
 			t.Errorf("want ceiling message, got %q", got)
 		}
@@ -22,7 +22,7 @@ func TestQueryResultNotice(t *testing.T) {
 	})
 
 	t.Run("generic truncation notice when not capped and full", func(t *testing.T) {
-		got := queryResultNotice(false, 100, 1_000_000, 100, 100)
+		got := queryResultNotice(false, 100, 1_000_000, 100, 100, "")
 		if !strings.Contains(got, "increase the limit") {
 			t.Errorf("want generic truncation notice, got %q", got)
 		}
@@ -31,8 +31,27 @@ func TestQueryResultNotice(t *testing.T) {
 		}
 	})
 
+	// The truncation notice names which END the trim kept (#1439): a client
+	// that asked for the last N must be able to tell whether the newest
+	// events survived the cut. Both directions asserted, and asserted
+	// disjoint, so swapping the arms cannot pass.
+	t.Run("truncation names the kept end per direction", func(t *testing.T) {
+		asc := queryResultNotice(false, 100, 1_000_000, 100, 100, "ASC")
+		if !strings.Contains(asc, "OLDEST") || strings.Contains(asc, "NEWEST") {
+			t.Errorf("ASC truncation must say it kept the OLDEST events: %q", asc)
+		}
+		empty := queryResultNotice(false, 100, 1_000_000, 100, 100, "")
+		if !strings.Contains(empty, "OLDEST") {
+			t.Errorf("the empty default is ASC and must say OLDEST: %q", empty)
+		}
+		desc := queryResultNotice(false, 100, 1_000_000, 100, 100, "desc")
+		if !strings.Contains(desc, "NEWEST") || strings.Contains(desc, "OLDEST") {
+			t.Errorf("DESC truncation (case-insensitive) must say it kept the NEWEST events: %q", desc)
+		}
+	})
+
 	t.Run("no notice below the limit", func(t *testing.T) {
-		if got := queryResultNotice(false, 100, 1_000_000, 42, 100); got != "" {
+		if got := queryResultNotice(false, 100, 1_000_000, 42, 100, "DESC"); got != "" {
 			t.Errorf("want empty notice for a partial result, got %q", got)
 		}
 	})

--- a/cmd/bintrail-mcp/ceiling_test.go
+++ b/cmd/bintrail-mcp/ceiling_test.go
@@ -9,7 +9,7 @@ func TestQueryResultNotice(t *testing.T) {
 	t.Run("ceiling supersedes the generic truncation notice", func(t *testing.T) {
 		// After a cap, n == limit (== ceiling), so the generic arm would also
 		// match; the ceiling message must win and must NOT say "increase the limit".
-		got := queryResultNotice(true, 5_000_000, 1_000_000, 1_000_000, 1_000_000, "")
+		got := queryResultNotice(true, 5_000_000, 1_000_000, 1_000_000, 1_000_000, 0, "")
 		if !strings.Contains(got, "exceeds the MCP query ceiling") {
 			t.Errorf("want ceiling message, got %q", got)
 		}
@@ -22,7 +22,7 @@ func TestQueryResultNotice(t *testing.T) {
 	})
 
 	t.Run("generic truncation notice when not capped and full", func(t *testing.T) {
-		got := queryResultNotice(false, 100, 1_000_000, 100, 100, "")
+		got := queryResultNotice(false, 100, 1_000_000, 100, 100, 0, "")
 		if !strings.Contains(got, "increase the limit") {
 			t.Errorf("want generic truncation notice, got %q", got)
 		}
@@ -36,22 +36,37 @@ func TestQueryResultNotice(t *testing.T) {
 	// events survived the cut. Both directions asserted, and asserted
 	// disjoint, so swapping the arms cannot pass.
 	t.Run("truncation names the kept end per direction", func(t *testing.T) {
-		asc := queryResultNotice(false, 100, 1_000_000, 100, 100, "ASC")
+		asc := queryResultNotice(false, 100, 1_000_000, 100, 100, 0, "ASC")
 		if !strings.Contains(asc, "OLDEST") || strings.Contains(asc, "NEWEST") {
 			t.Errorf("ASC truncation must say it kept the OLDEST events: %q", asc)
 		}
-		empty := queryResultNotice(false, 100, 1_000_000, 100, 100, "")
+		empty := queryResultNotice(false, 100, 1_000_000, 100, 100, 0, "")
 		if !strings.Contains(empty, "OLDEST") {
 			t.Errorf("the empty default is ASC and must say OLDEST: %q", empty)
 		}
-		desc := queryResultNotice(false, 100, 1_000_000, 100, 100, "desc")
+		desc := queryResultNotice(false, 100, 1_000_000, 100, 100, 0, "desc")
 		if !strings.Contains(desc, "NEWEST") || strings.Contains(desc, "OLDEST") {
 			t.Errorf("DESC truncation (case-insensitive) must say it kept the NEWEST events: %q", desc)
 		}
 	})
 
+	// Under limit_per_pk the kept-end claim is false in BOTH directions (the
+	// per-PK cap's inner ordering is pinned DESC, so events fell off both
+	// ends); the notice must say that instead of naming an end.
+	t.Run("limit_per_pk suppresses the kept-end claim", func(t *testing.T) {
+		for _, order := range []string{"", "ASC", "DESC"} {
+			got := queryResultNotice(false, 100, 1_000_000, 100, 100, 5, order)
+			if strings.Contains(got, "OLDEST") || strings.Contains(got, "NEWEST") {
+				t.Errorf("order=%q: a per-PK-capped truncation named a kept end: %q", order, got)
+			}
+			if !strings.Contains(got, "both ends") || !strings.Contains(got, "latest 5 events per row") {
+				t.Errorf("order=%q: the per-PK arm does not state the double cut: %q", order, got)
+			}
+		}
+	})
+
 	t.Run("no notice below the limit", func(t *testing.T) {
-		if got := queryResultNotice(false, 100, 1_000_000, 42, 100, "DESC"); got != "" {
+		if got := queryResultNotice(false, 100, 1_000_000, 42, 100, 0, "DESC"); got != "" {
 			t.Errorf("want empty notice for a partial result, got %q", got)
 		}
 	})

--- a/cmd/bintrail-mcp/integration_test.go
+++ b/cmd/bintrail-mcp/integration_test.go
@@ -255,6 +255,87 @@ func TestQueryTool_noResults(t *testing.T) {
 	}
 }
 
+// TestQueryTool_orderDescKeepsTheNewest is #1439's contract end to end: under
+// order=DESC a truncating limit keeps the NEWEST matching events, returned
+// newest-first, and the truncation warning names the end it kept. Three
+// events and limit 2, so the assertion discriminates: the ASC default would
+// answer with the two OLDEST (ids 1,2) and the warning would say OLDEST.
+func TestQueryTool_orderDescKeepsTheNewest(t *testing.T) {
+	db, _, dsn := setupTestDB(t)
+	ctx := context.Background()
+
+	for i, ts := range []string{"2026-02-19 10:00:00", "2026-02-19 10:01:00", "2026-02-19 10:02:00"} {
+		testutil.InsertEvent(t, db, "mysql-bin.000001", uint64(100*(i+1)), uint64(100*(i+2)), ts, nil,
+			"mydb", "orders", 1, fmt.Sprintf("%d", i+1), nil, nil,
+			[]byte(fmt.Sprintf(`{"id":%d}`, i+1)))
+	}
+
+	session := connectMCP(t)
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "query",
+		Arguments: map[string]any{
+			"index_dsn": dsn,
+			"schema":    "mydb",
+			"table":     "orders",
+			"format":    "json",
+			"order":     "DESC",
+			"limit":     2,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("tool error: %s", callToolText(t, result))
+	}
+	text := callToolText(t, result)
+
+	// The JSON body ends at the closing bracket; the warning is appended text.
+	end := strings.LastIndex(text, "]")
+	if end < 0 {
+		t.Fatalf("no JSON array in result: %s", text)
+	}
+	var rows []map[string]any
+	if err := json.Unmarshal([]byte(text[:end+1]), &rows); err != nil {
+		t.Fatalf("parse JSON: %v\ntext: %s", err, text)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+	if pk0, pk1 := rows[0]["pk_values"], rows[1]["pk_values"]; pk0 != "3" || pk1 != "2" {
+		t.Errorf("DESC page = pks %v,%v; want 3,2 (newest first, newest kept)", pk0, pk1)
+	}
+	if !strings.Contains(text, "NEWEST") {
+		t.Errorf("truncation warning does not name the kept end: %s", text)
+	}
+}
+
+// A typo must refuse, never silently answer ascending: OrderDirection treats
+// anything but DESC as ASC, so without the boundary check "descending" would
+// return the OLDEST rows to a client that asked for the newest.
+func TestQueryTool_invalidOrder(t *testing.T) {
+	_, _, dsn := setupTestDB(t)
+	ctx := context.Background()
+
+	session := connectMCP(t)
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "query",
+		Arguments: map[string]any{
+			"index_dsn": dsn,
+			"order":     "descending",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected IsError for invalid order, got: %s", callToolText(t, result))
+	}
+	if !strings.Contains(callToolText(t, result), "must be ASC or DESC") {
+		t.Errorf("refusal does not name the valid values: %s", callToolText(t, result))
+	}
+}
+
 func TestQueryTool_invalidFormat(t *testing.T) {
 	_, _, dsn := setupTestDB(t)
 	ctx := context.Background()

--- a/cmd/bintrail-mcp/main.go
+++ b/cmd/bintrail-mcp/main.go
@@ -349,8 +349,8 @@ func applyQueryCeiling(limit, max int) (int, bool) {
 	return mcptools.ApplyQueryCeiling(limit, max)
 }
 
-func queryResultNotice(ceilingApplied bool, requestedLimit, ceiling, n, limit int) string {
-	return mcptools.QueryResultNotice(ceilingApplied, requestedLimit, ceiling, n, limit)
+func queryResultNotice(ceilingApplied bool, requestedLimit, ceiling, n, limit int, order string) string {
+	return mcptools.QueryResultNotice(ceilingApplied, requestedLimit, ceiling, n, limit, order)
 }
 
 func buildQueryOptions(p mcptools.FilterParams, defaultLimit int) (query.Options, error) {

--- a/cmd/bintrail-mcp/main.go
+++ b/cmd/bintrail-mcp/main.go
@@ -349,8 +349,8 @@ func applyQueryCeiling(limit, max int) (int, bool) {
 	return mcptools.ApplyQueryCeiling(limit, max)
 }
 
-func queryResultNotice(ceilingApplied bool, requestedLimit, ceiling, n, limit int, order string) string {
-	return mcptools.QueryResultNotice(ceilingApplied, requestedLimit, ceiling, n, limit, order)
+func queryResultNotice(ceilingApplied bool, requestedLimit, ceiling, n, limit, limitPerPK int, order string) string {
+	return mcptools.QueryResultNotice(ceilingApplied, requestedLimit, ceiling, n, limit, limitPerPK, order)
 }
 
 func buildQueryOptions(p mcptools.FilterParams, defaultLimit int) (query.Options, error) {

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -248,7 +248,11 @@ both accept:
   keep: pair it with `since`/`until`. See
   [Primary key ranges](query-and-recovery.md#primary-key-ranges---pk-min----pk-max)
 - `limit_per_pk` — cap events per `pk_values` to the latest N (0 = unlimited);
-  requires `pk` or `pks`
+  requires `pk` or `pks`. The cap always keeps each row's *latest* N whatever
+  `order` says, so with it active a truncated `ASC` answer loses events at
+  both ends of the window (the warning says so instead of naming a kept end);
+  under `DESC` the newest events are still intact and older ones drop from
+  inside the window
 - `column_eq` — repeatable `column=value` equality filters
 - `flag` — table/column flag filter
 - `profile` — RBAC table-deny + column-redaction

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -274,9 +274,14 @@ The `pk` parameter takes the stored `pk_values` spelling — for a binary PK
 whose bytes are not valid UTF-8 that is `0x` + uppercase hex, see
 [Binary primary keys](query-and-recovery.md#binary-primary-keys-the-0x-hex-spelling).
 
-`query` additionally takes `format` (`json`, `table`, or `csv`). Time values
-(`since` / `until`) accept MySQL datetime (`2006-01-02 15:04:05`), RFC 3339, or
-date-only (`2006-01-02`) — the same formats as the CLI.
+`query` additionally takes `format` (`json`, `table`, or `csv`) and `order`
+(`ASC`, the default, or `DESC`). The direction decides which end a truncating
+`limit` keeps: `ASC` returns oldest-first and keeps the **oldest** matching
+events, `DESC` returns newest-first and keeps the **newest** — so "the last N
+events" is `order: DESC` with `limit: N`, no `since` guessing required, and
+the truncation warning names the end it kept. Time values (`since` / `until`)
+accept MySQL datetime (`2006-01-02 15:04:05`), RFC 3339, or date-only
+(`2006-01-02`) — the same formats as the CLI.
 
 **Query row ceiling ([#654](https://github.com/dbtrail/dbtrail/issues/654)).** The
 `query` tool caps an explicit `limit` at a hard ceiling (default **1,000,000

--- a/internal/cli/query.go
+++ b/internal/cli/query.go
@@ -430,7 +430,7 @@ func runQuery(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(os.Stderr, "\n%d row(s)\n", n)
 		}
 		if n >= qLimit {
-			fmt.Fprintf(os.Stderr, "Warning: results truncated at %d rows. Use a narrower time range or --limit to adjust.\n", qLimit)
+			fmt.Fprintf(os.Stderr, "Warning: results truncated at %d rows, keeping the %s matching events. Use a narrower time range or --limit to adjust.\n", qLimit, truncationKeptEnd(qOrder))
 		}
 		return nil
 	}
@@ -512,7 +512,7 @@ func runQuery(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "\n%d row(s)\n", n)
 	}
 	if n >= qLimit {
-		fmt.Fprintf(os.Stderr, "Warning: results truncated at %d rows. Use a narrower time range or --limit to adjust.\n", qLimit)
+		fmt.Fprintf(os.Stderr, "Warning: results truncated at %d rows, keeping the %s matching events. Use a narrower time range or --limit to adjust.\n", qLimit, truncationKeptEnd(qOrder))
 	}
 	// An empty digest-filtered result means one of two opposite things. Probe
 	// only here — after the answer came back empty — so the cost lands on the
@@ -586,6 +586,17 @@ func runQuery(cmd *cobra.Command, args []string) error {
 // tests drive the real loop body with a fake fetcher — no DuckDB, no real
 // database, and the exact same code path that production hits. Similarly
 // stderr is an io.Writer so tests capture into a bytes.Buffer without
+// truncationKeptEnd names which end of the matched window a truncating
+// --limit kept, for the stderr warning (#1439): under DESC the newest events
+// survive the cut, under ASC (or the empty default) the oldest do, and
+// "truncated" alone left the reader unable to tell which.
+func truncationKeptEnd(order string) string {
+	if query.OrderDirection(order) == "DESC" {
+		return "NEWEST"
+	}
+	return "OLDEST"
+}
+
 // touching os.Stderr.
 //
 // Stderr messages are sanitized against every line-terminator character via

--- a/internal/cli/query.go
+++ b/internal/cli/query.go
@@ -545,6 +545,15 @@ func runQuery(cmd *cobra.Command, args []string) error {
 // off both ends), so that shape says so instead.
 func truncationWarn(limit, limitPerPK int, order string) {
 	if limitPerPK > 0 {
+		// Same direction split as the MCP notice: under DESC the newest end
+		// is provably intact (the cap's inner ordering is itself DESC), so
+		// "both ends" would be false there.
+		if query.OrderDirection(order) == "DESC" {
+			fmt.Fprintf(os.Stderr, "Warning: results truncated at %d rows, keeping the NEWEST matching events, "+
+				"and --limit-per-pk kept only the latest %d events per row, so older events were dropped from "+
+				"inside the window as well. Use a narrower time range or --limit to adjust.\n", limit, limitPerPK)
+			return
+		}
 		fmt.Fprintf(os.Stderr, "Warning: results truncated at %d rows, and --limit-per-pk kept only the latest %d "+
 			"events per row, so events were dropped at both ends of the window. Use a narrower time range or --limit to adjust.\n",
 			limit, limitPerPK)

--- a/internal/cli/query.go
+++ b/internal/cli/query.go
@@ -430,7 +430,7 @@ func runQuery(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(os.Stderr, "\n%d row(s)\n", n)
 		}
 		if n >= qLimit {
-			fmt.Fprintf(os.Stderr, "Warning: results truncated at %d rows, keeping the %s matching events. Use a narrower time range or --limit to adjust.\n", qLimit, truncationKeptEnd(qOrder))
+			truncationWarn(qLimit, qLimitPerPK, qOrder)
 		}
 		return nil
 	}
@@ -512,7 +512,7 @@ func runQuery(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "\n%d row(s)\n", n)
 	}
 	if n >= qLimit {
-		fmt.Fprintf(os.Stderr, "Warning: results truncated at %d rows, keeping the %s matching events. Use a narrower time range or --limit to adjust.\n", qLimit, truncationKeptEnd(qOrder))
+		truncationWarn(qLimit, qLimitPerPK, qOrder)
 	}
 	// An empty digest-filtered result means one of two opposite things. Probe
 	// only here — after the answer came back empty — so the cost lands on the
@@ -534,6 +534,28 @@ func runQuery(cmd *cobra.Command, args []string) error {
 		}
 	}
 	return nil
+}
+
+// truncationWarn prints the stderr warning for a result cut by --limit,
+// naming which end of the matched window survived (#1439): under DESC the
+// newest events, under ASC (or the empty default) the oldest — "truncated"
+// alone left the reader unable to tell which. Under --limit-per-pk the claim
+// is false in BOTH directions (the per-PK cap's inner ordering is pinned
+// DESC, so the result is a slice of a per-PK-newest subset and events fell
+// off both ends), so that shape says so instead.
+func truncationWarn(limit, limitPerPK int, order string) {
+	if limitPerPK > 0 {
+		fmt.Fprintf(os.Stderr, "Warning: results truncated at %d rows, and --limit-per-pk kept only the latest %d "+
+			"events per row, so events were dropped at both ends of the window. Use a narrower time range or --limit to adjust.\n",
+			limit, limitPerPK)
+		return
+	}
+	kept := "OLDEST"
+	if query.OrderDirection(order) == "DESC" {
+		kept = "NEWEST"
+	}
+	fmt.Fprintf(os.Stderr, "Warning: results truncated at %d rows, keeping the %s matching events. "+
+		"Use a narrower time range or --limit to adjust.\n", limit, kept)
 }
 
 // queryArchiveSources is the single choke point for issue #203: it fetches
@@ -586,17 +608,6 @@ func runQuery(cmd *cobra.Command, args []string) error {
 // tests drive the real loop body with a fake fetcher — no DuckDB, no real
 // database, and the exact same code path that production hits. Similarly
 // stderr is an io.Writer so tests capture into a bytes.Buffer without
-// truncationKeptEnd names which end of the matched window a truncating
-// --limit kept, for the stderr warning (#1439): under DESC the newest events
-// survive the cut, under ASC (or the empty default) the oldest do, and
-// "truncated" alone left the reader unable to tell which.
-func truncationKeptEnd(order string) string {
-	if query.OrderDirection(order) == "DESC" {
-		return "NEWEST"
-	}
-	return "OLDEST"
-}
-
 // touching os.Stderr.
 //
 // Stderr messages are sanitized against every line-terminator character via

--- a/internal/mcptools/mcptools.go
+++ b/internal/mcptools/mcptools.go
@@ -1314,10 +1314,20 @@ func QueryResultNotice(ceilingApplied bool, requestedLimit, ceiling, n, limit, l
 		return fmt.Sprintf("\nWarning: requested limit %d exceeds the MCP query ceiling of %d rows; capped to %d. "+
 			"Narrow your filters/time range, or run the `bintrail query` CLI for an unbounded export.\n", requestedLimit, ceiling, ceiling)
 	case n >= limit && limitPerPK > 0:
-		// Under a per-PK cap the "kept end" claim is false in BOTH
-		// directions: the cap's inner ordering is pinned DESC (latest N per
-		// pk_values, whatever the final direction), so the returned rows are
-		// a slice of a per-PK-newest subset and events fell off both ends.
+		// The per-PK cap's inner ordering is pinned DESC (latest N per
+		// pk_values, whatever the final direction), so what the cap can drop
+		// depends on the outer direction. Under DESC the globally newest
+		// event is always bt_rn=1 in its own partition and row 0 of the
+		// page — the newest end is provably intact, and claiming it was
+		// dropped is the same defect class this notice exists to remove.
+		// Under ASC (or empty) the outer limit cuts the newest end while the
+		// cap cuts old events per row: both ends.
+		if query.OrderDirection(order) == "DESC" {
+			return fmt.Sprintf("\nWarning: results truncated at %d rows, keeping the NEWEST matching events, "+
+				"and limit_per_pk kept only the latest %d events per row, so older events were dropped from "+
+				"inside the window as well. Use a narrower since/until range or increase the limit to see more.\n",
+				limit, limitPerPK)
+		}
 		return fmt.Sprintf("\nWarning: results truncated at %d rows, and limit_per_pk kept only the latest %d "+
 			"events per row, so events were dropped at both ends of the window. "+
 			"Use a narrower since/until range or increase the limit to see more.\n", limit, limitPerPK)

--- a/internal/mcptools/mcptools.go
+++ b/internal/mcptools/mcptools.go
@@ -740,7 +740,7 @@ func MakeQueryTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Query
 		if n > 0 && format != "json" {
 			text += fmt.Sprintf("\n%d row(s)\n", n)
 		}
-		text += QueryResultNotice(ceilingApplied, requestedLimit, ceiling, n, opts.Limit, opts.Order)
+		text += QueryResultNotice(ceilingApplied, requestedLimit, ceiling, n, opts.Limit, opts.LimitPerPK, opts.Order)
 		text += ArchiveSkipNotice(discoveryFailed, skippedArchives)
 		text += EventDivergenceNotice(divergedEvents)
 		if misfiledScanFailed {
@@ -982,7 +982,9 @@ func MakeRecoverTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Rec
 			text += fmt.Sprintf("\n-- %d reversal statement(s) generated.\n", n)
 		}
 		if n >= opts.Limit {
-			text += fmt.Sprintf("\n-- Warning: results truncated at %d rows. Use a narrower since/until range or increase the limit to see more.\n", opts.Limit)
+			// The fetch ran Order=DESC (#785/#927), so the cut kept the newest
+			// events — say so, matching the CLI recover warning (#1439).
+			text += fmt.Sprintf("\n-- Warning: results truncated at %d rows; only the most recent events of the window are reversed. Use a narrower since/until range or increase the limit to see more.\n", opts.Limit)
 		}
 		if divergedEvents > 0 {
 			// SQL-comment form so the warning survives inside the script text an
@@ -1184,7 +1186,9 @@ func MakeSchemaChangesTool(cfg Config) func(context.Context, *mcp.CallToolReques
 			text = "No schema changes found."
 		}
 		if n >= limit {
-			text += fmt.Sprintf("\nWarning: results truncated at %d rows. Use a narrower since/until range or increase the limit to see more.", limit)
+			// Results come back newest-first, so the cut kept the newest
+			// changes (#1439).
+			text += fmt.Sprintf("\nWarning: results truncated at %d rows, keeping the NEWEST changes; older ones were dropped. Use a narrower since/until range or increase the limit to see more.", limit)
 		}
 
 		return &mcp.CallToolResult{
@@ -1304,11 +1308,19 @@ func ApplyQueryCeiling(limit, max int) (int, bool) {
 // telling an agent to "increase the limit" would be wrong, since the limit it
 // asked for is exactly the one that was capped (and after a cap n == limit makes
 // the generic arm true too, so order matters). Returns "" when no notice applies.
-func QueryResultNotice(ceilingApplied bool, requestedLimit, ceiling, n, limit int, order string) string {
+func QueryResultNotice(ceilingApplied bool, requestedLimit, ceiling, n, limit, limitPerPK int, order string) string {
 	switch {
 	case ceilingApplied:
 		return fmt.Sprintf("\nWarning: requested limit %d exceeds the MCP query ceiling of %d rows; capped to %d. "+
 			"Narrow your filters/time range, or run the `bintrail query` CLI for an unbounded export.\n", requestedLimit, ceiling, ceiling)
+	case n >= limit && limitPerPK > 0:
+		// Under a per-PK cap the "kept end" claim is false in BOTH
+		// directions: the cap's inner ordering is pinned DESC (latest N per
+		// pk_values, whatever the final direction), so the returned rows are
+		// a slice of a per-PK-newest subset and events fell off both ends.
+		return fmt.Sprintf("\nWarning: results truncated at %d rows, and limit_per_pk kept only the latest %d "+
+			"events per row, so events were dropped at both ends of the window. "+
+			"Use a narrower since/until range or increase the limit to see more.\n", limit, limitPerPK)
 	case n >= limit:
 		// The direction names which END the trim kept (#1439): "truncated"
 		// alone left a client that asked for the last N unable to tell

--- a/internal/mcptools/mcptools.go
+++ b/internal/mcptools/mcptools.go
@@ -473,6 +473,7 @@ type QueryArgs struct {
 	Flag          string   `json:"flag,omitempty" jsonschema:"Filter events from tables or columns carrying this flag"`
 	Format        string   `json:"format,omitempty" jsonschema:"Output format: json table or csv (default: json)"`
 	Limit         int      `json:"limit,omitempty" jsonschema:"Maximum number of events to return (default: 100)"`
+	Order         string   `json:"order,omitempty" jsonschema:"Sort direction: ASC (default) or DESC. Under ASC results return oldest-first and a truncating limit keeps the OLDEST matching events; under DESC newest-first and limit keeps the NEWEST. For 'the last N events' use DESC with limit N instead of guessing a since window."`
 	Profile       string   `json:"profile,omitempty" jsonschema:"Apply RBAC access rules for this profile (table-level deny and column-level redaction)"`
 	NoArchive     bool     `json:"no_archive,omitempty" jsonschema:"Disable auto-routing to Parquet archives (MySQL-only results)"`
 }
@@ -613,6 +614,18 @@ func MakeQueryTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Query
 		}
 		opts.QueryHash = queryHash
 
+		// Order is set after BuildQueryOptions for the same reason as
+		// query_hash: the recover tool shares that builder and pins its own
+		// Order=DESC (#785/#927 — a truncated reversal must keep the newest
+		// events), so the parameter must not exist there. Validated at the
+		// boundary because OrderDirection treats garbage as ASC: a client
+		// typo like "descending" would silently answer with the oldest rows,
+		// the exact wrong end for the question DESC exists to ask (#1439).
+		if args.Order != "" && !strings.EqualFold(args.Order, "ASC") && !strings.EqualFold(args.Order, "DESC") {
+			return ErrorResult(fmt.Errorf("invalid order %q; must be ASC or DESC", args.Order)), nil, nil
+		}
+		opts.Order = args.Order
+
 		// Hard ceiling on an explicit, oversized limit (#654). BuildQueryOptions
 		// already coerces limit<=0 to the default, so this only bounds a large
 		// EXPLICIT value an agent might pass. It is applied here, per-tool, on the
@@ -727,7 +740,7 @@ func MakeQueryTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Query
 		if n > 0 && format != "json" {
 			text += fmt.Sprintf("\n%d row(s)\n", n)
 		}
-		text += QueryResultNotice(ceilingApplied, requestedLimit, ceiling, n, opts.Limit)
+		text += QueryResultNotice(ceilingApplied, requestedLimit, ceiling, n, opts.Limit, opts.Order)
 		text += ArchiveSkipNotice(discoveryFailed, skippedArchives)
 		text += EventDivergenceNotice(divergedEvents)
 		if misfiledScanFailed {
@@ -1291,13 +1304,21 @@ func ApplyQueryCeiling(limit, max int) (int, bool) {
 // telling an agent to "increase the limit" would be wrong, since the limit it
 // asked for is exactly the one that was capped (and after a cap n == limit makes
 // the generic arm true too, so order matters). Returns "" when no notice applies.
-func QueryResultNotice(ceilingApplied bool, requestedLimit, ceiling, n, limit int) string {
+func QueryResultNotice(ceilingApplied bool, requestedLimit, ceiling, n, limit int, order string) string {
 	switch {
 	case ceilingApplied:
 		return fmt.Sprintf("\nWarning: requested limit %d exceeds the MCP query ceiling of %d rows; capped to %d. "+
 			"Narrow your filters/time range, or run the `bintrail query` CLI for an unbounded export.\n", requestedLimit, ceiling, ceiling)
 	case n >= limit:
-		return fmt.Sprintf("\nWarning: results truncated at %d rows. Use a narrower since/until range or increase the limit to see more.\n", limit)
+		// The direction names which END the trim kept (#1439): "truncated"
+		// alone left a client that asked for the last N unable to tell
+		// whether the newest events survived the cut or fell off it.
+		kept, dropped := "OLDEST", "newer"
+		if query.OrderDirection(order) == "DESC" {
+			kept, dropped = "NEWEST", "older"
+		}
+		return fmt.Sprintf("\nWarning: results truncated at %d rows, keeping the %s matching events; %s ones were dropped. "+
+			"Use a narrower since/until range or increase the limit to see more.\n", limit, kept, dropped)
 	}
 	return ""
 }

--- a/internal/mcptools/paramsync_test.go
+++ b/internal/mcptools/paramsync_test.go
@@ -44,7 +44,6 @@ var recoverCLIOnly = map[string]string{
 
 // queryCLIOnly is the same ledger for `bintrail query` vs the MCP query tool.
 var queryCLIOnly = map[string]string{
-	"order":               "sort-direction of the returned page (#1511); the MCP tool keeps the pre-#1511 ascending default",
 	"archive-dir":         "explicit archive source override; the MCP surface uses env config + archive_state auto-discovery",
 	"archive-s3":          "explicit archive source override; the MCP surface uses env config + archive_state auto-discovery",
 	"bintrail-id":         "companion to the explicit archive source flags above",


### PR DESCRIPTION
closes #1439

## Summary
- `query` MCP tool gains `order` (`ASC` default / `DESC`), mapped onto the engine's existing `Options.Order` after `BuildQueryOptions` (the `query_hash` pattern: the recover tool shares the builder and pins its own internal `Order=DESC`, so the parameter must not exist there).
- Validated at the boundary: `OrderDirection` treats anything but DESC as ASC, so a typo like `"descending"` would silently answer with the oldest rows — the exact wrong end. It refuses with `must be ASC or DESC`.
- The truncation warning names which end the trim kept (`keeping the NEWEST/OLDEST matching events`), on the MCP notice and on the CLI `query` warning (`--order` landed in #1511 without it).
- The `paramsync` CLI-only ledger entry for `order` is removed, so the parity test enforces the CLI↔MCP mapping structurally from now on.
- `docs/mcp-server.md` documents the argument and the limit interaction.

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`); `go vet` both tag sets
- [x] Integration: `TestQueryTool_orderDescKeepsTheNewest` (3 events, limit 2, DESC → pks 3,2 newest-first + NEWEST in the warning), `TestQueryTool_invalidOrder`
- [x] Guard red-checks: zeroing the `opts.Order` threading, deleting the validation, and swapping the notice's direction arm each fail exactly one test; restored and re-greened
