### PR TITLE
console-e2e: put the waitForFunction timeouts where Playwright reads them

### DIFF
--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -43,6 +43,55 @@ const results = [];
 const ok = (name) => results.push({ name, pass: true });
 const bad = (name, detail) => results.push({ name, pass: false, detail });
 
+// Playwright's signature is waitForFunction(pageFunction, arg, options) —
+// options are the THIRD parameter, unlike Puppeteer's second. Passing
+// { timeout: N } in the arg slot serializes it as the page function's
+// argument and discards it, so the wait silently runs on the 30-second
+// default: measured at 30011 ms for the two-arg form against 2003 ms for the
+// three-arg one (#1589).
+//
+// Every budget in this file was written that way, so none of the stated
+// numbers had ever run. Adopting them at the position fix would have enabled
+// ~25 untested budgets at once on a suite whose flakes are load-sensitive, so
+// the ones below 30s were DROPPED instead of moved: the default is what the
+// suite is actually green with, and a number that has never been exercised is
+// worse than no number. Only the 60s verification wait was moved to the third
+// slot, because that one was being silently SHORTENED to 30s — the single
+// case where the bug could cause a flake rather than mask one.
+//
+// This guard keeps the shape from coming back. It reads its own source, so a
+// call written in the two-arg form fails the run with the line number instead
+// of quietly waiting 30s. waitForSelector is deliberately not scanned: its
+// options ARE the second parameter.
+{
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  // Assembled rather than written whole: the scan reads this very file, and a
+  // literal here would be a call site of its own to parse.
+  const NEEDLE = "waitFor" + "Function(";
+  const misplaced = [];
+  let i = 0;
+  while ((i = src.indexOf(NEEDLE, i)) >= 0) {
+    let depth = 0, j = i + NEEDLE.length - 1;
+    const start = j, topCommas = [];
+    for (; j < src.length; j++) {
+      const c = src[j];
+      if (c === "(" || c === "{" || c === "[") depth++;
+      else if (c === ")" || c === "}" || c === "]") { depth--; if (depth === 0) { j++; break; } }
+      else if (c === "," && depth === 1) topCommas.push(j);
+    }
+    // Two top-level arguments and a timeout in the second one: the options
+    // object is sitting in the arg slot.
+    if (topCommas.length === 1 && /timeout:\s*\d+/.test(src.slice(topCommas[0], j))) {
+      misplaced.push(src.slice(0, i).split("\n").length);
+    }
+    i = j;
+  }
+  misplaced.length === 0
+    ? ok("suite: every waitForFunction timeout is in the options slot")
+    : bad("suite: every waitForFunction timeout is in the options slot",
+        `lines ${misplaced.join(", ")} pass options as the page-function argument, so the stated timeout never applies`);
+}
+
 const browser = await chromium.launch({ headless: true, channel: CHANNEL });
 const page = await browser.newPage({ viewport: { width: 1300, height: 1000 } });
 const jsErrors = [];
