### PR TITLE
parser: resolve unqualified DDL against the session default database

### DIFF
--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -6896,9 +6896,10 @@ function buildSchemaChangeRows(container, changes, filtered, withheld) {
     // on click, so a long ALTER does not push the next row off screen.
     const row = el("div", { class: "sc-row", "data-sc": i, tabindex: "0", role: "button", "aria-expanded": "false" });
     row.append(tsSpan("ev-time", c.detected_at));
-    // The schema comes from the statement text; an unqualified statement
-    // (USE app; ALTER TABLE users ...) records none, so show the table alone
-    // rather than ".users".
+    // Rows indexed before #1435 recorded unqualified DDL with no schema
+    // (new rows carry the session default), so the bare-table rendering and
+    // its tooltip are the historical-row path; show the table alone rather
+    // than ".users".
     row.append(el("span", { class: "ev-table", text: c.schema_name ? c.schema_name + "." + c.table_name : c.table_name,
       title: c.schema_name ? null : "Schema not recorded: the statement did not name it" }));
     row.append(el("span", {}, scBadge(c.ddl_type)));

--- a/internal/console/schema_changes_api.go
+++ b/internal/console/schema_changes_api.go
@@ -160,14 +160,17 @@ func buildSchemaChangesQuery(f schemaChangesFilter) (string, []any) {
 	// (case-insensitive there withholds MORE, the safe direction). Deny
 	// composes over allow via AND, so deny always wins.
 	//
-	// One thing binlog_events never has: schema_name can be EMPTY here. The
-	// parser derives it from the statement text alone, so `USE app; TRUNCATE
-	// TABLE secrets` is stored with schema_name = '' (the session's default
-	// database is not recorded). A deny keyed on the pair would let that row
-	// through, so the deny also withholds an unqualified row whose TABLE
-	// matches: it may be the denied table, and the safe direction is to
-	// withhold. The allow list already excludes such rows (BINARY '' never
-	// matches a named schema).
+	// One thing binlog_events never has: schema_name can be EMPTY here — on
+	// rows indexed before #1435, which recorded unqualified DDL (`USE app;
+	// TRUNCATE TABLE secrets`) with no schema. New rows carry the session's
+	// default database, so under an allow-list profile an unqualified DDL
+	// row goes from invisible-to-everyone to visible-to-users-allowed on
+	// that schema+table — the correct attribution, not a widening. The
+	// empty-row handling stays for the historical rows: a deny keyed on the
+	// pair would let them through, so the deny also withholds an unqualified
+	// row whose TABLE matches (it may be the denied table, and the safe
+	// direction is to withhold), and the allow list already excludes them
+	// (BINARY '' never matches a named schema).
 	if len(f.Allow) > 0 {
 		ors := make([]string, len(f.Allow))
 		for i, at := range f.Allow {

--- a/internal/console/schema_changes_api_integration_test.go
+++ b/internal/console/schema_changes_api_integration_test.go
@@ -30,9 +30,10 @@ func seedSchemaChanges(t *testing.T) *Server {
 			(detected_at, binlog_file, binlog_pos, schema_name, table_name, ddl_type, ddl_query)
 			VALUES (?, ?, ?, ?, ?, ?, ?)`, at, file, pos, schema, table, ddlType, stmt)
 	}
-	// Unqualified DDL: the parser derives schema_name from the statement
-	// text alone, so `USE app; TRUNCATE TABLE secrets` lands with an EMPTY
-	// schema. A deny on app.secrets has to withhold it too.
+	// A pre-#1435 unqualified-DDL row: those landed with an EMPTY schema
+	// (new rows carry the session default; this fixture INSERTs directly,
+	// standing in for the historical shape). A deny on app.secrets has to
+	// withhold it too.
 	insert("2026-06-01 11:59:00", "bin.000001", 800, "", "secrets", "TRUNCATE TABLE", "TRUNCATE TABLE secrets")
 	insert("2026-06-01 12:00:00", "bin.000001", 900, "app", "users", "CREATE TABLE", "CREATE TABLE users (id INT PRIMARY KEY)")
 	insert("2026-06-01 12:00:05", "bin.000001", 200, "app", "users", "ALTER TABLE", "ALTER TABLE users ADD COLUMN email VARCHAR(255)")

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -252,7 +252,7 @@ func (p *Parser) ParseFile(ctx context.Context, filename string, events chan<- E
 			// is stale. The statement's own ROWS_QUERY_EVENT arrives AFTER this.
 			currentQueryText = ""
 			ts := time.Unix(int64(binlogEv.Header.Timestamp), 0).UTC()
-			if ddlEv, ok := parseDDL(p.logger, filename, binlogEv.Header.LogPos, ts, currentGTID, string(ev.Query), p.schemaVersion.Load()); ok {
+			if ddlEv, ok := parseDDL(p.logger, filename, binlogEv.Header.LogPos, ts, currentGTID, string(ev.Query), string(ev.Schema), p.schemaVersion.Load()); ok {
 				if err := em.send(ctx, ddlEv); err != nil {
 					return err
 				}
@@ -1117,7 +1117,17 @@ func isSQLSpace(b byte) bool {
 // Returns zero Event and false if the query is not a DDL statement.
 // TRUNCATE is included for audit purposes but does not invalidate the snapshot
 // (callers should skip auto-snapshot for DDLTruncateTable).
-func parseDDL(logger *slog.Logger, filename string, logPos uint32, timestamp time.Time, gtid, queryStr string, schemaVersion uint32) (Event, bool) {
+//
+// defaultSchema is the QUERY_EVENT's session default database (#1435): the
+// unqualified form (`USE wordpress; TRUNCATE TABLE t`) is what people and
+// ORMs actually type, and recording it with an empty schema_name made most
+// DDL rows unfindable by the schema filter. A schema qualified in the
+// statement always wins — the fallback is exactly the database MySQL itself
+// resolved the unqualified name against. It can be empty (a client with no
+// default database running qualified DDL); then schema_name stays empty, as
+// before. Historical rows are NOT backfilled: the original session's default
+// is unrecoverable, and matching empty rows against any filter would lie.
+func parseDDL(logger *slog.Logger, filename string, logPos uint32, timestamp time.Time, gtid, queryStr, defaultSchema string, schemaVersion uint32) (Event, bool) {
 	upper := strings.ToUpper(strings.TrimSpace(queryStr))
 
 	var ddlType DDLKind
@@ -1150,6 +1160,9 @@ func parseDDL(logger *slog.Logger, filename string, logPos uint32, timestamp tim
 		case m[6] != "": // table (unquoted, no schema)
 			table = m[6]
 		}
+	}
+	if schema == "" {
+		schema = defaultSchema
 	}
 
 	startPos := uint64(0) // DDL events have no row-level start position

--- a/internal/parser/parser_integration_test.go
+++ b/internal/parser/parser_integration_test.go
@@ -208,6 +208,64 @@ func TestParseFile_realBinlog(t *testing.T) {
 	}
 }
 
+// TestParseFile_unqualifiedDDLTakesTheSessionDefaultSchema pins the #1435
+// wiring at the FILE-path call site against a real binlog: MustExec's
+// connection has the test schema as its default database, so the unqualified
+// TRUNCATE below is exactly the `USE db; TRUNCATE TABLE t` shape — the
+// QUERY_EVENT carries the default in ev.Schema and the statement does not.
+// Replace the call site's string(ev.Schema) with "" and only this notices
+// (the stream sibling has its own unit pin).
+func TestParseFile_unqualifiedDDLTakesTheSessionDefaultSchema(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+
+	sourceDB, sourceName := testutil.CreateTestDB(t)
+	testutil.MustExec(t, sourceDB, "CREATE TABLE dbt_burst_referrers (id INT PRIMARY KEY)")
+	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
+	currentBinlog, _, err := config.CurrentBinlogPosition(sourceDB)
+	if err != nil {
+		t.Fatalf("CurrentBinlogPosition: %v", err)
+	}
+	testutil.MustExec(t, sourceDB, "TRUNCATE TABLE dbt_burst_referrers")
+	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
+
+	tmpDir := t.TempDir()
+	cpCmd := exec.Command("docker", "cp",
+		fmt.Sprintf("bintrail-test-mysql:/var/lib/mysql/%s", currentBinlog),
+		filepath.Join(tmpDir, currentBinlog))
+	if out, err := cpCmd.CombinedOutput(); err != nil {
+		t.Fatalf("docker cp %s failed: %v\n%s", currentBinlog, err, out)
+	}
+
+	p := parser.New(tmpDir, nil, parser.Filters{Schemas: map[string]bool{sourceName: true}}, nil)
+	events := make(chan parser.Event, 100)
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(events)
+		errCh <- p.ParseFile(context.Background(), currentBinlog, events)
+	}()
+	all := drainEvents(events)
+	if err := <-errCh; err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+
+	// The shared container's window may hold other packages' DDL; find OURS
+	// by table (unique enough for this fixture) rather than counting.
+	var found bool
+	for _, ev := range all {
+		if ev.EventType != parser.EventDDL || ev.Table != "dbt_burst_referrers" {
+			continue
+		}
+		found = true
+		if ev.Schema != sourceName {
+			t.Errorf("unqualified TRUNCATE recorded schema %q, want the session default %q (#1435): "+
+				"the row would be unfindable by the schema filter", ev.Schema, sourceName)
+		}
+	}
+	if !found {
+		t.Fatal("the TRUNCATE's EventDDL never arrived; the fixture proved nothing")
+	}
+}
+
 func TestParseFile_withFilters(t *testing.T) {
 	testutil.SkipIfNoMySQL(t)
 

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -435,28 +435,44 @@ func TestParseDDL_ddlStatements(t *testing.T) {
 	ts := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
 
 	tests := []struct {
-		query   string
-		ddlType DDLKind
-		schema  string
-		table   string
+		query string
+		// defaultSchema is the QUERY_EVENT's session default database
+		// (#1435): the schema MySQL itself resolved an unqualified name
+		// against. Empty on the pre-#1435 rows, whose expectations must not
+		// move — no default, no attribution.
+		defaultSchema string
+		ddlType       DDLKind
+		schema        string
+		table         string
 	}{
-		{"ALTER TABLE orders ADD COLUMN foo INT", DDLAlterTable, "", "orders"},
-		{"CREATE TABLE new_tbl (id INT)", DDLCreateTable, "", "new_tbl"},
-		{"DROP TABLE old_tbl", DDLDropTable, "", "old_tbl"},
-		{"RENAME TABLE a TO b", DDLRenameTable, "", "a"},
-		{"ALTER TABLE mydb.orders ADD COLUMN foo INT", DDLAlterTable, "mydb", "orders"},
-		{"ALTER TABLE `mydb`.`orders` ADD COLUMN foo INT", DDLAlterTable, "mydb", "orders"},
-		{"DROP TABLE IF EXISTS old_tbl", DDLDropTable, "", "old_tbl"},
-		{"CREATE TABLE IF NOT EXISTS `mydb`.`new_tbl` (id INT)", DDLCreateTable, "mydb", "new_tbl"},
-		{"TRUNCATE orders", DDLTruncateTable, "", "orders"},
-		{"TRUNCATE TABLE orders", DDLTruncateTable, "", "orders"},
-		{"TRUNCATE TABLE mydb.orders", DDLTruncateTable, "mydb", "orders"},
-		{"TRUNCATE `mydb`.`orders`", DDLTruncateTable, "mydb", "orders"},
+		{"ALTER TABLE orders ADD COLUMN foo INT", "", DDLAlterTable, "", "orders"},
+		{"CREATE TABLE new_tbl (id INT)", "", DDLCreateTable, "", "new_tbl"},
+		{"DROP TABLE old_tbl", "", DDLDropTable, "", "old_tbl"},
+		{"RENAME TABLE a TO b", "", DDLRenameTable, "", "a"},
+		{"ALTER TABLE mydb.orders ADD COLUMN foo INT", "", DDLAlterTable, "mydb", "orders"},
+		{"ALTER TABLE `mydb`.`orders` ADD COLUMN foo INT", "", DDLAlterTable, "mydb", "orders"},
+		{"DROP TABLE IF EXISTS old_tbl", "", DDLDropTable, "", "old_tbl"},
+		{"CREATE TABLE IF NOT EXISTS `mydb`.`new_tbl` (id INT)", "", DDLCreateTable, "mydb", "new_tbl"},
+		{"TRUNCATE orders", "", DDLTruncateTable, "", "orders"},
+		{"TRUNCATE TABLE orders", "", DDLTruncateTable, "", "orders"},
+		{"TRUNCATE TABLE mydb.orders", "", DDLTruncateTable, "mydb", "orders"},
+		{"TRUNCATE `mydb`.`orders`", "", DDLTruncateTable, "mydb", "orders"},
+		// #1435: an unqualified statement resolves against the session's
+		// default database — one case per statement kind, since each rides a
+		// different regex arm.
+		{"TRUNCATE TABLE dbt_burst_referrers", "wordpress", DDLTruncateTable, "wordpress", "dbt_burst_referrers"},
+		{"ALTER TABLE orders ADD COLUMN foo INT", "shop", DDLAlterTable, "shop", "orders"},
+		{"CREATE TABLE new_tbl (id INT)", "shop", DDLCreateTable, "shop", "new_tbl"},
+		{"DROP TABLE old_tbl", "shop", DDLDropTable, "shop", "old_tbl"},
+		{"RENAME TABLE a TO b", "shop", DDLRenameTable, "shop", "a"},
+		// A schema qualified in the statement always beats the default.
+		{"ALTER TABLE mydb.orders ADD COLUMN foo INT", "shop", DDLAlterTable, "mydb", "orders"},
+		{"TRUNCATE `mydb`.`orders`", "shop", DDLTruncateTable, "mydb", "orders"},
 	}
 
 	for _, tt := range tests {
 		buf.Reset()
-		ev, ok := parseDDL(logger, "binlog.000001", 100, ts, "uuid:1", tt.query, 0)
+		ev, ok := parseDDL(logger, "binlog.000001", 100, ts, "uuid:1", tt.query, tt.defaultSchema, 0)
 		if !ok {
 			t.Errorf("parseDDL(%q) returned false, want true", tt.query)
 			continue
@@ -496,7 +512,7 @@ func TestParseDDL_nonDDL(t *testing.T) {
 	}
 	for _, stmt := range nonDDL {
 		buf.Reset()
-		_, ok := parseDDL(logger, "binlog.000001", 100, ts, "", stmt, 0)
+		_, ok := parseDDL(logger, "binlog.000001", 100, ts, "", stmt, "", 0)
 		if ok {
 			t.Errorf("parseDDL(%q) returned true, want false", stmt)
 		}
@@ -508,7 +524,7 @@ func TestParseDDL_caseInsensitive(t *testing.T) {
 	logger := newTestLogger(&buf)
 	ts := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
 
-	ev, ok := parseDDL(logger, "binlog.000001", 100, ts, "", "alter table orders add column x int", 0)
+	ev, ok := parseDDL(logger, "binlog.000001", 100, ts, "", "alter table orders add column x int", "", 0)
 	if !ok {
 		t.Errorf("parseDDL(lowercase ALTER TABLE) returned false, want true")
 	}

--- a/internal/parser/stream.go
+++ b/internal/parser/stream.go
@@ -351,7 +351,7 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 			// the previous statement's ROWS_QUERY text is stale.
 			currentQueryText = ""
 			ts := time.Unix(int64(binlogEv.Header.Timestamp), 0).UTC()
-			if ddlEv, ok := parseDDL(sp.logger, currentFile, binlogEv.Header.LogPos, ts, currentGTID, string(ev.Query), sp.schemaVersion.Load()); ok {
+			if ddlEv, ok := parseDDL(sp.logger, currentFile, binlogEv.Header.LogPos, ts, currentGTID, string(ev.Query), string(ev.Schema), sp.schemaVersion.Load()); ok {
 				// Synchronous DDL hook runs BEFORE ddlEv is emitted (#760,
 				// reordered from emit-then-hook). The consumer (streamLoop)
 				// advances the durable checkpoint's binlogPos/GTID off events

--- a/internal/parser/stream_test.go
+++ b/internal/parser/stream_test.go
@@ -707,6 +707,35 @@ func TestStreamParser_ddlBypassesSchemaFilter(t *testing.T) {
 	}
 }
 
+// TestStreamParser_unqualifiedDDLTakesTheSessionDefaultSchema pins the #1435
+// WIRING at the stream call site: parseDDL's fallback is unit-tested on its
+// own, but the call site handing it string(ev.Schema) is what makes `USE
+// wordpress; TRUNCATE TABLE t` findable by schema — replace that argument
+// with "" and only this test notices.
+func TestStreamParser_unqualifiedDDLTakesTheSessionDefaultSchema(t *testing.T) {
+	sp := NewStreamParser(nil, Filters{}, nil)
+	streamer := replication.NewBinlogStreamer()
+	out := make(chan Event, 10)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	feedThenCancel(t, streamer, cancel, makeQueryEventWithSchema("wordpress", "TRUNCATE TABLE dbt_burst_referrers"))
+
+	if err := sp.Run(ctx, streamer, out); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("expected 1 EventDDL, got %d", len(out))
+	}
+	ev := <-out
+	if ev.EventType != EventDDL || ev.Table != "dbt_burst_referrers" {
+		t.Fatalf("expected the TRUNCATE's EventDDL, got type=%d table=%q", ev.EventType, ev.Table)
+	}
+	if ev.Schema != "wordpress" {
+		t.Errorf("Schema = %q, want the session default 'wordpress'; the unqualified form is what "+
+			"people and ORMs type, and an empty schema_name makes the row unfindable by filter (#1435)", ev.Schema)
+	}
+}
+
 // ─── RowsEvent filtering ──────────────────────────────────────────────────────
 
 // TestStreamParser_filteredRowsEvent verifies that a RowsEvent for a schema

--- a/internal/reconstruct/destructive_ddl.go
+++ b/internal/reconstruct/destructive_ddl.go
@@ -37,18 +37,16 @@ var ErrDestructiveDDL = errors.New("destructive DDL in reconstruction window")
 // than a hard failure: this is an additive safety net on top of the existing
 // reconstruct contract, not a new hard dependency.
 func CheckDestructiveDDL(ctx context.Context, db *sql.DB, schema, table string, since, until time.Time) error {
-	// schema_name = '' is matched too: parseDDL (internal/parser/parser.go)
-	// derives schema/table from the DDL statement text alone via a regex, and
-	// an unqualified statement — "TRUNCATE TABLE orders" after a session
-	// "USE mydb" — has no schema in the text, so schema_changes.schema_name is
-	// recorded empty for it even though the table itself is unambiguous. Since
-	// go-mysql's QUERY_EVENT does carry the session's default database
-	// (QueryEvent.Schema) but parseDDL doesn't consult it, matching schema_name
-	// = '' as a fallback is the safe direction here: it can only widen a match
-	// (favoring an over-cautious refusal) never narrow one, so a genuine
-	// TRUNCATE/DROP/RENAME can never be missed because of this gap. A future
-	// fix to plumb the session database through parseDDL would make this
-	// fallback redundant, not wrong.
+	// schema_name = '' is matched too, and the arm is NOT removable. Since
+	// #1435 parseDDL resolves an unqualified statement ("TRUNCATE TABLE
+	// orders" after "USE mydb") against the QUERY_EVENT's session default
+	// database, so NEW rows carry a real schema — but every row indexed
+	// before that fix has schema_name = '' (the original session's default
+	// is unrecoverable, so no backfill exists), and deleting this arm as
+	// "redundant now" would silently stop destructive-DDL detection for
+	// exactly the historical windows people reconstruct after an incident
+	// (#764's return path). The '' match can only widen a match (favoring an
+	// over-cautious refusal on historical rows), never narrow one.
 	const q = `SELECT ddl_type, detected_at FROM schema_changes
 		WHERE (schema_name = ? OR schema_name = '') AND table_name = ?
 		AND ddl_type IN ('TRUNCATE TABLE', 'DROP TABLE', 'RENAME TABLE')


### PR DESCRIPTION
closes #1435

## Summary
- `parseDDL` gains the QUERY_EVENT's session default database (`ev.Schema`) as a fallback: an unqualified DDL now records the schema MySQL itself resolved the name against, so `list_schema_changes` with a `schema` filter finds it. A schema qualified in the statement always wins; an empty default (client with no default database) leaves `schema_name` empty, exactly as before.
- Both parser call sites (file path and replication stream) pass `string(ev.Schema)`.
- Non-goal, per the issue: no backfill of historical rows and no read-side papering over — empty stays invisible to the filter, which is honest for rows whose session default is unrecoverable.

## Test plan
- [x] `TestParseDDL_ddlStatements` grows unqualified-with-default cases per statement kind (each rides a different regex arm), plus qualified-beats-default; pre-existing empty-default rows keep their expectations
- [x] Wiring pinned per call site: `TestStreamParser_unqualifiedDDLTakesTheSessionDefaultSchema` (unit, synthetic QUERY_EVENT) and `TestParseFile_unqualifiedDDLTakesTheSessionDefaultSchema` (integration, real unqualified TRUNCATE against the test container)
- [x] Red checks: dropping the fallback and blanking either call site's argument each fail exactly one test; restored and re-greened
- [x] `go test ./... -count=1` green; `go vet -tags integration ./internal/parser/`
