### PR TITLE
Console: say when the baseline-refresh timer runs over zero servers

### DIFF
--- a/consoleapp/baseline_refresh_loop.go
+++ b/consoleapp/baseline_refresh_loop.go
@@ -798,7 +798,8 @@ func startBaselineRefreshLoop(ctx context.Context, reg *console.Registry, sup *b
 		// instead of running a console with a flag that is silently inert.
 		return fmt.Errorf("internal: --baseline-refresh-interval was set without a baseline supervisor")
 	}
-	targets := baselineRefreshTargets(registryEntries(reg), globalDSN, globalBaselineDir)
+	targets, skipped := baselineRefreshTargets(registryEntries(reg), globalDSN, globalBaselineDir)
+	logSkippedRefreshTargets(skipped)
 	// Name the effective reuse setting AND where it came from, once, at the one
 	// moment an operator is reading the log to see whether their configuration
 	// took. A console override beats the command line silently by design, so
@@ -963,7 +964,8 @@ func refreshTargetsFor(reg *console.Registry, globalDSN, globalBaselineDir strin
 // refreshTargetsWith is the same thing with the setting ALREADY resolved, so
 // one cycle resolves it once and logs exactly the value it dispatched with.
 func refreshTargetsWith(reg *console.Registry, globalDSN, globalBaselineDir string, carry bool) []refreshRequest {
-	reqs := baselineRefreshTargets(registryEntries(reg), globalDSN, globalBaselineDir)
+	reqs, skipped := baselineRefreshTargets(registryEntries(reg), globalDSN, globalBaselineDir)
+	logSkippedRefreshTargets(skipped)
 	for i := range reqs {
 		reqs[i].CarryForwardUnchanged = carry
 	}
@@ -1094,15 +1096,17 @@ func registryEntries(reg *console.Registry) []console.ServerEntry {
 	return reg.List()
 }
 
-// baselineRefreshTargets collects the servers a refresh can run for: an index
-// DSN to fold from and a LOCAL baseline directory to fold into.
+// baselineRefreshTargets collects the servers a refresh can run for — an index
+// DSN to fold from and a LOCAL baseline directory to fold into — plus the
+// names of servers skipped for having only an S3 destination.
 //
-// A server with only an S3 baseline destination is skipped WITH a warning rather
-// than silently: the refresh writes files, so an in-place S3 refresh is not
-// something this loop can do, and an operator who configured S3-only baselines
-// and set the interval would otherwise see nothing happen and no reason why.
-func baselineRefreshTargets(entries []console.ServerEntry, globalDSN, globalBaselineDir string) []refreshRequest {
+// PURE on purpose (#1579): it used to slog.Warn the S3-only skip itself, and
+// the same computation now also answers GET /api/baseline-refresh live, where
+// a warning per page load would be log spam. The callers that dispatch work
+// log the skip via logSkippedRefreshTargets, preserving the old visibility.
+func baselineRefreshTargets(entries []console.ServerEntry, globalDSN, globalBaselineDir string) ([]refreshRequest, []string) {
 	var out []refreshRequest
+	var skippedS3Only []string
 	seen := map[string]bool{}
 	add := func(id, name, dsn, dir string) {
 		if dsn == "" || dir == "" || seen[id] {
@@ -1114,11 +1118,23 @@ func baselineRefreshTargets(entries []console.ServerEntry, globalDSN, globalBase
 	add("default", "boot", globalDSN, globalBaselineDir)
 	for _, e := range entries {
 		if e.DSN != "" && e.BaselineDir == "" && e.BaselineS3 != "" {
-			slog.Warn("baseline refresh: server has an S3-only baseline destination and will not be refreshed "+
-				"(a refresh writes Parquet to a filesystem, so it needs a local directory to fold into)", "server", e.Name)
+			skippedS3Only = append(skippedS3Only, e.Name)
 			continue
 		}
 		add(e.ID, e.Name, e.DSN, e.BaselineDir)
 	}
-	return out
+	return out, skippedS3Only
+}
+
+// logSkippedRefreshTargets is the warning half baselineRefreshTargets no
+// longer carries: a server with only an S3 baseline destination is skipped
+// WITH a warning rather than silently — the refresh writes files, so an
+// in-place S3 refresh is not something the loop can do, and an operator who
+// configured S3-only baselines and set the interval would otherwise see
+// nothing happen and no reason why.
+func logSkippedRefreshTargets(skipped []string) {
+	for _, name := range skipped {
+		slog.Warn("baseline refresh: server has an S3-only baseline destination and will not be refreshed "+
+			"(a refresh writes Parquet to a filesystem, so it needs a local directory to fold into)", "server", name)
+	}
 }

--- a/consoleapp/baseline_refresh_loop_test.go
+++ b/consoleapp/baseline_refresh_loop_test.go
@@ -29,7 +29,7 @@ func TestBaselineRefreshTargets(t *testing.T) {
 		{ID: "d", Name: "viewonly", BaselineDir: "/b/d"},
 	}
 
-	got := baselineRefreshTargets(entries, "boot-dsn", "/b/boot")
+	got, skipped := baselineRefreshTargets(entries, "boot-dsn", "/b/boot")
 	want := map[string]string{"default": "/b/boot", "a": "/b/a"}
 	if len(got) != len(want) {
 		t.Fatalf("got %d target(s) %+v, want %d", len(got), got, len(want))
@@ -39,16 +39,24 @@ func TestBaselineRefreshTargets(t *testing.T) {
 			t.Errorf("target %q = %q, want %q", r.ServerID, r.BaselineDir, want[r.ServerID])
 		}
 	}
+	// The skip is REPORTED, not just absent (#1579): the same computation
+	// answers GET /api/baseline-refresh, and "covers every server" was wrong
+	// exactly because this server vanished without a count. The no-baseline
+	// and no-DSN entries are NOT in it: they are unconfigured, not skipped
+	// for a reason the card should name.
+	if len(skipped) != 1 || skipped[0] != "s3only" {
+		t.Errorf("skippedS3Only = %v, want exactly [s3only]", skipped)
+	}
 }
 
 // TestBaselineRefreshTargets_bootNeedsBoth: the boot entry is only a target when
 // the daemon has both halves — a --baseline-dir with no --index-dsn (or the
 // reverse) has nothing to fold.
 func TestBaselineRefreshTargets_bootNeedsBoth(t *testing.T) {
-	if got := baselineRefreshTargets(nil, "", "/b/boot"); len(got) != 0 {
+	if got, _ := baselineRefreshTargets(nil, "", "/b/boot"); len(got) != 0 {
 		t.Errorf("targets without an index DSN = %+v, want none", got)
 	}
-	if got := baselineRefreshTargets(nil, "boot-dsn", ""); len(got) != 0 {
+	if got, _ := baselineRefreshTargets(nil, "boot-dsn", ""); len(got) != 0 {
 		t.Errorf("targets without a baseline dir = %+v, want none", got)
 	}
 }

--- a/consoleapp/watch.go
+++ b/consoleapp/watch.go
@@ -473,6 +473,13 @@ func runUpConsoleOnly(cmd *cobra.Command) error {
 	}
 	if upBaselineRefreshEvery != "" {
 		cfg.BaselineRefresh = baselineSup
+		// Live target count for GET /api/baseline-refresh (#1579): the loop
+		// recomputes its set per tick, so the page must too, or a fresh
+		// install reports everything-running over zero refreshable servers.
+		cfg.BaselineRefreshTargets = func() (int, int) {
+			reqs, skipped := baselineRefreshTargets(registryEntries(registry), upIndexDSN, upConsoleBaselineDir)
+			return len(reqs), len(skipped)
+		}
 	}
 	wireBaselineExtras(&cfg, baselineSup, serversPath)
 	// The per-server backup schedule (#1442) needs only the supervisor: the
@@ -688,6 +695,13 @@ func runUpStreamWithConsole(cmd *cobra.Command, args []string) error {
 	}
 	if upBaselineRefreshEvery != "" {
 		cfg.BaselineRefresh = baselineSup
+		// Live target count for GET /api/baseline-refresh (#1579): the loop
+		// recomputes its set per tick, so the page must too, or a fresh
+		// install reports everything-running over zero refreshable servers.
+		cfg.BaselineRefreshTargets = func() (int, int) {
+			reqs, skipped := baselineRefreshTargets(registryEntries(registry), upIndexDSN, upConsoleBaselineDir)
+			return len(reqs), len(skipped)
+		}
 	}
 	wireBaselineExtras(&cfg, baselineSup, serversPath)
 	// The per-server backup schedule (#1442) needs only the supervisor: the

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -4142,13 +4142,16 @@ function backupRefreshCard(br) {
       "The refresh timer is on, but no server can be refreshed: a refresh needs an index connection " +
       "and a local Backup dir. Nothing will refresh until a server has both; set one in the servers list below." }));
   }
-  // What the skipped servers CAN do, not what a reader would like them to do:
-  // an update from the recorded changes writes Parquet to a local directory,
-  // which is the very field these servers lack, so the bucket is never read
-  // back into a cheaper backup. Promising one here would put this card's own
-  // false-coverage failure two lines below its fix.
+  // What the skipped servers CANNOT do, not what they will do: an update from
+  // the recorded changes writes Parquet to a local directory, which is the very
+  // field these servers lack, so the bucket is never read back into a cheaper
+  // backup. The positive form ("their backups are full backups") would be a
+  // PREDICTION, and this card holds no gate data: with the create-backup
+  // opt-in off, a schedule on such a server is refused and takes no backup at
+  // all. The per-server rows below make that prediction, and only after
+  // checking the refusal.
   if (br.skipped_s3_only > 0) {
-    say(br.skipped_s3_only + " server(s) keep backups only in S3, so the timer skips them. A backup on those servers is always a full backup.");
+    say(br.skipped_s3_only + " server(s) keep backups only in S3, so the timer skips them. Those servers never get an update from the recorded changes; the only backup they can get is a full one.");
   }
   // Three situations, not two. A daemon started with the backup trigger and no
   // refresh schedule still applies this to restores, so calling it dormant

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -4139,11 +4139,16 @@ function backupRefreshCard(br) {
   // daemon whose loop truly covers nothing.
   if (br.scheduled && br.targets === 0) {
     card.append(el("p", { class: "form-msg err", text:
-      "The refresh timer is running, but no server can be refreshed: a refresh needs an index connection " +
-      "and a local Backup dir. Nothing will refresh until a server has both (Backups & snapshots page)." }));
+      "The refresh timer is on, but no server can be refreshed: a refresh needs an index connection " +
+      "and a local Backup dir. Nothing will refresh until a server has both; set one in the servers list below." }));
   }
+  // What the skipped servers CAN do, not what a reader would like them to do:
+  // an update from the recorded changes writes Parquet to a local directory,
+  // which is the very field these servers lack, so the bucket is never read
+  // back into a cheaper backup. Promising one here would put this card's own
+  // false-coverage failure two lines below its fix.
   if (br.skipped_s3_only > 0) {
-    say(br.skipped_s3_only + " server(s) keep backups only in S3, so the timer skips them; their scheduled backups read the bucket instead.");
+    say(br.skipped_s3_only + " server(s) keep backups only in S3, so the timer skips them. A backup on those servers is always a full backup.");
   }
   // Three situations, not two. A daemon started with the backup trigger and no
   // refresh schedule still applies this to restores, so calling it dormant

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -4127,7 +4127,24 @@ function backupRefreshCard(br) {
     say("Turn this on and a table with no changes keeps its file from the last backup instead. The backup is still complete.");
   }
   say("It saves disk only when the last backup is read from this machine. A scheduled backup on a server that has a Backup S3 reuses nothing, so it writes every table.");
-  say("This one setting covers every server.");
+  // "covers every server" was false for an S3-only server, which the refresh
+  // timer skips permanently (#1579); scoped to the servers the loop can
+  // actually reach, with the skip counted right below it.
+  say("This one setting covers every server that keeps backups on this machine.");
+  // The everything-running silence #1579 names: enabled and scheduled both
+  // true reads as the healthy state, while the timer can be running over
+  // ZERO refreshable servers (fresh install, or every server S3-only or
+  // without a Backup dir). br.targets is computed live by the daemon and
+  // omitted where no loop runs, so the alarm can only fire on a watch
+  // daemon whose loop truly covers nothing.
+  if (br.scheduled && br.targets === 0) {
+    card.append(el("p", { class: "form-msg err", text:
+      "The refresh timer is running, but no server can be refreshed: a refresh needs an index connection " +
+      "and a local Backup dir. Nothing will refresh until a server has both (Backups & snapshots page)." }));
+  }
+  if (br.skipped_s3_only > 0) {
+    say(br.skipped_s3_only + " server(s) keep backups only in S3, so the timer skips them; their scheduled backups read the bucket instead.");
+  }
   // Three situations, not two. A daemon started with the backup trigger and no
   // refresh schedule still applies this to restores, so calling it dormant
   // there would let an operator reuse files right after being told nothing

--- a/internal/console/assets_backuprefresh_test.go
+++ b/internal/console/assets_backuprefresh_test.go
@@ -195,7 +195,11 @@ func TestBackupRefreshWireNamesMatchTheFrontend(t *testing.T) {
 		}
 	}
 
-	dto, err := json.Marshal(baselineRefreshDTO{CarryForwardUnchanged: true, Source: "override", Enabled: true, Scheduled: true})
+	// Targets non-nil and SkippedS3Only non-zero, or their omitempty hides
+	// the very keys this pin exists for.
+	zero := 0
+	dto, err := json.Marshal(baselineRefreshDTO{CarryForwardUnchanged: true, Source: "override",
+		Enabled: true, Scheduled: true, Targets: &zero, SkippedS3Only: 1})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,13 +207,20 @@ func TestBackupRefreshWireNamesMatchTheFrontend(t *testing.T) {
 	if err := json.Unmarshal(dto, &d); err != nil {
 		t.Fatal(err)
 	}
-	for _, key := range []string{"carry_forward_unchanged", "source", "enabled", "scheduled"} {
+	for _, key := range []string{"carry_forward_unchanged", "source", "enabled", "scheduled", "targets", "skipped_s3_only"} {
 		if _, ok := d[key]; !ok {
 			t.Errorf("baselineRefreshDTO does not serialise %q (got %s)", key, dto)
 		}
 		if !strings.Contains(js, "br."+key) && !strings.Contains(js, key) {
 			t.Errorf("app.js never reads %q from the refresh DTO", key)
 		}
+	}
+	// The zero-targets alarm keys on the exact shape #1579 names: scheduled
+	// AND a REAL zero. `br.targets === 0` (strict) so an omitted field
+	// (serve, no loop) can never fire it.
+	if !strings.Contains(js, "br.targets === 0") {
+		t.Error("the zero-targets alarm is gone or no longer strict; a running timer over zero " +
+			"refreshable servers would fall back to silence (#1579)")
 	}
 }
 

--- a/internal/console/baseline_refresh_api.go
+++ b/internal/console/baseline_refresh_api.go
@@ -22,6 +22,18 @@ type baselineRefreshDTO struct {
 	// running. Enabled without Scheduled is the --baseline-trigger daemon: the
 	// setting governs restores today and nothing is on a timer.
 	Scheduled bool `json:"scheduled"`
+	// Targets is how many servers the NEXT refresh tick will cover, computed
+	// live at request time (the loop recomputes per tick, so a boot snapshot
+	// would go stale the moment a server is added). A pointer so it is
+	// OMITTED where the daemon wired no counter (serve, or no loop) and a
+	// real zero where the loop runs over nothing — the enabled+scheduled+
+	// zero-targets shape the page previously reported as everything-running
+	// (#1579).
+	Targets *int `json:"targets,omitempty"`
+	// SkippedS3Only counts servers the tick skips for keeping baselines only
+	// in S3: a refresh writes Parquet to a filesystem, so it needs a local
+	// directory to fold into. The reason "covers every server" was false.
+	SkippedS3Only int `json:"skipped_s3_only,omitempty"`
 }
 
 // baselineRefreshRequest is the PUT /api/baseline-refresh body.
@@ -50,20 +62,22 @@ func (s *Server) handleBaselineRefreshGet(w http.ResponseWriter, r *http.Request
 // the presence of an override.
 func (s *Server) effectiveBaselineRefresh() baselineRefreshDTO {
 	d := s.baselineRefreshDefaults
-	if bc, ok := s.cm.reg.BaselineRefresh(); ok {
-		return baselineRefreshDTO{
-			CarryForwardUnchanged: bc.CarryForwardUnchanged,
-			Source:                "override",
-			Enabled:               d.Enabled,
-			Scheduled:             d.Scheduled,
-		}
-	}
-	return baselineRefreshDTO{
+	dto := baselineRefreshDTO{
 		CarryForwardUnchanged: d.CarryForwardUnchanged,
 		Source:                "default",
 		Enabled:               d.Enabled,
 		Scheduled:             d.Scheduled,
 	}
+	if bc, ok := s.cm.reg.BaselineRefresh(); ok {
+		dto.CarryForwardUnchanged = bc.CarryForwardUnchanged
+		dto.Source = "override"
+	}
+	if s.baselineRefreshTargets != nil {
+		targets, skipped := s.baselineRefreshTargets()
+		dto.Targets = &targets
+		dto.SkippedS3Only = skipped
+	}
+	return dto
 }
 
 // handleBaselineRefreshUpdate serves PUT /api/baseline-refresh: persist a

--- a/internal/console/baseline_refresh_api_test.go
+++ b/internal/console/baseline_refresh_api_test.go
@@ -88,6 +88,36 @@ func TestBaselineRefreshGet_targetsAreLiveAndOmittedOffWatch(t *testing.T) {
 		t.Fatalf("second read: %+v; the count is a boot snapshot, not live — a server added later would "+
 			"keep the stale zero and the alarm would cry wolf forever", got)
 	}
+
+	// The counts must survive an OVERRIDE, on the PUT response and on every
+	// read after it. They are appended after the override branch for exactly
+	// this reason, and the browser-side render matrix cannot see a server-side
+	// branch: an early return there makes the alarm and the skip note vanish
+	// the moment an operator uses this card's own switch.
+	//
+	// Decoded into a FRESH struct each time, never the one above: Unmarshal
+	// leaves a field the payload omits at its previous value, so reusing `got`
+	// would carry the pointer from the read before and the assertion would pass
+	// against a response that dropped the key.
+	rec, body := doServersReq(t, srv, "PUT", "/api/baseline-refresh", `{"carry_forward_unchanged":true}`)
+	if rec.Code != 200 {
+		t.Fatalf("PUT code=%d body=%s", rec.Code, body)
+	}
+	var put baselineRefreshDTO
+	if err := json.Unmarshal(body, &put); err != nil {
+		t.Fatal(err)
+	}
+	if put.Source != "override" || put.Targets == nil || put.SkippedS3Only != 2 {
+		t.Fatalf("PUT response: %+v (%s), want the override plus both counts", put, body)
+	}
+	_, body = doServersReq(t, srv, "GET", "/api/baseline-refresh", "")
+	var after baselineRefreshDTO
+	if err := json.Unmarshal(body, &after); err != nil {
+		t.Fatal(err)
+	}
+	if after.Source != "override" || after.Targets == nil || after.SkippedS3Only != 2 {
+		t.Fatalf("read after the override: %+v (%s), want the override plus both counts", after, body)
+	}
 }
 
 // Enabled is the loop's boot-time liveness and must NOT be implied by the

--- a/internal/console/baseline_refresh_api_test.go
+++ b/internal/console/baseline_refresh_api_test.go
@@ -48,6 +48,48 @@ func TestBaselineRefreshGet_defaultThenOverride(t *testing.T) {
 	}
 }
 
+// TestBaselineRefreshGet_targetsAreLiveAndOmittedOffWatch pins the #1579
+// shape: enabled+scheduled both true was reachable while the loop covered
+// ZERO servers, and the DTO had no way to say so. With the counter wired the
+// counts are computed at REQUEST time (the loop recomputes per tick, so a
+// boot snapshot goes stale the moment a server is added); without it — serve,
+// or no loop — the keys are omitted entirely, so the page cannot alarm on a
+// zero that means "nobody is counting".
+func TestBaselineRefreshGet_targetsAreLiveAndOmittedOffWatch(t *testing.T) {
+	srv, _ := newSupervisorServer(t)
+	srv.baselineRefreshDefaults = BaselineRefreshDefaults{Enabled: true, Scheduled: true}
+
+	// No counter wired: both keys absent, not zero.
+	_, body := doServersReq(t, srv, "GET", "/api/baseline-refresh", "")
+	var raw map[string]any
+	if err := json.Unmarshal(body, &raw); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := raw["targets"]; ok {
+		t.Fatalf("targets serialised without a counter wired: %s (a real zero and \"nobody is counting\" must differ)", body)
+	}
+
+	// Wired: live values, re-read per request.
+	n := 0
+	srv.baselineRefreshTargets = func() (int, int) { n++; return n, 2 }
+	var got baselineRefreshDTO
+	_, body = doServersReq(t, srv, "GET", "/api/baseline-refresh", "")
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Targets == nil || *got.Targets != 1 || got.SkippedS3Only != 2 {
+		t.Fatalf("first read: %+v, want targets=1 skipped=2", got)
+	}
+	_, body = doServersReq(t, srv, "GET", "/api/baseline-refresh", "")
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Targets == nil || *got.Targets != 2 {
+		t.Fatalf("second read: %+v; the count is a boot snapshot, not live — a server added later would "+
+			"keep the stale zero and the alarm would cry wolf forever", got)
+	}
+}
+
 // Enabled is the loop's boot-time liveness and must NOT be implied by the
 // presence of an override: a daemon started with no refresh schedule runs no
 // loop, so a saved setting is dormant until a restart and the panel has to keep

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -174,6 +174,15 @@ type Config struct {
 	// hides the panel).
 	RotationDefaults RotationDefaults
 
+	// BaselineRefreshTargets reports, LIVE, how many servers the next refresh
+	// tick will cover and how many were skipped for keeping their baselines
+	// only in S3. Wired by the watch daemon only when the refresh loop is
+	// scheduled; nil everywhere else, and the DTO then omits the counts. Live
+	// rather than a boot snapshot because the loop recomputes its target set
+	// every tick — a snapshot would go stale the moment a server is added,
+	// which is exactly the fresh-install shape #1579 is about (enabled and
+	// scheduled both true, zero servers refreshable, and the page silent).
+	BaselineRefreshTargets func() (targets, skippedS3Only int)
 	// BaselineRefreshDefaults carries the daemon's baseline-refresh flag/env
 	// values, the fallback the settings panel reports when no console override
 	// is saved. Same role as RotationDefaults above.
@@ -301,6 +310,8 @@ type Server struct {
 	// baselineRefreshDefaults is the fallback GET /api/baseline-refresh reports
 	// when no console override is saved.
 	baselineRefreshDefaults BaselineRefreshDefaults
+	// baselineRefreshTargets is Config.BaselineRefreshTargets (nil off watch).
+	baselineRefreshTargets func() (targets, skippedS3Only int)
 	// version is the running build's version string (Config.Version).
 	version string
 	// archiveFetcher reads one archive source for the browsing endpoints —
@@ -505,6 +516,7 @@ func New(cfg Config) (*Server, error) {
 		rotationDefaults:        cfg.RotationDefaults,
 		backupSettingsDefaults:  cfg.BackupSettingsDefaults,
 		baselineRefreshDefaults: cfg.BaselineRefreshDefaults,
+		baselineRefreshTargets:  cfg.BaselineRefreshTargets,
 		version:                 cfg.Version,
 		cm:                      newConnManager(cfg.Registry, profileActive),
 		authPath:                authPath,

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -4097,12 +4097,15 @@ try {
               // says "server(s)" without the number tells an operator nothing
               // about how much is uncovered.
               skipNote: t.includes(skipped + " server(s) keep backups only in S3"),
-              // The claim the skip note must NOT make: these servers cannot
-              // rebuild from the bucket, because the fold writes its Parquet
-              // to the local directory they do not have. Read from the skip
-              // PARAGRAPH, not the card: the saving sentence above legitimately
-              // says "reuses nothing" about the same servers.
-              skipPromisesReuse: /read the bucket|reus|recorded changes/i.test(
+              // The skip note may MENTION the cheaper update, but only to DENY
+              // it: these servers cannot get one, because the fold writes its
+              // Parquet to the local directory they do not have. An unnegated
+              // mention is the promise the first version of this note made
+              // ("their scheduled backups read the bucket instead"). Read from
+              // the skip PARAGRAPH, not the card: the saving sentence above
+              // legitimately says "reuses nothing" about the same servers.
+              skipPromisesReuse: ((line) => /read the bucket/i.test(line)
+                || (/(reus|recorded changes)/i.test(line) && !/\b(never|cannot|no)\b/i.test(line)))(
                 Array.from(el.querySelectorAll("p")).map((p) => p.textContent)
                   .find((x) => x.includes("keep backups only in S3")) || ""),
               pill: (el.querySelector(".bkr-state") || {}).textContent || "",

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -4059,7 +4059,7 @@ try {
     : bad("layout: a card left alone on the last row spans it", JSON.stringify(bandRow));
 
   // ── Scenario 17g3 — the disk-space card, every state it can be in ──
-  // Calls the REAL backupRefreshCard with each of the 16 DTOs the daemon can
+  // Calls the REAL backupRefreshCard with each of the 96 DTOs the daemon can
   // serve and reads the rendered element. A Go guard over the source can only
   // see that both `br.enabled` and `br.scheduled` appear somewhere in the
   // function, so inverting either condition survives it while the card tells
@@ -4077,10 +4077,30 @@ try {
       for (const enabled of [false, true]) {
         for (const scheduled of [false, true]) {
           for (const source of ["default", "override"]) {
-            const el = backupRefreshCard({ carry_forward_unchanged: on, enabled, scheduled, source });
+          // The two #1579 dimensions. `targets` is absent off a watch daemon
+          // (no loop to count) and a real 0 on one whose loop covers nothing;
+          // the alarm must separate those, so undefined and 0 are distinct
+          // values here, not one falsy case.
+          for (const targets of [undefined, 0, 1]) {
+          for (const skipped of [0, 2]) {
+            const el = backupRefreshCard({ carry_forward_unchanged: on, enabled, scheduled, source,
+              targets, skipped_s3_only: skipped });
             const t = el.innerText || el.textContent || "";
             rows.push({
-              on, enabled, scheduled, source,
+              on, enabled, scheduled, source, targets, skipped,
+              alarm: t.includes("no server can be refreshed"),
+              // The count is read back, not just the sentence: a card that
+              // says "server(s)" without the number tells an operator nothing
+              // about how much is uncovered.
+              skipNote: t.includes(skipped + " server(s) keep backups only in S3"),
+              // The claim the skip note must NOT make: these servers cannot
+              // rebuild from the bucket, because the fold writes its Parquet
+              // to the local directory they do not have. Read from the skip
+              // PARAGRAPH, not the card: the saving sentence above legitimately
+              // says "reuses nothing" about the same servers.
+              skipPromisesReuse: /read the bucket|reus|recorded changes/i.test(
+                Array.from(el.querySelectorAll("p")).map((p) => p.textContent)
+                  .find((x) => x.includes("keep backups only in S3")) || ""),
               pill: (el.querySelector(".bkr-state") || {}).textContent || "",
               dormant: t.includes("Nothing uses this yet"),
               middle: t.includes("Nothing refreshes all servers on one timer"),
@@ -4094,6 +4114,8 @@ try {
               live: /\b(live|running)\b/i.test(t),
               buttons: Array.from(el.querySelectorAll("button")).map((b) => b.textContent),
             });
+          }
+          }
           }
         }
       }
@@ -4114,9 +4136,18 @@ try {
     || r.live
     // the saving never appears without the condition it actually has
     || !r.saving
+    // #1579: the alarm fires exactly when a timer is on over zero refreshable
+    // servers. An ABSENT count (no loop in this daemon) is not zero, and that
+    // is the whole point of the strict compare in the card.
+    || r.alarm !== (r.scheduled && r.targets === 0)
+    // the skip note appears with its count, and only when servers were skipped
+    || r.skipNote !== (r.skipped > 0)
+    // and it never promises those servers an update from the bucket, which
+    // needs the local directory they lack
+    || r.skipPromisesReuse
     // the hand-it-back button appears only where there is something to hand back
     || (r.buttons.length === 2) !== (r.source === "override"));
-  cardStates.length === 16 && cardBad.length === 0
+  cardStates.length === 96 && cardBad.length === 0
     ? ok("backups: the disk-space card reports every state it can be in")
     : bad("backups: the disk-space card reports every state it can be in",
         JSON.stringify({ n: cardStates.length, wrong: cardBad.slice(0, 4) }));

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -4059,7 +4059,7 @@ try {
     : bad("layout: a card left alone on the last row spans it", JSON.stringify(bandRow));
 
   // ── Scenario 17g3 — the disk-space card, every state it can be in ──
-  // Calls the REAL backupRefreshCard with each of the 96 DTOs the daemon can
+  // Calls the REAL backupRefreshCard with each of the 144 DTOs the daemon can
   // serve and reads the rendered element. A Go guard over the source can only
   // see that both `br.enabled` and `br.scheduled` appear somewhere in the
   // function, so inverting either condition survives it while the card tells
@@ -4082,7 +4082,11 @@ try {
           // the alarm must separate those, so undefined and 0 are distinct
           // values here, not one falsy case.
           for (const targets of [undefined, 0, 1]) {
-          for (const skipped of [0, 2]) {
+          // 0, 1 and 2: a predicate that agrees with "> 0" on {0, 2} but hides
+          // the note for a SINGLE skipped server survives a two-value axis, and
+          // one S3-only server is both the common deployment and the value a
+          // later pluralization edit is most likely to special-case.
+          for (const skipped of [0, 1, 2]) {
             const el = backupRefreshCard({ carry_forward_unchanged: on, enabled, scheduled, source,
               targets, skipped_s3_only: skipped });
             const t = el.innerText || el.textContent || "";
@@ -4147,7 +4151,7 @@ try {
     || r.skipPromisesReuse
     // the hand-it-back button appears only where there is something to hand back
     || (r.buttons.length === 2) !== (r.source === "override"));
-  cardStates.length === 96 && cardBad.length === 0
+  cardStates.length === 144 && cardBad.length === 0
     ? ok("backups: the disk-space card reports every state it can be in")
     : bad("backups: the disk-space card reports every state it can be in",
         JSON.stringify({ n: cardStates.length, wrong: cardBad.slice(0, 4) }));


### PR DESCRIPTION
closes #1579

## Summary
- `GET /api/baseline-refresh` gains `targets` (pointer, omitted where no counter is wired) and `skipped_s3_only`, computed live per request via the loop's own `baselineRefreshTargets` — the loop recomputes per tick, so the page does too, and a fresh install's zero heals without a restart.
- The Backups & disk space card alarms on `scheduled && targets === 0` ("the refresh timer is running, but no server can be refreshed..."), counts the S3-only skips, and the "covers every server" sentence is scoped to servers that keep backups on this machine — it was permanently wrong for an S3-only server.
- `baselineRefreshTargets` became pure (returns the skipped names); the per-server S3-only warning moved to `logSkippedRefreshTargets` at the two dispatching call sites, preserving today's log visibility while the GET path stays quiet.

## Test plan
- [x] `TestBaselineRefreshGet_targetsAreLiveAndOmittedOffWatch`: keys absent without the callback (a real zero and "nobody is counting" must differ), live values re-read per request
- [x] Targets test asserts the skipped list is exactly the S3-only server (unconfigured entries are not "skipped")
- [x] Wire test pins `targets`/`skipped_s3_only` serialization + reads and the strict `br.targets === 0` alarm
- [x] Red checks: dropping the DTO fill, disabling the alarm branch, and not reporting the skip each fail exactly one test; restored and re-greened
- [x] `go test ./... -count=1` green
