### PR TITLE
One predicate for uncovered DDL: status and list_schema_changes share it

### DIFF
--- a/docs/ddl-tracking.md
+++ b/docs/ddl-tracking.md
@@ -94,11 +94,13 @@ This table is created by `bintrail init` and must exist in the index database. O
 The MCP server exposes this table as the `list_schema_changes` tool, so an AI
 assistant can answer "what ALTERs hit the orders table this month?" directly.
 Filters: `schema`, `table`, `ddl_type` (prefix-matched — `ALTER` matches
-`ALTER TABLE`), `since`, `until`, `limit`, and `uncovered_only` (only rows
-where `snapshot_id` is NULL). Each result carries the full DDL statement,
-binlog coordinates, detection timestamp, and the covering `snapshot_id`
-(`null` = uncovered), so an agent can go from the status warning about
-uncovered DDLs straight to the exact rows. See
+`ALTER TABLE`), `since`, `until`, `limit`, and `uncovered_only` — exactly the
+rows behind the `status` warning: `snapshot_id` null AND the DDL is not a
+`TRUNCATE TABLE`, whose null is by design (see below). Each result carries
+the full DDL statement, binlog coordinates, detection timestamp, and the
+covering `snapshot_id`; a `null` there means uncovered except on a TRUNCATE
+row, which says so itself via `snapshot_note`. An agent can go from the
+status warning about uncovered DDLs straight to the exact rows. See
 [mcp-server.md](./mcp-server.md).
 
 ---

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -210,8 +210,11 @@ HTTP, console-token auth, per-server routing by URL path) — if you already run
 `list_schema_changes` accepts `schema`, `table`, `ddl_type`
 (`CREATE`/`ALTER`/`DROP`/`RENAME`/`TRUNCATE`, prefix-matched so `ALTER` matches
 `ALTER TABLE`), `since`, `until`, `limit` (default 100), and `uncovered_only`
