### PR TITLE
doctor: statement-capture remediation states it is not retroactive

### DIFF
--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -594,7 +594,8 @@ func checkStatementCapture(ctx context.Context, db *sql.DB) CheckResult {
 			Status: StatusWarn,
 			Detail: "binlog_rows_query_log_events=OFF — events index without the originating SQL statement (query_text stays NULL)",
 			Remediation: "Optional: log the original statement with each row event so `bintrail query` can show it (dynamic, no restart; costs binlog bytes per statement):\n\n" +
-				"  SET PERSIST binlog_rows_query_log_events = ON;",
+				"  SET PERSIST binlog_rows_query_log_events = ON;\n\n" +
+				"Not retroactive: only events written AFTER the change carry text, so `query --query-hash` still matches nothing in the window before it (#1437).",
 		}
 	}
 	if !isUnknownVar(err) {
@@ -623,7 +624,8 @@ func checkStatementCapture(ctx context.Context, db *sql.DB) CheckResult {
 			Detail: "binlog_annotate_row_events=OFF — events index without the originating SQL statement (query_text stays NULL)",
 			Remediation: "Optional: log the original statement with each row event so `bintrail query` can show it (stream capture also needs `--source-flavor mariadb`):\n\n" +
 				"  SET GLOBAL binlog_annotate_row_events = ON;\n\n" +
-				"Persist it in my.cnf ([mysqld] binlog_annotate_row_events=ON) to survive restarts.",
+				"Persist it in my.cnf ([mysqld] binlog_annotate_row_events=ON) to survive restarts. " +
+				"Not retroactive: only events written AFTER the change carry text (#1437).",
 		}
 	}
 	if !isUnknownVar(err) {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -674,6 +674,12 @@ func TestCheckStatementCapture(t *testing.T) {
 			if tt.wantRemediation && got.Remediation == "" {
 				t.Error("expected remediation but got none")
 			}
+			// Enabling is NOT retroactive (#1437): only events written after
+			// the change carry text, so a remediation that omits this sends
+			// the operator to re-query a window that can never match.
+			if tt.wantRemediation && !strings.Contains(got.Remediation, "Not retroactive") {
+				t.Errorf("Remediation = %q, missing the non-retroactivity caveat", got.Remediation)
+			}
 			if got.Status == StatusFail {
 				t.Error("statement capture is optional — the check must never FAIL")
 			}


### PR DESCRIPTION
closes #1437

## Summary
Nearly all of #1437 already existed: `checkStatementCapture` landed with the forensics work (#712) — it probes the SOURCE's `binlog_rows_query_log_events` (MariaDB `binlog_annotate_row_events` fallback via the error-1193 pattern), WARNs and never FAILs, remediates with `SET PERSIST` (dynamic, no restart), PASSes when ON, SKIPs when neither variable exists, is wired into `doctor`'s `Build`, and is pinned by a seven-case grid test.

The one ask it did not cover: the remediation never said enabling is **not retroactive**. An operator who flips the variable and re-runs `query --query-hash` over the same window still matches nothing, with nothing anywhere explaining why. Both flavor arms now carry the caveat, and the grid test requires it on every WARN arm.

## Test plan
- [x] `go test ./internal/doctor/` green; grid test extended (`Not retroactive` required whenever a remediation is expected)
- [x] Red check: removing the caveat from the MySQL arm fails the grid test; restored and re-greened