@@ -63,7 +112,7 @@ try {
   // bare name in evaluate's global scope, never as a window property.
   let monitor = false;
   try {
-    await page.waitForFunction(() => typeof capsCache !== "undefined" && capsCache.monitor === true, { timeout: 8000 });
+    await page.waitForFunction(() => typeof capsCache !== "undefined" && capsCache.monitor === true);
     monitor = true;
   } catch (_) {
     monitor = await page.evaluate(() => typeof capsCache !== "undefined" && !!capsCache.monitor);
@@ -1048,7 +1097,7 @@ try {
     // words the command line refuses with) and writes nothing.
     await page.fill('#ap-flag-form input[name="flag"]', "orphan");
     await page.click('#ap-flag-form button[type="submit"]');
-    await page.waitForFunction(() => !document.getElementById("toast-error").hidden, { timeout: 5000 });
+    await page.waitForFunction(() => !document.getElementById("toast-error").hidden);
     const apRefusal = await page.evaluate(async () => ({
       toast: document.getElementById("toast-error").textContent,
       flags: (await api("/api/access-profiles")).flags.length,
@@ -1059,11 +1108,11 @@ try {
 
     // Tear down through the buttons: the rule, the profile, then the flag.
     await page.click("#ap-rules .ap-row button");
-    await page.waitForFunction(() => document.querySelectorAll("#ap-rules .ap-row").length === 0, { timeout: 10000 });
+    await page.waitForFunction(() => document.querySelectorAll("#ap-rules .ap-row").length === 0);
     await page.click("#ap-profiles .ap-row button");
-    await page.waitForFunction(() => document.querySelectorAll("#ap-profiles .ap-row").length === 0, { timeout: 10000 });
+    await page.waitForFunction(() => document.querySelectorAll("#ap-profiles .ap-row").length === 0);
     await page.click("#ap-flags .ap-row button");
-    await page.waitForFunction(() => document.querySelectorAll("#ap-flags .ap-row").length === 0, { timeout: 10000 });
+    await page.waitForFunction(() => document.querySelectorAll("#ap-flags .ap-row").length === 0);
     const apAfter = await page.evaluate(() => api("/api/access-profiles"));
     (apAfter.flags.length === 0 && apAfter.profiles.length === 0 && apAfter.rules.length === 0)
       ? ok("access profiles: the Remove buttons take the rule, the profile and the flag back off the index")
@@ -1403,7 +1452,7 @@ try {
   await page.waitForFunction(() => {
     const b = document.querySelector("#recover-out .ctx-banner .badge");
     return b && b.textContent === "CASCADE";
-  }, { timeout: 8000 });
+  });
   const cas = await page.evaluate(() => ({
     banner: (document.querySelector("#recover-out .ctx-banner") || {}).textContent || "",
     sql: (document.querySelector("#recover-out #sql-panel .code") || {}).textContent || "",
@@ -1476,7 +1525,7 @@ try {
   // pk=4: exists ONLY in the baseline (no events) — a binlog-only reconstruct
   // cannot resolve it, so this pins the baseline half of baseline+deltas.
   await page.evaluate(async () => { const f = document.getElementById("recover-form"); f.elements.pk.value = "4"; await runState(f, false); });
-  await page.waitForFunction(() => /d@example\.com/.test((document.querySelector("#modal .state-modal") || {}).textContent || ""), { timeout: 10000 });
+  await page.waitForFunction(() => /d@example\.com/.test((document.querySelector("#modal .state-modal") || {}).textContent || ""));
   const tt4 = await page.evaluate(() => {
     const cells = {};
     document.querySelectorAll("#modal .state-modal .statetable tr").forEach((tr) => {
@@ -1491,7 +1540,7 @@ try {
   // pk=2: in the baseline, then DELETEd — must render the deleted note, not an
   // empty table and not the stale baseline value.
   await page.evaluate(async () => { const f = document.getElementById("recover-form"); f.elements.pk.value = "2"; await runState(f, false); });
-  await page.waitForFunction(() => !!document.querySelector("#modal .state-modal .deleted-note"), { timeout: 10000 });
+  await page.waitForFunction(() => !!document.querySelector("#modal .state-modal .deleted-note"));
   const tt2 = await page.evaluate(() => (document.querySelector("#modal .state-modal .deleted-note") || {}).textContent || "");
   /Row was deleted/.test(tt2)
     ? ok("restore: a deleted row renders the deleted note")
@@ -1959,10 +2008,10 @@ try {
   // Wait on the TILES, not on the scope lines: waiting on the thing under test
   // turns a missing scope into a driver timeout that aborts the rest of the run
   // instead of one legible failure.
-  await page.waitForFunction(() => document.querySelectorAll(".ov-stat").length === 4, { timeout: 10000 });
+  await page.waitForFunction(() => document.querySelectorAll(".ov-stat").length === 4);
   // The coverage card fills independently (#1352); its freshness clock is part
   // of what this scenario pins, so wait for that fill too.
-  await page.waitForFunction(() => !!document.querySelector(".cov-card .cov-asof"), { timeout: 10000 });
+  await page.waitForFunction(() => !!document.querySelector(".cov-card .cov-asof"));
   const ovLive = await page.evaluate(() => ({
     scopes: Array.from(document.querySelectorAll(".ov-stat")).map((n) => (n.querySelector(".ov-stat-scope") || {}).textContent || ""),
     win: (document.querySelector(".ov-coverage") || {}).textContent || "",
@@ -2168,7 +2217,7 @@ try {
   // enabled, and the fixture snapshot (1 table, anchored at
   // binlog.000001:50) must be listed.
   await page.evaluate(() => navigate("baselines"));
-  await page.waitForFunction(() => Array.from(document.querySelectorAll(".stg-row")).some((r) => r.textContent.includes("binlog.000001:50")), { timeout: 10000 });
+  await page.waitForFunction(() => Array.from(document.querySelectorAll(".stg-row")).some((r) => r.textContent.includes("binlog.000001:50")));
   const stg = await page.evaluate(() => {
     // #1415: the Create action moved to the context strip (page level); the
     // uniform table count moved there too, so the row carries only what
@@ -2597,7 +2646,7 @@ try {
       /To load into MySQL/.test((c.querySelector(".bk-lane-t") || {}).textContent || ""));
     return !!card && /Ready: every table as of/.test(card.textContent) &&
       Array.from(card.querySelectorAll("button")).some((b) => /Download \.sql backup/.test(b.textContent));
-  }, { timeout: 30000 });
+  });
   ok("sqlx: after the run settles the card offers the finished build for download");
 
   // The download wire: gunzip the archive in node and read the actual SQL.
@@ -2679,7 +2728,7 @@ try {
         const card = Array.from(v.querySelectorAll(".bk-lane")).find((c) =>
           /To load into MySQL/.test((c.querySelector(".bk-lane-t") || {}).textContent || ""));
         return !!card && /Last build failed/.test(card.textContent);
-      }, { timeout: 15000 });
+      });
       const gapMsg = await page.evaluate(() => {
         const v = document.querySelector(".view");
         const card = Array.from(v.querySelectorAll(".bk-lane")).find((c) =>
@@ -2718,15 +2767,13 @@ try {
 
   await page.evaluate(() => navigate("baselines"));
   await page.waitForFunction(() => location.pathname === "/baselines"
-    && Array.from(document.querySelectorAll(".ov-panel-title")).some((h) => /Backups/.test(h.textContent)),
-    { timeout: 10000 });
+    && Array.from(document.querySelectorAll(".ov-panel-title")).some((h) => /Backups/.test(h.textContent)));
   ok("protect: /baselines renders the snapshot panel");
 
   await page.evaluate(() => navigate("verification"));
   await page.waitForFunction(() => location.pathname === "/verification"
     && Array.from(document.querySelectorAll("h1.page-title")).some((h) => /Verification/.test(h.textContent))
-    && document.querySelectorAll(".vfy-region").length >= 3,
-    { timeout: 10000 });
+    && document.querySelectorAll(".vfy-region").length >= 3);
   ok("protect: /verification renders its three regions");
 
   // Scenario 15w — the page-header Docs link (#1450). One route → slug table
@@ -2748,8 +2795,7 @@ try {
     : bad("docs link: Verification header links to /docs/guides/verify/ in a new tab", JSON.stringify(docsVfy));
   await page.evaluate(() => navigate("events"));
   await page.waitForFunction(() => location.pathname === "/events"
-    && Array.from(document.querySelectorAll("h1.page-title")).some((h) => /Events/.test(h.textContent)),
-    { timeout: 10000 });
+    && Array.from(document.querySelectorAll("h1.page-title")).some((h) => /Events/.test(h.textContent)));
   const docsEvents = await docsLinkOf();
   docsEvents.n === 1 && docsEvents.href === "https://www.dbtrail.com/docs/guides/recovery/"
     ? ok("docs link: follows the route change to Events")
@@ -2757,7 +2803,7 @@ try {
   // Put the page back: 15v below reads the Verification form as it found it.
   await page.evaluate(() => navigate("verification"));
   await page.waitForFunction(() => location.pathname === "/verification"
-    && document.querySelectorAll(".vfy-region").length >= 3, { timeout: 10000 });
+    && document.querySelectorAll(".vfy-region").length >= 3);
 
   // Scenario 15v — the verification page rework (#1417/#1418/#1419/#1420),
   // driven END TO END against the real daemon: a real recover-inputs run over
@@ -2884,7 +2930,7 @@ try {
     if (sel.value !== "recover-inputs") { sel.value = "recover-inputs"; sel.dispatchEvent(new Event("change")); }
     document.querySelector(".vfy-run").click();
   });
-  await page.waitForFunction(() => document.querySelector(".vfy-results .chip-done") !== null, { timeout: 60000 });
+  await page.waitForFunction(() => document.querySelector(".vfy-results .chip-done") !== null, undefined, { timeout: 60000 });
   const vfyDone = await page.evaluate(() => ({
     verdictSentence: (document.querySelector(".vfy-results .form-hint") || {}).textContent || "",
     rows: document.querySelectorAll(".vfy-results .vfy-row").length,
@@ -2897,7 +2943,7 @@ try {
   // (e) history (#1417): the finished run is a disclosure row that expands to
   // its per-table detail — data the old renderer dropped on the floor — and
   // LAST VERIFIED wears the age treatment, not the live one (#1420).
-  await page.waitForFunction(() => document.querySelectorAll(".vfy-histrow").length > 0, { timeout: 10000 });
+  await page.waitForFunction(() => document.querySelectorAll(".vfy-histrow").length > 0);
   const vfyHist = await page.evaluate(() => {
     const row = document.querySelector(".vfy-histrow");
     row.click();
@@ -2953,8 +2999,7 @@ try {
   // existing link and bookmark drops the operator on Overview.
   await page.evaluate(() => navigate("storage"));
   await page.waitForFunction(() => location.pathname === "/retention"
-    && Array.from(document.querySelectorAll(".ov-panel-title")).some((h) => /S3 archiving/.test(h.textContent)),
-    { timeout: 10000 });
+    && Array.from(document.querySelectorAll(".ov-panel-title")).some((h) => /S3 archiving/.test(h.textContent)));
   const storageTitles = await page.evaluate(() =>
     Array.from(document.querySelectorAll(".ov-panel-title")).map((h) => h.textContent));
   (!storageTitles.some((t) => /Baseline snapshots|Backups|Verification/.test(t)))
@@ -3988,7 +4033,7 @@ try {
   // On This daemon, which is the half that still carries two or more
   // unconditional cards after the split (#1543); Retention has one.
   await page.evaluate(() => navigate("daemon"));
-  await page.waitForFunction(() => location.pathname === "/daemon" && document.querySelectorAll(".cards .card").length >= 2, { timeout: 10000 });
+  await page.waitForFunction(() => location.pathname === "/daemon" && document.querySelectorAll(".cards .card").length >= 2);
   const tints = await page.evaluate(() => {
     const cards = Array.from(document.querySelectorAll(".cards .card")).slice(0, 2);
     return cards.map((c) => getComputedStyle(c).backgroundColor);
@@ -4013,7 +4058,7 @@ try {
   const rowFill = [];
   for (const route of ["retention", "daemon"]) {
     await page.evaluate((r) => navigate(r), route);
-    await page.waitForFunction(() => document.querySelectorAll(".cards .card").length >= 1, { timeout: 10000 });
+    await page.waitForFunction(() => document.querySelectorAll(".cards .card").length >= 1);
     rowFill.push(await page.evaluate((r) => {
       const g = document.querySelector(".cards");
       const gw = g.getBoundingClientRect().width;
@@ -4047,7 +4092,7 @@ try {
   await page.setViewportSize({ width: 1000, height: 1000 });
   await page.evaluate(() => navigate("connect"));
   await page.waitForFunction(() => location.pathname === "/connect"
-    && document.querySelectorAll(".cards .card").length >= 3, { timeout: 10000 });
+    && document.querySelectorAll(".cards .card").length >= 3);
   const bandRow = await page.evaluate(() => {
     const g = document.querySelector(".cards");
     const gw = g.getBoundingClientRect().width;
@@ -4065,7 +4110,7 @@ try {
   // one.
   await page.evaluate(() => navigate("daemon"));
   await page.waitForFunction(() => location.pathname === "/daemon"
-    && document.querySelectorAll(".cards .card").length >= 2, { timeout: 10000 });
+    && document.querySelectorAll(".cards .card").length >= 2);
   // rows > 1 asserts the band is actually the wrapped case, so a future width
   // change that stops wrapping here cannot pass this vacuously.
   (bandRow.rows > 1 && bandRow.left <= 2)
@@ -4265,7 +4310,7 @@ try {
   // sleep could pass this vacuously against a half-rendered page.
   await page.evaluate(() => navigate("baselines"));
   await page.waitForFunction(() => location.pathname === "/baselines"
-    && document.querySelector(".view .ov-panel-title"), { timeout: 10000 });
+    && document.querySelector(".view .ov-panel-title"));
   const dupCard = await page.evaluate(() => !!document.querySelector(".view .bkr-head"));
   (!dupCard)
     ? ok("backups: the carry-forward card is not duplicated on the Backups page")
@@ -4304,7 +4349,7 @@ try {
   // ABORTS the suite at this line, hiding the four assertions below and every
   // later scenario. Catch it and let the assertions report the actual shape.
   await page.waitForFunction(() => location.pathname === "/connect"
-    && document.querySelectorAll(".view .cn-card").length === 3, { timeout: 15000 })
+    && document.querySelectorAll(".view .cn-card").length === 3)
     .catch(() => {});
   // The mock's field labels come from the REAL bundle manifest, not from a
   // second hand-maintained copy: renaming either side alone rings below. A
@@ -4799,7 +4844,7 @@ try {
   scr.tsTitle.startsWith("UTC; in your local time:") ? ok("schema changes: rows carry the local-time tooltip") : bad("schema changes: rows carry the local-time tooltip", JSON.stringify(scr.tsTitle));
   scr.count === "2" ? ok("schema changes: the count line says 2") : bad("schema changes: the count line says 2", JSON.stringify(scr.count));
   await page.selectOption('#sc-form select[name="ddl_type"]', "CREATE");
-  await page.waitForFunction(() => document.querySelectorAll("#sc-rows .sc-row").length === 1, { timeout: 10000 });
+  await page.waitForFunction(() => document.querySelectorAll("#sc-rows .sc-row").length === 1);
   const scf = await page.evaluate(() => Array.from(document.querySelectorAll("#sc-rows .sc-row")).map((r) => r.textContent).join(" | "));
   (scf.includes("e2e-ddl-create") && !scf.includes("e2e-ddl-alter"))
     ? ok("schema changes: the type filter narrows to the CREATE through the API")

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -15,6 +15,7 @@
 import { chromium } from "playwright";
 import zlib from "node:zlib";
 import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { execSync } from "node:child_process";
 
 const URL = process.env.CONSOLE_URL || "http://127.0.0.1:8090";
@@ -64,7 +65,9 @@ const bad = (name, detail) => results.push({ name, pass: false, detail });
 // of quietly waiting 30s. waitForSelector is deliberately not scanned: its
 // options ARE the second parameter.
 {
-  const src = readFileSync(new URL(import.meta.url), "utf8");
+  // fileURLToPath, not `new URL`: this file shadows the global URL with the
+  // console's address (line 20), so the constructor form throws here.
+  const src = readFileSync(fileURLToPath(import.meta.url), "utf8");
   // Assembled rather than written whole: the scan reads this very file, and a
   // literal here would be a call site of its own to parse.
   const NEEDLE = "waitFor" + "Function(";


### PR DESCRIPTION
closes #1589

## Summary

`waitForFunction(pageFunction, arg, options)` — options are the **third** parameter (Puppeteer's are the second). 28 of the 34 calls passed `{ timeout: N }` in the `arg` slot, where it is serialized as the page function's argument and discarded, so all of them ran on the 30-second default. Measured against the repo's Playwright: **30011 ms** for the two-arg form vs **2003 ms** for the three-arg one.

## The budget decision, not just the position

None of the stated numbers had ever run, so moving them all would enable ~25 untested budgets at once on a load-sensitive suite. So:

- **27 budgets under 30s: dropped.** The default is what the suite is actually green with; a number that has never been exercised is worse than no number.
- **The 60s verification wait: moved to the options slot.** That one was being silently *shortened* to 30s — the single case where the bug could cause a flake rather than mask one.

All rewritten call sites have page functions taking no parameter, so removing the second argument is behavior-neutral (the three calls that do take an argument were already correctly shaped).

## Guard

The suite scans its own source and reports offending line numbers as an ordinary failed check, so the shape cannot come back silently. It skips `waitForSelector` (whose options really are the second parameter) and assembles its search string at runtime so the scan does not match itself.

**Second commit (review pass 1):** the first census counted top-level commas, and so did the guard, so a two-arg call with a trailing comma (the page-load wait at the top of the suite) survived both. The guard now counts arguments, and a positive control runs it over an assembled fixture (single-line, multi-line-with-trailing-comma, and the legitimate three-arg form) before scanning the suite, so a scanner that stops matching fails instead of reading as all clear. That control caught a `src`/`text` mix-up in its own first draft.

Verified standalone: green on this branch; red on `origin/main` naming all 28 lines; red on the branch with the trailing-comma call reintroduced; the control fails when the scanner is deliberately broken.

## Correction to the issue

The issue said 30 of 31; the file has 34 calls and 28 were misshaped (the 28th is the one the comma census missed).