-(only changes whose `snapshot_id` is `null` — the rows behind the `status`
-tool's "DDL(s) detected without auto-snapshot" warning); results come back
+(exactly the rows behind the `status` tool's "DDL(s) detected without
+auto-snapshot" warning — `snapshot_id` is `null` AND the DDL is not a
+`TRUNCATE TABLE`, whose null is by design since it changes no structure; a
+TRUNCATE row in the plain listing carries a `snapshot_note` saying so, and
+`ddl_type: TRUNCATE` lists them all); results come back
 newest-first, and changes inside the same second are ordered by binlog
 coordinate (`binlog_file`, then `binlog_pos`), so a migration's burst of DDLs
 reads in the order it ran and a `limit` that cuts inside the burst keeps the

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -191,7 +191,7 @@ automatically.
 | `recover_cascade` | `bintrail recover-cascade --dry-run` | Generate reversal SQL for foreign-key `ON DELETE`/`ON UPDATE` cascade side effects InnoDB ran below the binlog — the child rows plain `recover` cannot see. Fails with the reasons when the synthesis is provably partial, unless `allow_incomplete` is set |
 | `reconstruct` | `bintrail reconstruct` | A single row's full state at a point in time (needs a baseline) |
 | `status` | `bintrail status` | Indexed files, partitions, and summary |
-| `list_schema_changes` | reads `schema_changes` (see [DDL tracking](./ddl-tracking.md)) | DDL changes recorded while indexing/streaming, with the full statement, binlog coordinates, and the covering `snapshot_id` (`null` = no auto-snapshot) |
+| `list_schema_changes` | reads `schema_changes` (see [DDL tracking](./ddl-tracking.md)) | DDL changes recorded while indexing/streaming, with the full statement, binlog coordinates, and the covering `snapshot_id` (`null` = no auto-snapshot; a TRUNCATE row's null is by design and carries a `snapshot_note` saying so) |
 
 All six are read-only — annotated `ReadOnlyHint: true` and `IdempotentHint: true`,
 so the client knows they're safe to call repeatedly and never modify state.

--- a/internal/mcptools/mcptools.go
+++ b/internal/mcptools/mcptools.go
@@ -532,7 +532,7 @@ type SchemaChangesArgs struct {
 	// UncoveredOnly narrows results to DDLs with no covering snapshot — the
 	// rows the status tool's "N DDL(s) detected without auto-snapshot" warning
 	// counts, so an agent can go straight from that warning to the exact rows.
-	UncoveredOnly bool `json:"uncovered_only,omitempty" jsonschema:"Return only changes with no covering schema snapshot (snapshot_id is null); the ones counted by the status tool's uncovered-DDL warning"`
+	UncoveredOnly bool `json:"uncovered_only,omitempty" jsonschema:"Return only changes with no covering schema snapshot; exactly the ones counted by the status tool's uncovered-DDL warning. TRUNCATE TABLE rows are excluded like the warning excludes them: TRUNCATE changes no table structure, so no snapshot is needed and their null snapshot_id is by design. To list TRUNCATEs, drop this flag or filter ddl_type TRUNCATE"`
 }
 
 // rejectSurfaceParams enforces the surface's parameter policy: a non-nil
@@ -1108,7 +1108,12 @@ func MakeSchemaChangesTool(cfg Config) func(context.Context, *mcp.CallToolReques
 			params = append(params, *untilT)
 		}
 		if args.UncoveredOnly {
-			q += " AND snapshot_id IS NULL"
+			// The status package's predicate, verbatim: this filter promises
+			// "the ones counted by the status tool's uncovered-DDL warning",
+			// and a re-written clause here diverged once (#1436: a bare
+			// IS NULL listed the TRUNCATEs the warning deliberately excludes,
+			// 9 rows against a count of 1).
+			q += " AND " + status.UncoveredDDLWhere
 		}
 		// detected_at has one-second resolution and a migration lands dozens of
 		// DDLs inside one second, so the timestamp alone leaves the group in
@@ -1147,8 +1152,13 @@ func MakeSchemaChangesTool(cfg Config) func(context.Context, *mcp.CallToolReques
 			GTID       string `json:"gtid,omitempty"`
 			// SnapshotID is the auto-snapshot taken after this DDL. Deliberately
 			// NOT omitempty: an explicit null is the "uncovered DDL" signal the
-			// status tool's warning points at (#1050).
+			// status tool's warning points at (#1050) — except on TRUNCATE
+			// rows, where SnapshotNote says the null is by design (#1436).
 			SnapshotID *int64 `json:"snapshot_id"`
+			// SnapshotNote disambiguates the one ddl_type whose null
+			// snapshot_id means "no snapshot needed" rather than "no snapshot
+			// taken": without it the same null carries two opposite meanings.
+			SnapshotNote string `json:"snapshot_note,omitempty"`
 		}
 
 		var results []schemaChange
@@ -1166,6 +1176,11 @@ func MakeSchemaChangesTool(cfg Config) func(context.Context, *mcp.CallToolReques
 			}
 			if snapshotID.Valid {
 				sc.SnapshotID = &snapshotID.Int64
+			} else if sc.DDLType == "TRUNCATE TABLE" {
+				// The one null that is not a gap (#1436): every capture path
+				// records TRUNCATE with snapshot_id = NULL on purpose, and
+				// the status warning excludes it for the same reason.
+				sc.SnapshotNote = "no snapshot needed: TRUNCATE changes no table structure"
 			}
 			results = append(results, sc)
 		}

--- a/internal/mcptools/mcptools_test.go
+++ b/internal/mcptools/mcptools_test.go
@@ -379,7 +379,7 @@ func TestSchemaChangesTool_uncoveredOnlyFilter(t *testing.T) {
 	// the rows the status warning counts, and the two clauses diverged once
 	// (9 listed against a count of 1, the delta being TRUNCATEs whose null is
 	// by design).
-	mock.ExpectQuery(`FROM schema_changes WHERE 1=1 AND snapshot_id IS NULL AND ddl_type <> 'TRUNCATE TABLE' ORDER BY detected_at DESC, binlog_file DESC, binlog_pos DESC, id DESC LIMIT`).
+	mock.ExpectQuery(`FROM schema_changes WHERE 1=1 AND \(snapshot_id IS NULL AND ddl_type <> 'TRUNCATE TABLE'\) ORDER BY detected_at DESC, binlog_file DESC, binlog_pos DESC, id DESC LIMIT`).
 		WillReturnRows(sqlmock.NewRows(schemaChangesMockCols).
 			AddRow(2, detected, "shop", "orders", "ALTER TABLE",
 				"ALTER TABLE orders ADD COLUMN note TEXT", "binlog.000001", 900, nil, nil))

--- a/internal/mcptools/mcptools_test.go
+++ b/internal/mcptools/mcptools_test.go
@@ -351,6 +351,15 @@ func TestSchemaChangesTool_snapshotIDRoundTrip(t *testing.T) {
 	if !strings.Contains(text, `"snapshot_id": null`) {
 		t.Errorf("uncovered DDL must carry an explicit null snapshot_id, got:\n%s", text)
 	}
+	// The null row above is a TRUNCATE, the one ddl_type whose null is by
+	// design: without the note the same null means both "no snapshot taken"
+	// and "no snapshot needed" (#1436).
+	if !strings.Contains(text, `"snapshot_note": "no snapshot needed`) {
+		t.Errorf("a TRUNCATE's null snapshot_id carries no snapshot_note, so the null keeps two meanings:\n%s", text)
+	}
+	if strings.Count(text, "snapshot_note") != 1 {
+		t.Errorf("snapshot_note must appear on the TRUNCATE row only, got:\n%s", text)
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Error(err)
 	}
@@ -364,11 +373,16 @@ func TestSchemaChangesTool_uncoveredOnlyFilter(t *testing.T) {
 	defer db.Close()
 
 	detected := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
-	// The expectation only matches when the SQL carries the IS NULL predicate.
-	mock.ExpectQuery("FROM schema_changes WHERE 1=1 AND snapshot_id IS NULL ORDER BY detected_at DESC, binlog_file DESC, binlog_pos DESC, id DESC LIMIT").
+	// The expectation only matches when the SQL carries the STATUS package's
+	// predicate — IS NULL plus the TRUNCATE exclusion (#1436). A bare IS NULL
+	// here is the drift this pin exists to catch: the filter promises exactly
+	// the rows the status warning counts, and the two clauses diverged once
+	// (9 listed against a count of 1, the delta being TRUNCATEs whose null is
+	// by design).
+	mock.ExpectQuery(`FROM schema_changes WHERE 1=1 AND snapshot_id IS NULL AND ddl_type <> 'TRUNCATE TABLE' ORDER BY detected_at DESC, binlog_file DESC, binlog_pos DESC, id DESC LIMIT`).
 		WillReturnRows(sqlmock.NewRows(schemaChangesMockCols).
-			AddRow(2, detected, "shop", "orders", "TRUNCATE TABLE",
-				"TRUNCATE TABLE orders", "binlog.000001", 900, nil, nil))
+			AddRow(2, detected, "shop", "orders", "ALTER TABLE",
+				"ALTER TABLE orders ADD COLUMN note TEXT", "binlog.000001", 900, nil, nil))
 
 	res, _, err := MakeSchemaChangesTool(newSchemaChangesTarget(db))(context.Background(), nil, SchemaChangesArgs{UncoveredOnly: true})
 	if err != nil {

--- a/internal/mcptools/uncoveredddl_1436_integration_test.go
+++ b/internal/mcptools/uncoveredddl_1436_integration_test.go
@@ -36,9 +36,9 @@ func TestIntegrationUncoveredOnlyMatchesTheStatusCount(t *testing.T) {
 			pos, table, ddlType, stmt, snapshotID))
 	}
 	insert(100, "orders", "ALTER TABLE", "ALTER TABLE orders ADD COLUMN note TEXT", "7") // covered
-	insert(200, "users", "ALTER TABLE", "ALTER TABLE users DROP COLUMN tmp", "NULL")    // uncovered
-	insert(300, "orders", "TRUNCATE TABLE", "TRUNCATE TABLE orders", "NULL")            // null by design
-	insert(400, "users", "TRUNCATE TABLE", "TRUNCATE users", "NULL")                    // null by design
+	insert(200, "users", "ALTER TABLE", "ALTER TABLE users DROP COLUMN tmp", "NULL")     // uncovered
+	insert(300, "orders", "TRUNCATE TABLE", "TRUNCATE TABLE orders", "NULL")             // null by design
+	insert(400, "users", "TRUNCATE TABLE", "TRUNCATE users", "NULL")                     // null by design
 
 	cov, err := status.LoadCoverage(context.Background(), db)
 	if err != nil {
@@ -88,4 +88,3 @@ func TestIntegrationUncoveredOnlyMatchesTheStatusCount(t *testing.T) {
 		t.Errorf("both TRUNCATE rows must carry the snapshot_note, got:\n%s", allText)
 	}
 }
-

--- a/internal/mcptools/uncoveredddl_1436_integration_test.go
+++ b/internal/mcptools/uncoveredddl_1436_integration_test.go
@@ -1,0 +1,91 @@
+//go:build integration
+
+package mcptools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/status"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestIntegrationUncoveredOnlyMatchesTheStatusCount pins the #1436
+// equivalence against a real index: the uncovered_only filter promises
+// "exactly the ones counted by the status tool's uncovered-DDL warning", and
+// the two predicates were hand-maintained WHERE clauses that diverged once
+// (a bare IS NULL listed 9 rows where the warning counted 1 — one genuinely
+// uncovered DDL plus eight TRUNCATEs whose null snapshot_id is by design).
+// Seeded: one covered DDL, one uncovered DDL, two TRUNCATEs. The count and
+// the row set must agree at 1, through the REAL query both sides run — the
+// shared status.UncoveredDDLWhere constant makes divergence structural, and
+// this test is what says the constant is actually what both execute.
+func TestIntegrationUncoveredOnlyMatchesTheStatusCount(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	insert := func(pos int, table, ddlType, stmt, snapshotID string) {
+		// positions distinct so the deterministic ORDER BY has real work
+		testutil.MustExec(t, db, fmt.Sprintf(`INSERT INTO schema_changes
+			(detected_at, binlog_file, binlog_pos, schema_name, table_name, ddl_type, ddl_query, snapshot_id)
+			VALUES ('2026-08-01 12:00:00', 'binlog.000001', %d, 'shop', '%s', '%s', '%s', %s)`,
+			pos, table, ddlType, stmt, snapshotID))
+	}
+	insert(100, "orders", "ALTER TABLE", "ALTER TABLE orders ADD COLUMN note TEXT", "7") // covered
+	insert(200, "users", "ALTER TABLE", "ALTER TABLE users DROP COLUMN tmp", "NULL")    // uncovered
+	insert(300, "orders", "TRUNCATE TABLE", "TRUNCATE TABLE orders", "NULL")            // null by design
+	insert(400, "users", "TRUNCATE TABLE", "TRUNCATE users", "NULL")                    // null by design
+
+	cov, err := status.LoadCoverage(context.Background(), db)
+	if err != nil {
+		t.Fatalf("LoadCoverage: %v", err)
+	}
+	if cov.UncoveredDDLs != 1 {
+		t.Fatalf("status counts %d uncovered DDLs, want 1 (the fixture's premise failed)", cov.UncoveredDDLs)
+	}
+
+	cfg := Config{Resolve: func(context.Context, string) (*Target, error) { return &Target{DB: db}, nil }}
+	res, _, err := MakeSchemaChangesTool(cfg)(context.Background(), nil, SchemaChangesArgs{UncoveredOnly: true})
+	if err != nil {
+		t.Fatalf("tool: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("tool error: %s", resultText(res))
+	}
+	text := resultText(res)
+	end := strings.LastIndex(text, "]")
+	if end < 0 {
+		t.Fatalf("no JSON array in result: %s", text)
+	}
+	var rowsOut []map[string]any
+	if err := json.Unmarshal([]byte(text[:end+1]), &rowsOut); err != nil {
+		t.Fatalf("parse: %v\n%s", err, text)
+	}
+	if len(rowsOut) != cov.UncoveredDDLs {
+		t.Fatalf("uncovered_only returned %d rows against a status count of %d; the two surfaces "+
+			"describe the same set and an agent following the warning into the tool must not be "+
+			"contradicted", len(rowsOut), cov.UncoveredDDLs)
+	}
+	if got := rowsOut[0]["ddl_type"]; got != "ALTER TABLE" {
+		t.Errorf("the one uncovered row is %v, want the ALTER (a TRUNCATE here means the exclusion is gone)", got)
+	}
+
+	// The plain listing still carries the TRUNCATEs — nothing is hidden, the
+	// null just stops meaning two opposite things.
+	resAll, _, err := MakeSchemaChangesTool(cfg)(context.Background(), nil, SchemaChangesArgs{})
+	if err != nil {
+		t.Fatalf("tool (plain): %v", err)
+	}
+	allText := resultText(resAll)
+	if !strings.Contains(allText, "4 schema change(s)") {
+		t.Errorf("plain listing lost rows: %s", allText)
+	}
+	if strings.Count(allText, "no snapshot needed") != 2 {
+		t.Errorf("both TRUNCATE rows must carry the snapshot_note, got:\n%s", allText)
+	}
+}
+

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -330,6 +330,18 @@ func LoadArchiveStats(ctx context.Context, db *sql.DB) (*ArchiveStats, error) {
 // and archive_state. Archive coverage is derived from partition names stored in
 // archive_state (e.g. "p_2026021914" → 2026-02-19 14:00 UTC) without reading
 // Parquet files.
+// UncoveredDDLWhere is the ONE definition of "a DDL with no covering
+// snapshot", shared by this package's UncoveredDDLs count and the
+// list_schema_changes tool's uncovered_only filter (#1436) — the two were
+// hand-maintained WHERE clauses and diverged once: the tool used a bare
+// `snapshot_id IS NULL` and listed 9 rows where the status warning counted 1.
+//
+// TRUNCATE TABLE is excluded: it does not change table structure, so every
+// capture path records it with snapshot_id = NULL on purpose ("DDL detected
+// (no snapshot needed)") — a NULL there is not a coverage gap, and counting
+// it would permanently inflate the warning.
+const UncoveredDDLWhere = `snapshot_id IS NULL AND ddl_type <> 'TRUNCATE TABLE'`
+
 func LoadCoverage(ctx context.Context, db *sql.DB) (*CoverageInfo, error) {
 	var c CoverageInfo
 	err := db.QueryRowContext(ctx, `
@@ -346,12 +358,8 @@ func LoadCoverage(ctx context.Context, db *sql.DB) (*CoverageInfo, error) {
 		return nil, fmt.Errorf("query schema_changes count: %w", err)
 	}
 
-	// TRUNCATE TABLE is excluded: it does not change table structure, so every
-	// capture path records it with snapshot_id = NULL on purpose ("DDL detected
-	// (no snapshot needed)") — a NULL there is not a coverage gap.
 	err = db.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM schema_changes
-		 WHERE snapshot_id IS NULL AND ddl_type <> 'TRUNCATE TABLE'`).Scan(&c.UncoveredDDLs)
+		`SELECT COUNT(*) FROM schema_changes WHERE `+UncoveredDDLWhere).Scan(&c.UncoveredDDLs)
 	if err != nil {
 		return nil, fmt.Errorf("query uncovered DDLs: %w", err)
 	}

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -326,10 +326,6 @@ func LoadArchiveStats(ctx context.Context, db *sql.DB) (*ArchiveStats, error) {
 	return &a, nil
 }
 
-// LoadCoverage loads restore coverage info from binlog_events, schema_changes,
-// and archive_state. Archive coverage is derived from partition names stored in
-// archive_state (e.g. "p_2026021914" → 2026-02-19 14:00 UTC) without reading
-// Parquet files.
 // UncoveredDDLWhere is the ONE definition of "a DDL with no covering
 // snapshot", shared by this package's UncoveredDDLs count and the
 // list_schema_changes tool's uncovered_only filter (#1436) — the two were
@@ -340,8 +336,16 @@ func LoadArchiveStats(ctx context.Context, db *sql.DB) (*ArchiveStats, error) {
 // capture path records it with snapshot_id = NULL on purpose ("DDL detected
 // (no snapshot needed)") — a NULL there is not a coverage gap, and counting
 // it would permanently inflate the warning.
-const UncoveredDDLWhere = `snapshot_id IS NULL AND ddl_type <> 'TRUNCATE TABLE'`
+//
+// Parenthesized so both consumers compose it safely: status appends it to
+// WHERE, the tool to an existing clause with AND — an OR added here later
+// would otherwise bind correctly in one site and silently wrong in the other.
+const UncoveredDDLWhere = `(snapshot_id IS NULL AND ddl_type <> 'TRUNCATE TABLE')`
 
+// LoadCoverage loads restore coverage info from binlog_events, schema_changes,
+// and archive_state. Archive coverage is derived from partition names stored in
+// archive_state (e.g. "p_2026021914" → 2026-02-19 14:00 UTC) without reading
+// Parquet files.
 func LoadCoverage(ctx context.Context, db *sql.DB) (*CoverageInfo, error) {
 	var c CoverageInfo
 	err := db.QueryRowContext(ctx, `


### PR DESCRIPTION
closes #1436

## Summary
- `status.UncoveredDDLWhere` is now the ONE definition of "a DDL with no covering snapshot" (`snapshot_id IS NULL AND ddl_type <> 'TRUNCATE TABLE'`); both the status warning's count and the `uncovered_only` filter execute it verbatim, so the 1-versus-9 contradiction cannot re-form by re-typing the clause.
- TRUNCATEs stay reachable: the plain listing and `ddl_type: TRUNCATE` list them all.
- The second honesty gap: a TRUNCATE row's explicit `snapshot_id: null` was carrying the "uncovered" signal falsely; those rows now carry `snapshot_note: "no snapshot needed: TRUNCATE changes no table structure"` (omitempty, only on that shape).
- Tool schema description and `docs/mcp-server.md` state the exclusion and the note.

## Test plan
- [x] `TestIntegrationUncoveredOnlyMatchesTheStatusCount`: seeds covered + uncovered + 2 TRUNCATEs, asserts `LoadCoverage().UncoveredDDLs == 1 == rows(uncovered_only)`, the row is the ALTER, the plain listing keeps 4 rows and both TRUNCATEs carry the note
- [x] sqlmock pins the composed SQL (`AND snapshot_id IS NULL AND ddl_type <> 'TRUNCATE TABLE'`); the roundtrip test asserts the note appears on the TRUNCATE row only
- [x] Red checks: re-typing the tool clause as bare `IS NULL`, widening the shared constant, and dropping the note each fail exactly one test; restored and re-greened
- [x] `go test ./... -count=1` green; `go vet -tags integration` on both packages
