### PR TITLE
views: bind the events view by schema group, not by archived file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **The `events` view binds one Parquet footer per SCHEMA, not per archived
+  file** (#1535). `archive_state` gains `column_set`, the archived file's own
+  column set, and `bintrail views` / the console SQL panel now emit one
+  `read_parquet` per distinct set — each with an explicit file list and
+  `union_by_name = false`, padding the columns a group lacks with `NULL` and
+  joining the groups with `UNION ALL BY NAME`. A view re-binds on every
+  statement, so what used to cost one footer read per archived file, forever
+  growing, now costs one per group; the S3 LIST the glob needed goes away with
+  it. Explicit paths still carry `hive_partitioning`, so `bintrail_id`,
+  `event_date` and `event_hour` are still synthesized and a filter on them
+  still prunes files.
+  Rotation records the set for archives it writes. For archives already on
+  disk, `bintrail archive reconcile --repair` records it from the footer it
+  already reads for `row_count` — no extra file opens, and not gated on
+  `--deep`. Until every registered partition has one, the generated SQL keeps
+  the globbed form and says so, naming the command: the file list comes from
+  the registry, so grouping a partial one would leave the unrecorded
+  partitions out of the view rather than merely slow to bind. `archive
+  reconcile` now migrates the index schema before reading, like the other
+  archive_state readers.
+
 ## [0.76.0] - 2026-09-01
 
 ### Added
@@ -46,7 +68,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [0.75.0] - 2026-09-01
-
 ### Fixed
 - **A DuckDB schema file now refuses a dropped table up front, by name, before
   it creates any view.** When a table is dropped at the source it leaves the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **The `events` view binds one Parquet footer per SCHEMA, not per archived
   file** (#1535). `archive_state` gains `column_set`, the archived file's own
-  column set, and `bintrail views` / the console SQL panel now emit one
-  `read_parquet` per distinct set — each with an explicit file list and
+  column set, and `bintrail views` and the console's DuckDB-schema download now
+  emit one `read_parquet` per distinct set — each with an explicit file list and
   `union_by_name = false`, padding the columns a group lacks with `NULL` and
   joining the groups with `UNION ALL BY NAME`. A view re-binds on every
   statement, so what used to cost one footer read per archived file, forever
@@ -32,9 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   naming the command. The file list comes from the registry rather than a glob,
   so grouping a partial one would leave those partitions out of the view rather
   than merely slow to bind — and a listed file that is not there makes DuckDB
-  refuse the whole script, `events` and every state view with it. The console
-  SQL panel additionally retries over the whole layout if the grouped views do
-  not bind, so a registry fault degrades the panel to slow instead of blank.
+  refuse the whole script, `events` and every state view with it.
   **A grouped file does not follow the layout**: it names its archives
   explicitly, so partitions archived after it was generated are not in it. The
   header says which of the two forms the file uses; regenerate on the schedule

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,15 +19,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it. Explicit paths still carry `hive_partitioning`, so `bintrail_id`,
   `event_date` and `event_hour` are still synthesized and a filter on them
   still prunes files.
-  Rotation records the set for archives it writes. For archives already on
-  disk, `bintrail archive reconcile --repair` records it from the footer it
-  already reads for `row_count` — no extra file opens, and not gated on
-  `--deep`. Until every registered partition has one, the generated SQL keeps
-  the globbed form and says so, naming the command: the file list comes from
-  the registry, so grouping a partial one would leave the unrecorded
-  partitions out of the view rather than merely slow to bind. `archive
-  reconcile` now migrates the index schema before reading, like the other
-  archive_state readers.
+  Rotation records the set for archives it writes, and `restore-index` records
+  it for archives it re-registers. For archives already on disk, `bintrail
+  archive reconcile --repair` records it from the footer it already reads for
+  `row_count` — no extra file opens. **On an S3 archive that means `--deep
+  --repair`**: without `--deep` no remote footer is read, so the repair records
+  nothing. The first reconcile after upgrading reports drift on every partition
+  that predates the column; that is the backfill asking to be run, not a new
+  fault.
+  Until every registered partition has a recorded set AND its file is where the
+  registry says it is, the generated SQL keeps the globbed form and says so,
+  naming the command. The file list comes from the registry rather than a glob,
+  so grouping a partial one would leave those partitions out of the view rather
+  than merely slow to bind — and a listed file that is not there makes DuckDB
+  refuse the whole script, `events` and every state view with it. The console
+  SQL panel additionally retries over the whole layout if the grouped views do
+  not bind, so a registry fault degrades the panel to slow instead of blank.
+  **A grouped file does not follow the layout**: it names its archives
+  explicitly, so partitions archived after it was generated are not in it. The
+  header says which of the two forms the file uses; regenerate on the schedule
+  rotation archives on. `archive reconcile` now migrates `archive_state` before
+  reading it (that table only — its dry run is a cron drift monitor, and the
+  full migration also touches `binlog_events`).
 
 ## [0.76.0] - 2026-09-01
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -534,6 +534,24 @@ duckdb -init views.sql lake.db
 The `state_*` views are the baseline, not the table right now; changes after
 it are in `events`, and joining the two is your query's job.
 
+**If the first row takes a long time to arrive**, the `events` view is reading
+your archives the slow way. DuckDB has to know the column set before it can run
+anything, and where bintrail cannot tell it, DuckDB works it out by opening
+every archived file. That happens once per statement, so the wait grows with
+the archive.
+
+bintrail records each archived file's column set when it writes it. Archives
+written before that was recorded do not have one, and one file without it is
+enough to put the whole view back on the slow path. Record them once:
+
+```sh
+bintrail archive reconcile --index-dsn "$IDX" --archive-dir /data/archives --repair
+```
+
+Then regenerate `views.sql`. It reads each group of same-shaped files directly,
+which is a handful of reads instead of thousands. The file says which of the two
+it is doing, in a comment above the `events` view.
+
 **A table that stays current.** `bintrail export iceberg` does that join once
 per run and writes the result as an Apache Iceberg table per source table,
 appending only what changed since its last run, under a local warehouse:

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -548,9 +548,18 @@ enough to put the whole view back on the slow path. Record them once:
 bintrail archive reconcile --index-dsn "$IDX" --archive-dir /data/archives --repair
 ```
 
+If your archives live in S3, add `--deep`. Without it the scan never opens a
+remote file, so the repair records nothing and the wait stays exactly as it is.
+
 Then regenerate `views.sql`. It reads each group of same-shaped files directly,
 which is a handful of reads instead of thousands. The file says which of the two
 it is doing, in a comment above the `events` view.
+
+**A fast file names its archives one by one, so it stops covering new ones.**
+That is the trade: the slow file follows the layout because it describes it with
+a pattern, and the fast one cannot. Regenerate `views.sql` on the schedule your
+rotation archives on. Nothing warns you — a query over the last few hours simply
+comes back empty for them — so the file says so in its own header.
 
 **A table that stays current.** `bintrail export iceberg` does that join once
 per run and writes the result as an Apache Iceberg table per source table,

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -76,14 +76,14 @@ type Stats struct {
 	MinEventTS time.Time
 	MaxEventTS time.Time
 	// Columns is the canonical column set of the file that was just written
-	// (#1535), for the caller to record in archive_state.columns. Reported by
+	// (#1535), for the caller to record in archive_state.column_set. Reported by
 	// the writer rather than read back off BinlogEventColumns at the call site
 	// so the record cannot drift from the bytes: a build that ever writes a
 	// narrower file records the narrower set.
 	Columns string
 }
 
-// ColumnSet renders a Parquet column list as the canonical archive_state.columns
+// ColumnSet renders a Parquet column list as the canonical archive_state.column_set
 // value: lowercase names, SORTED, comma-joined.
 //
 // Sorted, because it is a grouping KEY (#1535). Two files holding the same
@@ -113,15 +113,6 @@ func ColumnSetOf(names []string) string {
 	return strings.Join(lower, ",")
 }
 
-// SplitColumnSet reads a stored archive_state.columns value back. Empty in,
-// nil out: a row with no recorded set is UNKNOWN, and the caller must not treat
-// it as a file with no columns.
-func SplitColumnSet(s string) []string {
-	if strings.TrimSpace(s) == "" {
-		return nil
-	}
-	return strings.Split(s, ",")
-}
 
 // ArchivePartition writes all rows from the named partition of binlog_events
 // to a Parquet file at outputPath. The db must have been opened with

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -8,7 +8,9 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/parquet-go/parquet-go"
@@ -73,6 +75,52 @@ type Stats struct {
 	Rows       int64
 	MinEventTS time.Time
 	MaxEventTS time.Time
+	// Columns is the canonical column set of the file that was just written
+	// (#1535), for the caller to record in archive_state.columns. Reported by
+	// the writer rather than read back off BinlogEventColumns at the call site
+	// so the record cannot drift from the bytes: a build that ever writes a
+	// narrower file records the narrower set.
+	Columns string
+}
+
+// ColumnSet renders a Parquet column list as the canonical archive_state.columns
+// value: lowercase names, SORTED, comma-joined.
+//
+// Sorted, because it is a grouping KEY (#1535). Two files holding the same
+// columns in different physical order are one schema group and must produce one
+// string; grouping on write order would split them for nothing, and each extra
+// group costs a footer read at bind time — the exact cost this exists to remove.
+func ColumnSet(cols []baseline.Column) string {
+	names := make([]string, len(cols))
+	for i, c := range cols {
+		names[i] = strings.ToLower(c.Name)
+	}
+	return ColumnSetOf(names)
+}
+
+// ColumnSetOf is ColumnSet over bare names — what a footer read produces.
+// Deduplicates: a repeated name would make the set a multiset and split a group
+// that is really the same schema.
+func ColumnSetOf(names []string) string {
+	lower := make([]string, 0, len(names))
+	for _, n := range names {
+		n = strings.ToLower(strings.TrimSpace(n))
+		if n != "" && !slices.Contains(lower, n) {
+			lower = append(lower, n)
+		}
+	}
+	slices.Sort(lower)
+	return strings.Join(lower, ",")
+}
+
+// SplitColumnSet reads a stored archive_state.columns value back. Empty in,
+// nil out: a row with no recorded set is UNKNOWN, and the caller must not treat
+// it as a file with no columns.
+func SplitColumnSet(s string) []string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	return strings.Split(s, ",")
 }
 
 // ArchivePartition writes all rows from the named partition of binlog_events
@@ -128,7 +176,9 @@ func ArchivePartition(ctx context.Context, db *sql.DB, dbName, partition, output
 	}
 	defer rows.Close()
 
-	var stats Stats
+	// Reported from the SAME list the writer above was built with, so the
+	// recorded set is the file's set by construction (#1535).
+	stats := Stats{Columns: ColumnSet(BinlogEventColumns)}
 	for rows.Next() {
 		// Every NOT NULL column is scanned defensively and its
 		// Valid bit is propagated into the nulls[] slice so the Parquet

--- a/internal/archive/columnset_test.go
+++ b/internal/archive/columnset_test.go
@@ -1,0 +1,195 @@
+package archive
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/parquet-go/parquet-go"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
+)
+
+// The stored value is a GROUPING KEY, so canonicalization is not cosmetic: two
+// files with the same columns must produce the same string, or they split into
+// two groups and each extra group costs a footer read at bind time — the exact
+// cost #1535 removes.
+func TestColumnSetOf_isCanonical(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   []string
+		want string
+	}{
+		{"sorted, not write order", []string{"query_text", "event_id", "commit_ts_us"}, "commit_ts_us,event_id,query_text"},
+		{"lowercased", []string{"Event_ID", "QUERY_TEXT"}, "event_id,query_text"},
+		{"trimmed", []string{" event_id ", "query_text"}, "event_id,query_text"},
+		{"deduplicated", []string{"event_id", "event_id", "query_text"}, "event_id,query_text"},
+		{"blanks dropped", []string{"event_id", "", "  "}, "event_id"},
+		{"nothing in, nothing out", nil, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ColumnSetOf(tc.in); got != tc.want {
+				t.Errorf("ColumnSetOf(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+
+	// Two orderings of one set must agree. This is the property, stated
+	// directly rather than left to the table above.
+	a := ColumnSetOf([]string{"a", "b", "c"})
+	b := ColumnSetOf([]string{"c", "a", "b"})
+	if a != b {
+		t.Errorf("two orderings of one column set gave %q and %q", a, b)
+	}
+}
+
+// ColumnSet over the REAL archive column list is what rotation records, so this
+// pins the two together: a column added to BinlogEventColumns without the
+// writer noticing would leave archives recorded under a set they do not have,
+// and a group naming a column its files lack fails the whole view.
+func TestColumnSet_matchesTheArchiveWriter(t *testing.T) {
+	got := ColumnSet(BinlogEventColumns)
+	names := strings.Split(got, ",")
+	if len(names) != len(BinlogEventColumns) {
+		t.Fatalf("the archive column set renders %d name(s) for %d column(s)", len(names), len(BinlogEventColumns))
+	}
+	for _, c := range BinlogEventColumns {
+		if !strings.Contains(","+got+",", ","+strings.ToLower(c.Name)+",") {
+			t.Errorf("column %q is written to every archive but is not in the recorded set %q", c.Name, got)
+		}
+	}
+}
+
+// Reading a stored value back. Empty in, NIL out: a row with no recorded set is
+// UNKNOWN, and a caller that took an empty slice for "a file with no columns"
+// would emit a read_parquet naming nothing at all.
+func TestSplitColumnSet_emptyMeansUnknown(t *testing.T) {
+	if got := SplitColumnSet(""); got != nil {
+		t.Errorf("SplitColumnSet(\"\") = %v, want nil", got)
+	}
+	if got := SplitColumnSet("   "); got != nil {
+		t.Errorf("SplitColumnSet(blank) = %v, want nil", got)
+	}
+	if got, want := SplitColumnSet("a,b"), []string{"a", "b"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("SplitColumnSet = %v, want %v", got, want)
+	}
+}
+
+// The backfill (#1535): a row with no recorded column set gets one from the
+// scanned footer, on a plain reconcile. NOT gated on --deep — the gate keeps S3
+// footer reads off the default path, and a set that was not read is empty here,
+// so the condition simply never fires on S3 without it. A local scan already
+// read the footer for row_count, so the repair costs no extra file open.
+func TestDiffRecordsTheArchivedColumnSet(t *testing.T) {
+	const set = "commit_ts_us,event_id,query_text"
+	withSet := func(f ScannedFile) ScannedFile { f.ColumnSet = set; return f }
+
+	t.Run("absent → recorded, without --deep", func(t *testing.T) {
+		f := withSet(localFile("p_2026060510", "abc", "/a/x.parquet", 100, 42))
+		rows := []StateRow{{PartitionName: "p_2026060510", BintrailID: "abc",
+			LocalPath: nStr("/a/x.parquet"), FileSizeBytes: nInt(100), RowCount: nInt(42), ArchivedAt: tOld}}
+		opts := bothScanned() // Deep is false
+		rep := Diff([]ScannedFile{f}, rows, opts)
+		if rep.Updates != 1 {
+			t.Fatalf("want 1 update, got %+v", rep)
+		}
+		if got := changes(rep.Actions[0])["column_set"]; got != set {
+			t.Errorf("column_set = %v, want %q", got, set)
+		}
+		if !strings.Contains(rep.Actions[0].Reason, "column set") {
+			t.Errorf("the reason does not name what is being repaired: %q", rep.Actions[0].Reason)
+		}
+	})
+
+	t.Run("already recorded → no action", func(t *testing.T) {
+		f := withSet(localFile("p_2026060510", "abc", "/a/x.parquet", 100, 42))
+		rows := []StateRow{{PartitionName: "p_2026060510", BintrailID: "abc",
+			LocalPath: nStr("/a/x.parquet"), FileSizeBytes: nInt(100), RowCount: nInt(42),
+			ColumnSet: nStr(set), ArchivedAt: tOld}}
+		rep := Diff([]ScannedFile{f}, rows, bothScanned())
+		if len(rep.Actions) != 0 || rep.InSync != 1 {
+			t.Fatalf("a repaired registry still reports drift, so a cron never goes green again: %+v", rep)
+		}
+	})
+
+	t.Run("drift → corrected", func(t *testing.T) {
+		f := withSet(localFile("p_2026060510", "abc", "/a/x.parquet", 100, 42))
+		rows := []StateRow{{PartitionName: "p_2026060510", BintrailID: "abc",
+			LocalPath: nStr("/a/x.parquet"), FileSizeBytes: nInt(100), RowCount: nInt(42),
+			ColumnSet: nStr("event_id"), ArchivedAt: tOld}}
+		rep := Diff([]ScannedFile{f}, rows, bothScanned())
+		if rep.Updates != 1 || changes(rep.Actions[0])["column_set"] != set {
+			t.Fatalf("a recorded set that no longer matches the file was left in place: %+v", rep)
+		}
+	})
+
+	t.Run("footer not read → nothing claimed", func(t *testing.T) {
+		// An S3 scan without --deep. The row stays unrecorded rather than
+		// being recorded as having no columns, which would form a group whose
+		// read_parquet names nothing.
+		f := s3File("p_2026060510", "abc", "bkt", "k/events.parquet", 100)
+		rows := []StateRow{{PartitionName: "p_2026060510", BintrailID: "abc",
+			S3Bucket: nStr("bkt"), S3Key: nStr("k/events.parquet"), S3UploadedAt: nTime(tModified),
+			FileSizeBytes: nInt(100), ArchivedAt: tOld}}
+		rep := Diff([]ScannedFile{f}, rows, DiffOptions{ScannedS3: true, PruneMinAge: 0, Now: tNow})
+		for _, a := range rep.Actions {
+			if _, ok := changes(a)["column_set"]; ok {
+				t.Errorf("a column set was recorded from a footer that was never read: %+v", a)
+			}
+		}
+	})
+
+	t.Run("insert carries it", func(t *testing.T) {
+		f := withSet(localFile("p_2026060510", "abc", "/a/x.parquet", 100, 42))
+		rep := Diff([]ScannedFile{f}, nil, bothScanned())
+		if rep.Inserts != 1 {
+			t.Fatalf("want 1 insert, got %+v", rep)
+		}
+		if got := changes(rep.Actions[0])["column_set"]; got != set {
+			t.Errorf("a rebuilt registry row has no column set (%v); every partition would read as unrecorded "+
+				"and the views would stay on the per-file bind", got)
+		}
+	})
+}
+
+// The recorded set must be the set that is actually IN the file. Asserting
+// ColumnSet(BinlogEventColumns) against the same list it was built from proves
+// nothing, so this writes a real Parquet through the real writer and reads the
+// names back out of its footer — the same footer `archive reconcile` reads to
+// backfill, which is what makes the recorded and the backfilled value one
+// thing.
+func TestColumnSet_isWhatTheParquetFooterHolds(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "events.parquet")
+	w, err := baseline.NewWriter(path, BinlogEventColumns, baseline.WriterConfig{
+		Compression: "none", RowGroupSize: 10,
+	})
+	if err != nil {
+		t.Fatalf("writer: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	fi, err := f.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pf, err := parquet.OpenFile(f, fi.Size())
+	if err != nil {
+		t.Fatalf("open parquet: %v", err)
+	}
+	var names []string
+	for _, fld := range pf.Schema().Fields() {
+		names = append(names, fld.Name())
+	}
+	if got, want := ColumnSetOf(names), ColumnSet(BinlogEventColumns); got != want {
+		t.Errorf("the footer holds %q but rotation records %q; a group would name columns its files do not have", got, want)
+	}
+}

--- a/internal/archive/columnset_test.go
+++ b/internal/archive/columnset_test.go
@@ -3,7 +3,6 @@ package archive
 import (
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -59,21 +58,6 @@ func TestColumnSet_matchesTheArchiveWriter(t *testing.T) {
 		if !strings.Contains(","+got+",", ","+strings.ToLower(c.Name)+",") {
 			t.Errorf("column %q is written to every archive but is not in the recorded set %q", c.Name, got)
 		}
-	}
-}
-
-// Reading a stored value back. Empty in, NIL out: a row with no recorded set is
-// UNKNOWN, and a caller that took an empty slice for "a file with no columns"
-// would emit a read_parquet naming nothing at all.
-func TestSplitColumnSet_emptyMeansUnknown(t *testing.T) {
-	if got := SplitColumnSet(""); got != nil {
-		t.Errorf("SplitColumnSet(\"\") = %v, want nil", got)
-	}
-	if got := SplitColumnSet("   "); got != nil {
-		t.Errorf("SplitColumnSet(blank) = %v, want nil", got)
-	}
-	if got, want := SplitColumnSet("a,b"), []string{"a", "b"}; !reflect.DeepEqual(got, want) {
-		t.Errorf("SplitColumnSet = %v, want %v", got, want)
 	}
 }
 

--- a/internal/archive/reconcile.go
+++ b/internal/archive/reconcile.go
@@ -45,6 +45,15 @@ type ScannedFile struct {
 	// RowCount is set when the footer was read (always for local scans —
 	// a local footer read is cheap — and for S3 only under --deep).
 	RowCount sql.NullInt64
+	// ColumnSet is the file's own column set in archive.ColumnSet form, read
+	// from the same footer as RowCount and therefore under the same rule:
+	// always on a local scan, on S3 only under --deep. Empty = not read.
+	//
+	// This is the backfill path for #1535: rotate records the set for archives
+	// it writes from now on, and everything already on disk gets it here, one
+	// footer each, offline — instead of DuckDB paying for every footer on
+	// every statement over the events view.
+	ColumnSet string
 }
 
 // StateRow is one archive_state row as stored.
@@ -57,6 +66,7 @@ type StateRow struct {
 	S3Bucket      sql.NullString
 	S3Key         sql.NullString
 	S3UploadedAt  sql.NullTime
+	ColumnSet     sql.NullString
 	ArchivedAt    time.Time
 }
 
@@ -354,6 +364,9 @@ func insertAction(k key, local, s3f *ScannedFile) Action {
 	if rowCount.Valid {
 		a.Changes = append(a.Changes, FieldChange{"row_count", rowCount.Int64})
 	}
+	if cs := pickColumnSet(local, s3f); cs != "" {
+		a.Changes = append(a.Changes, FieldChange{"column_set", cs})
+	}
 	if s3f != nil {
 		a.Changes = append(a.Changes,
 			FieldChange{"s3_bucket", s3f.S3Bucket},
@@ -444,12 +457,41 @@ func updateAction(k key, row *StateRow, local, s3f *ScannedFile, opts DiffOption
 		a.Changes = append(a.Changes, FieldChange{"row_count", rowCount.Int64})
 		addReason("row count drift")
 	}
+	// column_set: recorded whenever a footer was READ and the row disagrees,
+	// NOT gated on --deep. The gate exists to keep S3 footer reads off the
+	// default path, and a set that was not read is empty here — so on S3
+	// without --deep this condition simply never fires, while a local scan
+	// (whose footer read is cheap and already happened) backfills every row
+	// #1535 needs. A row already carrying the right set produces no action,
+	// which is what keeps a repaired registry from reporting drift forever.
+	if cs := pickColumnSet(local, s3f); cs != "" && (!row.ColumnSet.Valid || row.ColumnSet.String != cs) {
+		a.Changes = append(a.Changes, FieldChange{"column_set", cs})
+		if row.ColumnSet.Valid {
+			addReason("archived column set drift")
+		} else {
+			addReason("archived column set not recorded (the events view binds one footer per file without it)")
+		}
+	}
 
 	if len(a.Changes) == 0 {
 		return Action{}, false
 	}
 	a.Reason = reasons
 	return a, true
+}
+
+// pickColumnSet picks the column set from the scanned files, preferring local
+// for the same reason pickMeta does: the two describe the same Parquet object,
+// and the local footer read is the one that already happened. Empty when
+// neither footer was read (an S3-only scan without --deep).
+func pickColumnSet(local, s3f *ScannedFile) string {
+	if local != nil && local.ColumnSet != "" {
+		return local.ColumnSet
+	}
+	if s3f != nil {
+		return s3f.ColumnSet
+	}
+	return ""
 }
 
 // pickMeta picks size/row_count from the scanned files, preferring local

--- a/internal/cli/archive.go
+++ b/internal/cli/archive.go
@@ -270,10 +270,11 @@ func scanLocalArchive(root string) ([]archive.ScannedFile, error) {
 			PartitionName: part, BintrailID: id, Backend: archive.BackendLocal,
 			LocalPath: path, SizeBytes: info.Size(), LastModified: info.ModTime().UTC(),
 		}
-		if n, err := localParquetRowCount(path, info.Size()); err == nil {
+		if n, cols, err := localParquetFooter(path, info.Size()); err == nil {
 			f.RowCount = sql.NullInt64{Int64: n, Valid: true}
+			f.ColumnSet = cols
 		} else {
-			slog.Warn("reconcile: cannot read parquet footer, row_count left unset", "path", path, "error", err)
+			slog.Warn("reconcile: cannot read parquet footer, row_count and column set left unset", "path", path, "error", err)
 		}
 		out = append(out, f)
 		return nil
@@ -284,17 +285,25 @@ func scanLocalArchive(root string) ([]archive.ScannedFile, error) {
 	return out, nil
 }
 
-func localParquetRowCount(path string, size int64) (int64, error) {
+// localParquetFooter reads the row count AND the column set from one local
+// footer. One function, one open: the column set is the #1535 backfill, and
+// reading it in a second pass would double the file opens a repair costs on an
+// archive with thousands of partitions.
+func localParquetFooter(path string, size int64) (int64, string, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return 0, err
+		return 0, "", err
 	}
 	defer f.Close()
 	pf, err := parquet.OpenFile(f, size)
 	if err != nil {
-		return 0, err
+		return 0, "", err
 	}
-	return pf.NumRows(), nil
+	var names []string
+	for _, fld := range pf.Schema().Fields() {
+		names = append(names, fld.Name())
+	}
+	return pf.NumRows(), archive.ColumnSetOf(names), nil
 }
 
 // scanS3Archive lists the prefix for Hive-layout parquet objects. Size and
@@ -383,8 +392,9 @@ func scanS3Archive(ctx context.Context, s3URL, region string, deep bool) ([]arch
 					}
 					secretIssuedAt = time.Now()
 				}
-				if n, err := duckdbParquetRowCount(ctx, footerDB, "s3://"+bucket+"/"+*obj.Key); err == nil {
+				if n, cols, err := duckdbParquetFooter(ctx, footerDB, "s3://"+bucket+"/"+*obj.Key); err == nil {
 					f.RowCount = sql.NullInt64{Int64: n, Valid: true}
+					f.ColumnSet = cols
 				} else {
 					slog.Warn("reconcile: cannot read s3 parquet footer, row_count left unset",
 						"key", *obj.Key, "error", err)
@@ -442,23 +452,52 @@ func openS3FooterSession(ctx context.Context, region string) (*sql.DB, error) {
 	return db, nil
 }
 
-// duckdbParquetRowCount reads num_rows from a Parquet footer on the given
-// session (the ReadParquetMetadataAny pattern in internal/baseline). path is
-// an s3:// URI on the reconcile path; local paths work too (tests).
-func duckdbParquetRowCount(ctx context.Context, db *sql.DB, path string) (int64, error) {
+// duckdbParquetFooter reads num_rows and the column set from a Parquet footer
+// on the given session (the ReadParquetMetadataAny pattern in
+// internal/baseline). path is an s3:// URI on the reconcile path; local paths
+// work too (tests).
+//
+// Two statements, one remote footer: DuckDB caches the metadata it just read
+// for parquet_file_metadata, and parquet_schema over the same path answers
+// from it. Splitting them keeps each SELECT single-column, which is what the
+// scan-into-one-value shape here needs.
+//
+// parquet_schema returns the FULL schema tree, whose root is the message itself
+// and carries a child count; a LEAF carries NULL there, not 0 (verified against
+// the pinned DuckDB — filtering on `= 0` selects nothing at all and would
+// record every archive as having no columns). The archive layout is flat, so
+// "leaf" and "column" are the same set here.
+func duckdbParquetFooter(ctx context.Context, db *sql.DB, path string) (int64, string, error) {
 	safe := strings.ReplaceAll(path, "'", "''")
 	var n int64
 	if err := db.QueryRowContext(ctx,
 		fmt.Sprintf("SELECT num_rows FROM parquet_file_metadata('%s')", safe)).Scan(&n); err != nil {
-		return 0, err
+		return 0, "", err
 	}
-	return n, nil
+	rows, err := db.QueryContext(ctx,
+		fmt.Sprintf("SELECT name FROM parquet_schema('%s') WHERE num_children IS NULL", safe))
+	if err != nil {
+		return 0, "", err
+	}
+	defer rows.Close()
+	var names []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return 0, "", err
+		}
+		names = append(names, name)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, "", err
+	}
+	return n, archive.ColumnSetOf(names), nil
 }
 
 func loadArchiveStateRows(ctx context.Context, db *sql.DB) ([]archive.StateRow, error) {
 	rows, err := db.QueryContext(ctx, `
 		SELECT partition_name, bintrail_id, local_path, file_size_bytes,
-		       row_count, s3_bucket, s3_key, s3_uploaded_at, archived_at
+		       row_count, s3_bucket, s3_key, s3_uploaded_at, column_set, archived_at
 		FROM archive_state
 		WHERE bintrail_id IS NOT NULL`)
 	if err != nil {
@@ -470,7 +509,7 @@ func loadArchiveStateRows(ctx context.Context, db *sql.DB) ([]archive.StateRow, 
 	for rows.Next() {
 		var r archive.StateRow
 		if err := rows.Scan(&r.PartitionName, &r.BintrailID, &r.LocalPath, &r.FileSizeBytes,
-			&r.RowCount, &r.S3Bucket, &r.S3Key, &r.S3UploadedAt, &r.ArchivedAt); err != nil {
+			&r.RowCount, &r.S3Bucket, &r.S3Key, &r.S3UploadedAt, &r.ColumnSet, &r.ArchivedAt); err != nil {
 			return nil, err
 		}
 		out = append(out, r)

--- a/internal/cli/archive.go
+++ b/internal/cli/archive.go
@@ -46,10 +46,20 @@ registry row each file implies, and diffs against archive_state:
   - rows without files   → reported; --prune deletes them (registry rows
                            only; data files are NEVER touched)
   - metadata drift       → --repair updates (file size always; row counts
-                           only under --deep, which reads Parquet footers)
+                           and the archived column set from Parquet footers,
+                           which a local scan reads anyway and an S3 scan
+                           reads only under --deep)
+
+The archived column set is what lets bintrail views and the console SQL panel
+read the layout one group per schema instead of opening every file's footer on
+every query (#1535). On an S3 archive that means --deep --repair: without
+--deep no remote footer is read, so the repair records nothing.
 
 The default is a DRY-RUN that prints the drift and exits non-zero when any
-exists; safe to run from cron as a drift monitor.
+exists; safe to run from cron as a drift monitor. Note the first run after
+upgrading to a build that records the column set reports drift on every
+partition that predates it — that is the backfill asking to be run, not a new
+fault.
 
 Safety rules:
   - a row is only a prune candidate when EVERY backend it references was
@@ -203,15 +213,20 @@ func runArchiveReconcile(cmd *cobra.Command, args []string) error {
 	defer db.Close()
 
 	// reconcile reads and writes archive_state columns this build knows about,
-	// so it migrates first — the same rule the read paths adopted when
-	// query_text/query_hash were added (#699): a SELECT naming a column the
-	// index has not been migrated to is a hard 1054, not a degraded read.
+	// so it migrates THAT TABLE first — the same rule the read paths adopted
+	// when query_text/query_hash were added (#699): a SELECT naming a column
+	// the index has not been migrated to is a hard 1054, not a degraded read.
 	// column_set (#1535) is the current instance: without this, `archive
 	// reconcile` against an index whose rotation is older than this binary
 	// fails outright, which is exactly the operator most likely to run it.
-	// Idempotent, and it never touches data.
-	if err := indexer.EnsureSchema(db); err != nil {
-		return fmt.Errorf("migrate index schema: %w", err)
+	//
+	// EnsureArchiveStateSchema, NOT EnsureSchema: this command's dry run is
+	// documented as a read-only cron drift monitor, and the full migration also
+	// adds columns to binlog_events — the largest table in the deployment.
+	// Instant on a current MySQL, a rebuild on an older one, and either way not
+	// something a monitor should start on its own.
+	if err := indexer.EnsureArchiveStateSchema(db); err != nil {
+		return fmt.Errorf("migrate archive_state schema: %w", err)
 	}
 
 	rows, err := loadArchiveStateRows(ctx, db)

--- a/internal/cli/archive.go
+++ b/internal/cli/archive.go
@@ -50,7 +50,7 @@ registry row each file implies, and diffs against archive_state:
                            which a local scan reads anyway and an S3 scan
                            reads only under --deep)
 
-The archived column set is what lets bintrail views and the console SQL panel
+The archived column set is what lets the DuckDB schema bintrail views writes
 read the layout one group per schema instead of opening every file's footer on
 every query (#1535). On an S3 archive that means --deep --repair: without
 --deep no remote footer is read, so the repair records nothing.

--- a/internal/cli/archive.go
+++ b/internal/cli/archive.go
@@ -20,6 +20,7 @@ import (
 	"github.com/dbtrail/dbtrail/internal/archive"
 	"github.com/dbtrail/dbtrail/internal/cliutil"
 	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/indexer"
 	"github.com/dbtrail/dbtrail/internal/duckdbutil"
 	"github.com/dbtrail/dbtrail/internal/storage"
 )
@@ -200,6 +201,18 @@ func runArchiveReconcile(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("connect index database: %w", err)
 	}
 	defer db.Close()
+
+	// reconcile reads and writes archive_state columns this build knows about,
+	// so it migrates first — the same rule the read paths adopted when
+	// query_text/query_hash were added (#699): a SELECT naming a column the
+	// index has not been migrated to is a hard 1054, not a degraded read.
+	// column_set (#1535) is the current instance: without this, `archive
+	// reconcile` against an index whose rotation is older than this binary
+	// fails outright, which is exactly the operator most likely to run it.
+	// Idempotent, and it never touches data.
+	if err := indexer.EnsureSchema(db); err != nil {
+		return fmt.Errorf("migrate index schema: %w", err)
+	}
 
 	rows, err := loadArchiveStateRows(ctx, db)
 	if err != nil {
@@ -523,6 +536,7 @@ func loadArchiveStateRows(ctx context.Context, db *sql.DB) ([]archive.StateRow, 
 var reconcileColumns = map[string]bool{
 	"local_path": true, "file_size_bytes": true, "row_count": true,
 	"s3_bucket": true, "s3_key": true, "s3_uploaded_at": true,
+	"column_set": true,
 }
 
 // executeReconcileActions applies insert/update actions under --repair and

--- a/internal/cli/archive_integration_test.go
+++ b/internal/cli/archive_integration_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/dbtrail/dbtrail/internal/archive"
 	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/query"
 	"github.com/dbtrail/dbtrail/internal/rotation"
 	"github.com/dbtrail/dbtrail/internal/testutil"
 )
@@ -228,5 +229,115 @@ func TestParseArchivePathRoundTrip(t *testing.T) {
 		if gotID != id || gotPart != indexer.PartitionName(h) {
 			t.Errorf("round-trip(%s): got (%s, %s), want (%s, %s)", p, gotID, gotPart, id, indexer.PartitionName(h))
 		}
+	}
+}
+
+// TestArchiveReconcileRecordsTheColumnSet is #1535's backfill end to end: a real
+// Parquet archive, a registry with no recorded column set, and a repair that
+// fills it from the footer it already reads — after which query.ArchiveGroups
+// can group the layout and the views bind one footer per group instead of one
+// per file.
+//
+// Against real MySQL and a real footer on purpose. The unit tests drive Diff
+// with a hand-set ColumnSet, so they would still pass if the scan never read
+// the names, if the value rotation records disagreed with the file, or if the
+// column could not be written to archive_state at all.
+func TestArchiveReconcileRecordsTheColumnSet(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	ctx := context.Background()
+
+	h1 := time.Now().UTC().Add(-48 * time.Hour).Truncate(time.Hour)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h1})
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200,
+		h1.Add(30*time.Minute).Format("2006-01-02 15:04:05"), nil,
+		"testdb", "orders", 1, "42", nil, nil, []byte(`{"id":42}`))
+
+	archiveDir := t.TempDir()
+	const bintrailID = "deadbeef-dead-beef-dead-beefdeadbeef"
+	part := indexer.PartitionName(h1)
+	outPath, err := rotation.HiveArchivePath(archiveDir, bintrailID, part)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stats, err := archive.ArchivePartition(ctx, db, dbName, part, outPath, "zstd")
+	if err != nil {
+		t.Fatalf("ArchivePartition: %v", err)
+	}
+	// The writer reports the set it wrote, which is what rotation records.
+	if stats.Columns != archive.ColumnSet(archive.BinlogEventColumns) {
+		t.Fatalf("ArchivePartition reported column set %q, want the archive's own", stats.Columns)
+	}
+
+	// A registry row that predates the column: everything else recorded, no
+	// column set. This is every deployment on the day it upgrades.
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO archive_state (partition_name, bintrail_id, local_path, file_size_bytes, row_count)
+		 VALUES (?, ?, ?, ?, ?)`, part, bintrailID, outPath, 1, 1); err != nil {
+		t.Fatal(err)
+	}
+
+	files, err := scanLocalArchive(archiveDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 || files[0].ColumnSet != stats.Columns {
+		t.Fatalf("the local scan read column set %q from the real footer, want %q",
+			files[0].ColumnSet, stats.Columns)
+	}
+	rows, err := loadArchiveStateRows(ctx, db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Deep is FALSE: the backfill must not need it. A local footer read has
+	// already happened for row_count, so requiring --deep here would leave
+	// every plain reconcile unable to fix the thing it just measured.
+	rep := archive.Diff(files, rows, archive.DiffOptions{
+		ScannedLocal: true, PruneMinAge: time.Hour, Now: time.Now().UTC(),
+	})
+	if executed, errs := executeReconcileActions(ctx, db, rep.Actions, true, false); len(errs) != 0 || executed != 1 {
+		t.Fatalf("repair: executed=%d errs=%v", executed, errs)
+	}
+
+	var recorded sql.NullString
+	if err := db.QueryRowContext(ctx,
+		`SELECT column_set FROM archive_state WHERE partition_name = ? AND bintrail_id = ?`,
+		part, bintrailID).Scan(&recorded); err != nil {
+		t.Fatalf("read back column_set: %v", err)
+	}
+	if !recorded.Valid || recorded.String != stats.Columns {
+		t.Fatalf("column_set = %+v, want %q", recorded, stats.Columns)
+	}
+
+	// And the payoff: the registry can now group the layout.
+	groups, ungrouped, err := query.ArchiveGroups(ctx, db,
+		[]string{filepath.Join(archiveDir, "bintrail_id="+bintrailID)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ungrouped != 0 {
+		t.Fatalf("ungrouped = %d after a repair; the views would still bind every footer", ungrouped)
+	}
+	if len(groups) != 1 || len(groups[0].Files) != 1 || groups[0].Files[0] != outPath {
+		t.Fatalf("groups = %+v, want the archived file under its own source", groups)
+	}
+
+	// A second reconcile finds nothing to do. Without this the repair reports
+	// drift forever and a cron never goes green again.
+	rows, err = loadArchiveStateRows(ctx, db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rep = archive.Diff(files, rows, archive.DiffOptions{
+		ScannedLocal: true, PruneMinAge: time.Hour, Now: time.Now().UTC(),
+	})
+	if rep.Err() != nil {
+		t.Errorf("a repaired registry still reports drift: %v", rep.Err())
 	}
 }

--- a/internal/cli/archive_test.go
+++ b/internal/cli/archive_test.go
@@ -178,12 +178,18 @@ func TestDuckDBParquetRowCountSharedSession(t *testing.T) {
 		}
 	}
 	for name, want := range files {
-		got, err := duckdbParquetRowCount(ctx, db, filepath.Join(dir, name))
+		got, cols, err := duckdbParquetFooter(ctx, db, filepath.Join(dir, name))
 		if err != nil {
 			t.Fatalf("probe %s on the shared session: %v", name, err)
 		}
 		if got != want {
 			t.Errorf("%s: row count %d, want %d", name, got, want)
+		}
+		// The same footer read yields the column set the #1535 backfill
+		// records; the fixture is COPY (SELECT * FROM range(n)), whose single
+		// column is named "range".
+		if cols != "range" {
+			t.Errorf("%s: column set %q, want %q", name, cols, "range")
 		}
 	}
 }

--- a/internal/cli/restore_index.go
+++ b/internal/cli/restore_index.go
@@ -382,16 +382,27 @@ func recordRestoredArchive(ctx context.Context, db *sql.DB, f archive.ScannedFil
 	} else {
 		localPath = f.LocalPath
 	}
+	// column_set (#1535) when the scan read a footer — always on a local scan,
+	// never on the S3 one here (it is called with deep=false). NULL where it
+	// was not read, which the views generator treats as "cannot group" and
+	// falls back to the globbed bind for; recording it costs nothing extra and
+	// spares a restored index a `reconcile --repair` before its views are fast
+	// again.
+	var columnSet any
+	if f.ColumnSet != "" {
+		columnSet = f.ColumnSet
+	}
 	_, err := db.ExecContext(ctx, `
 		INSERT INTO archive_state
-			(partition_name, bintrail_id, local_path, file_size_bytes, row_count, s3_bucket, s3_key, s3_uploaded_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+			(partition_name, bintrail_id, local_path, file_size_bytes, row_count, s3_bucket, s3_key, s3_uploaded_at, column_set)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON DUPLICATE KEY UPDATE
 			local_path = COALESCE(VALUES(local_path), local_path),
 			s3_bucket = COALESCE(VALUES(s3_bucket), s3_bucket),
 			s3_key = COALESCE(VALUES(s3_key), s3_key),
-			s3_uploaded_at = COALESCE(VALUES(s3_uploaded_at), s3_uploaded_at)`,
-		f.PartitionName, f.BintrailID, localPath, f.SizeBytes, rows, bucket, key, uploadedAt)
+			s3_uploaded_at = COALESCE(VALUES(s3_uploaded_at), s3_uploaded_at),
+			column_set = COALESCE(VALUES(column_set), column_set)`,
+		f.PartitionName, f.BintrailID, localPath, f.SizeBytes, rows, bucket, key, uploadedAt, columnSet)
 	return err
 }
 

--- a/internal/cli/views.go
+++ b/internal/cli/views.go
@@ -335,6 +335,14 @@ func resolveArchiveGroups(ctx context.Context, dsn string, in *views.Input) erro
 		return fmt.Errorf("connect to index DB: %w", err)
 	}
 	defer db.Close()
+	return resolveArchiveGroupsFrom(ctx, db, in)
+}
+
+// resolveArchiveGroupsFrom is the DB-taking half, split out so the all-or-
+// nothing rule is pinned by a test rather than by the comment above it. The
+// console half has its own; a revert on either surface would otherwise ship
+// unnoticed, exactly as with discoverArchiveSourcesFrom.
+func resolveArchiveGroupsFrom(ctx context.Context, db *sql.DB, in *views.Input) error {
 	groups, ungrouped, err := query.ArchiveGroups(ctx, db, in.ArchiveSources)
 	if err != nil {
 		return fmt.Errorf("read archived column sets from archive_state: %w", err)

--- a/internal/cli/views.go
+++ b/internal/cli/views.go
@@ -202,6 +202,16 @@ func runViews(cmd *cobra.Command, _ []string) error {
 		// the connection and report it as an index fault.
 	}
 
+	// Grouping needs the registry, so it applies to operator-named roots too —
+	// but only when there is an index to ask. `--archive-dir` alone describes a
+	// layout with nothing to read column sets from, and the file then carries
+	// the globbed form, which is what it has always carried.
+	if vIndexDSN != "" {
+		if err := resolveArchiveGroups(cmd.Context(), vIndexDSN, &in); err != nil {
+			return err
+		}
+	}
+
 	if vIncludeLive {
 		li, err := resolveLiveIndex(cmd.Context(), vIndexDSN, vBintrailID)
 		if err != nil {
@@ -307,6 +317,44 @@ func discoverArchiveSourcesFrom(ctx context.Context, db *sql.DB) ([]string, erro
 		return nil, fmt.Errorf("resolve archive sources from archive_state: %w", err)
 	}
 	return sources, nil
+}
+
+// resolveArchiveGroups fills the per-column-set groups the events view is
+// emitted from (#1535), leaving them empty when the registry cannot fully
+// answer.
+//
+// EMPTY IS THE SAFE STATE and the reason this never fails the command: with no
+// groups the file keeps the globbed union_by_name leg, which reads every file
+// under the roots. Grouping reads the file list from archive_state instead, so
+// it is used only when every registered partition has a recorded column set —
+// otherwise the ungrouped ones would be missing from the view rather than
+// merely slow to bind.
+func resolveArchiveGroups(ctx context.Context, dsn string, in *views.Input) error {
+	db, err := config.Connect(dsn)
+	if err != nil {
+		return fmt.Errorf("connect to index DB: %w", err)
+	}
+	defer db.Close()
+	groups, ungrouped, err := query.ArchiveGroups(ctx, db, in.ArchiveSources)
+	if err != nil {
+		return fmt.Errorf("read archived column sets from archive_state: %w", err)
+	}
+	in.UngroupedPartitions = ungrouped
+	if ungrouped == 0 {
+		in.ArchiveGroups = toViewGroups(groups)
+	}
+	return nil
+}
+
+// toViewGroups converts the registry's groups to the generator's own struct.
+// The two are separate types so internal/views links nothing that reaches a
+// database; this is the only place they meet.
+func toViewGroups(groups []query.ArchiveGroup) []views.ArchiveGroup {
+	out := make([]views.ArchiveGroup, len(groups))
+	for i, g := range groups {
+		out[i] = views.ArchiveGroup{Columns: g.Columns, Files: g.Files}
+	}
+	return out
 }
 
 // resolveBaselineViews picks the NEWEST discoverable snapshot and takes its

--- a/internal/cli/views_groups_test.go
+++ b/internal/cli/views_groups_test.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -12,10 +14,26 @@ import (
 
 const groupTestID = "aaaa"
 
-func groupTestBase() string { return "/arc/bintrail_id=" + groupTestID }
+// A real directory with real files: ArchiveGroups stats every local path before
+// it will put one in a group (a registered file that is gone would make DuckDB
+// refuse the whole script).
+func groupTestBase(t *testing.T) string {
+	t.Helper()
+	base := filepath.Join(t.TempDir(), "bintrail_id="+groupTestID)
+	for _, hour := range []string{"03", "04"} {
+		p := groupTestFile(base, hour)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return base
+}
 
-func groupTestFile(hour string) string {
-	return groupTestBase() + "/event_date=2026-05-01/event_hour=" + hour + "/e.parquet"
+func groupTestFile(base, hour string) string {
+	return base + "/event_date=2026-05-01/event_hour=" + hour + "/e.parquet"
 }
 
 // The whole point of #1535 reaching the downloadable file: `bintrail views`
@@ -27,12 +45,13 @@ func TestResolveArchiveGroupsFrom_carriesTheGroups(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
+	base := groupTestBase(t)
 	mock.ExpectQuery("FROM archive_state").WillReturnRows(
 		sqlmock.NewRows([]string{"bintrail_id", "local_path", "s3_key", "column_set"}).
-			AddRow(groupTestID, groupTestFile("03"), nil, "event_id,query_text").
-			AddRow(groupTestID, groupTestFile("04"), nil, "event_id"))
+			AddRow(groupTestID, groupTestFile(base, "03"), nil, "event_id,query_text").
+			AddRow(groupTestID, groupTestFile(base, "04"), nil, "event_id"))
 
-	in := views.Input{ArchiveSources: []string{groupTestBase()}}
+	in := views.Input{ArchiveSources: []string{base}}
 	if err := resolveArchiveGroupsFrom(context.Background(), db, &in); err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +71,7 @@ func TestResolveArchiveGroupsFrom_carriesTheGroups(t *testing.T) {
 	if strings.Contains(sql, "union_by_name = true") {
 		t.Errorf("the generated file still asks DuckDB to unify every footer:\n%s", sql)
 	}
-	if !strings.Contains(sql, groupTestFile("03")) {
+	if !strings.Contains(sql, groupTestFile(base, "03")) {
 		t.Errorf("the generated file does not name the archived partitions:\n%s", sql)
 	}
 }
@@ -67,12 +86,13 @@ func TestResolveArchiveGroupsFrom_partialRegistryKeepsTheGlob(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
+	base := groupTestBase(t)
 	mock.ExpectQuery("FROM archive_state").WillReturnRows(
 		sqlmock.NewRows([]string{"bintrail_id", "local_path", "s3_key", "column_set"}).
-			AddRow(groupTestID, groupTestFile("03"), nil, "event_id,query_text").
-			AddRow(groupTestID, groupTestFile("04"), nil, nil))
+			AddRow(groupTestID, groupTestFile(base, "03"), nil, "event_id,query_text").
+			AddRow(groupTestID, groupTestFile(base, "04"), nil, nil))
 
-	in := views.Input{ArchiveSources: []string{groupTestBase()}}
+	in := views.Input{ArchiveSources: []string{base}}
 	if err := resolveArchiveGroupsFrom(context.Background(), db, &in); err != nil {
 		t.Fatal(err)
 	}
@@ -89,10 +109,10 @@ func TestResolveArchiveGroupsFrom_partialRegistryKeepsTheGlob(t *testing.T) {
 		ArchiveSources:      in.ArchiveSources,
 		UngroupedPartitions: in.UngroupedPartitions,
 	})
-	if !strings.Contains(sql, "no recorded column set") {
+	if !strings.Contains(sql, "cannot be grouped by schema") {
 		t.Errorf("the file does not explain why it still binds every footer:\n%s", sql)
 	}
-	if !strings.Contains(sql, "archive reconcile --repair") {
+	if !strings.Contains(sql, "bintrail archive reconcile") || !strings.Contains(sql, "--repair") {
 		t.Errorf("the file names no way to fix it:\n%s", sql)
 	}
 }

--- a/internal/cli/views_groups_test.go
+++ b/internal/cli/views_groups_test.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/dbtrail/dbtrail/internal/views"
+)
+
+const groupTestID = "aaaa"
+
+func groupTestBase() string { return "/arc/bintrail_id=" + groupTestID }
+
+func groupTestFile(hour string) string {
+	return groupTestBase() + "/event_date=2026-05-01/event_hour=" + hour + "/e.parquet"
+}
+
+// The whole point of #1535 reaching the downloadable file: `bintrail views`
+// must carry the groups, or the file it writes still binds one footer per
+// archived file in the operator's own DuckDB.
+func TestResolveArchiveGroupsFrom_carriesTheGroups(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	mock.ExpectQuery("FROM archive_state").WillReturnRows(
+		sqlmock.NewRows([]string{"bintrail_id", "local_path", "s3_key", "column_set"}).
+			AddRow(groupTestID, groupTestFile("03"), nil, "event_id,query_text").
+			AddRow(groupTestID, groupTestFile("04"), nil, "event_id"))
+
+	in := views.Input{ArchiveSources: []string{groupTestBase()}}
+	if err := resolveArchiveGroupsFrom(context.Background(), db, &in); err != nil {
+		t.Fatal(err)
+	}
+	if in.UngroupedPartitions != 0 {
+		t.Fatalf("UngroupedPartitions = %d, want 0", in.UngroupedPartitions)
+	}
+	if len(in.ArchiveGroups) != 2 {
+		t.Fatalf("%d group(s) reached the generator, want 2", len(in.ArchiveGroups))
+	}
+	// Rendered, not just carried: the field is only worth anything if the file
+	// it produces actually names the files instead of the glob.
+	sql := views.Generate(views.Input{
+		ArchiveSources:      in.ArchiveSources,
+		ArchiveGroups:       in.ArchiveGroups,
+		UngroupedPartitions: in.UngroupedPartitions,
+	})
+	if strings.Contains(sql, "union_by_name = true") {
+		t.Errorf("the generated file still asks DuckDB to unify every footer:\n%s", sql)
+	}
+	if !strings.Contains(sql, groupTestFile("03")) {
+		t.Errorf("the generated file does not name the archived partitions:\n%s", sql)
+	}
+}
+
+// The all-or-nothing rule. One unrecorded partition and the file keeps the
+// globbed leg, because the group list comes from the registry: grouping a
+// partial registry would leave the unrecorded partitions out of the view
+// entirely, which is a wrong answer rather than a slow one.
+func TestResolveArchiveGroupsFrom_partialRegistryKeepsTheGlob(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	mock.ExpectQuery("FROM archive_state").WillReturnRows(
+		sqlmock.NewRows([]string{"bintrail_id", "local_path", "s3_key", "column_set"}).
+			AddRow(groupTestID, groupTestFile("03"), nil, "event_id,query_text").
+			AddRow(groupTestID, groupTestFile("04"), nil, nil))
+
+	in := views.Input{ArchiveSources: []string{groupTestBase()}}
+	if err := resolveArchiveGroupsFrom(context.Background(), db, &in); err != nil {
+		t.Fatal(err)
+	}
+	if len(in.ArchiveGroups) != 0 {
+		t.Fatalf("grouping was used over a partial registry: %d group(s)", len(in.ArchiveGroups))
+	}
+	if in.UngroupedPartitions != 1 {
+		t.Fatalf("UngroupedPartitions = %d, want 1", in.UngroupedPartitions)
+	}
+
+	// And the file says so, with the command that fixes it. An operator who
+	// cannot see why the wait is still there has no way to act on it.
+	sql := views.Generate(views.Input{
+		ArchiveSources:      in.ArchiveSources,
+		UngroupedPartitions: in.UngroupedPartitions,
+	})
+	if !strings.Contains(sql, "no recorded column set") {
+		t.Errorf("the file does not explain why it still binds every footer:\n%s", sql)
+	}
+	if !strings.Contains(sql, "archive reconcile --repair") {
+		t.Errorf("the file names no way to fix it:\n%s", sql)
+	}
+}

--- a/internal/console/views_api.go
+++ b/internal/console/views_api.go
@@ -87,6 +87,33 @@ func (s *Server) buildViewsInput(ctx context.Context, b *bundle, req viewsReques
 	in.ArchiveSources, archiveErr = consoleArchiveSources(ctx, b.db, portable)
 	in.PortableRouting = portable
 	in.ArchiveDiscoveryFailed = archiveErr != nil
+	if archiveErr == nil {
+		// Per-column-set groups (#1535): whether a statement over the events
+		// view waits on EVERY archived file's footer or on one per schema.
+		// The console no longer runs this SQL itself (#1554 removed the panel),
+		// so the wait this saves is entirely the operator's, in whatever DuckDB
+		// they open the downloaded file in.
+		//
+		// A failure to read the column sets is NOT fatal and NOT reported as
+		// discovery failure: the sources resolved, so the file is honest with
+		// the globbed leg it has always carried. Only the speed is lost.
+		groups, ungrouped, err := query.ArchiveGroups(ctx, b.db, in.ArchiveSources)
+		if err != nil {
+			slog.Warn("console: could not read archived column sets; the events view keeps the globbed bind",
+				"error", err)
+		} else {
+			in.UngroupedPartitions = ungrouped
+			if ungrouped == 0 {
+				// Its own loop rather than a shared helper, deliberately: the
+				// CLI half has one too, and a test on each surface is what
+				// keeps one of them from silently losing the grouping.
+				in.ArchiveGroups = make([]views.ArchiveGroup, len(groups))
+				for i, g := range groups {
+					in.ArchiveGroups[i] = views.ArchiveGroup{Columns: g.Columns, Files: g.Files}
+				}
+			}
+		}
+	}
 	baseSrc := b.baselineSrc
 	if req.PortableBaseline && b.baselineFallbackSrc != "" {
 		// Read from the bundle, never from the request: the two locations this

--- a/internal/console/views_groups_test.go
+++ b/internal/console/views_groups_test.go
@@ -1,0 +1,92 @@
+package console
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+// expectGroupedArchiveSource queues the two archive_state reads buildViewsInput
+// performs, with a registry that HAS recorded column sets — the state after
+// `archive reconcile --repair`, or after rotation has written archives on this
+// build.
+func expectGroupedArchiveSource(mock sqlmock.Sqlmock, id string) {
+	key := func(hour string) string {
+		return "events/bintrail_id=" + id + "/event_date=2026-05-01/event_hour=" + hour + "/e.parquet"
+	}
+	mock.ExpectQuery("FROM archive_state").WillReturnRows(
+		sqlmock.NewRows([]string{"bintrail_id", "sample_local", "sample_bucket", "sample_key"}).
+			AddRow(id, nil, "bkt", key("03")))
+	mock.ExpectQuery("FROM archive_state").WillReturnRows(
+		sqlmock.NewRows([]string{"bintrail_id", "local_path", "s3_key", "column_set"}).
+			AddRow(id, nil, key("03"), "event_id,query_text").
+			AddRow(id, nil, key("04"), "event_id"))
+}
+
+// The console serves BOTH consumers of this SQL from one builder: the SQL panel
+// binds these views in-process on every statement, and the download binds them
+// in the operator's DuckDB. So the grouping has to reach the console builder,
+// not only the CLI one.
+func TestViewsAPI_groupsTheArchiveLayout(t *testing.T) {
+	const id = "aaaa"
+	srv, mock := newLiveViewsServer(t, liveTestDSN)
+	expectGroupedArchiveSource(mock, id)
+
+	rec, body := doServersReq(t, srv, "GET", "/api/views.sql", "")
+	if rec.Code != 200 {
+		t.Fatalf("code = %d, body = %s", rec.Code, body)
+	}
+	sql := string(body)
+	if strings.Contains(sql, "union_by_name = true") {
+		t.Errorf("the console's events view still unifies every footer at bind time:\n%s", sql)
+	}
+	if !strings.Contains(sql, "union_by_name = false") {
+		t.Errorf("the console's events view is not grouped at all:\n%s", sql)
+	}
+	if !strings.Contains(sql, "UNION ALL BY NAME") {
+		t.Errorf("the two column sets were not joined:\n%s", sql)
+	}
+	// The narrow group must pad the column it lacks rather than name it: naming
+	// it is a binder error that defines no view, which on the SQL panel means
+	// the whole page fails rather than one column reading NULL.
+	if !strings.Contains(sql, `NULL AS "query_text"`) {
+		t.Errorf("the group without query_text does not pad it:\n%s", sql)
+	}
+	if !strings.Contains(sql, "event_hour=04") {
+		t.Errorf("a registered partition is missing from the file lists:\n%s", sql)
+	}
+}
+
+// The all-or-nothing rule, on the console side. The file list comes from the
+// registry, so grouping a PARTIAL one would leave the unrecorded partitions out
+// of the view — a wrong answer instead of a slow one. This case is what makes
+// the gate testable at all: with every partition unrecorded the grouped and the
+// ungrouped paths both produce no groups and look identical.
+func TestViewsAPI_partialRegistryKeepsTheGlob(t *testing.T) {
+	const id = "aaaa"
+	srv, mock := newLiveViewsServer(t, liveTestDSN)
+	key := func(hour string) string {
+		return "events/bintrail_id=" + id + "/event_date=2026-05-01/event_hour=" + hour + "/e.parquet"
+	}
+	mock.ExpectQuery("FROM archive_state").WillReturnRows(
+		sqlmock.NewRows([]string{"bintrail_id", "sample_local", "sample_bucket", "sample_key"}).
+			AddRow(id, nil, "bkt", key("03")))
+	mock.ExpectQuery("FROM archive_state").WillReturnRows(
+		sqlmock.NewRows([]string{"bintrail_id", "local_path", "s3_key", "column_set"}).
+			AddRow(id, nil, key("03"), "event_id,query_text").
+			AddRow(id, nil, key("04"), nil))
+
+	rec, body := doServersReq(t, srv, "GET", "/api/views.sql", "")
+	if rec.Code != 200 {
+		t.Fatalf("code = %d, body = %s", rec.Code, body)
+	}
+	sql := string(body)
+	if strings.Contains(sql, "union_by_name = false") {
+		t.Errorf("the console grouped a registry that cannot account for every partition, "+
+			"so event_hour=04 is not in the view at all:\n%s", sql)
+	}
+	if !strings.Contains(sql, "no recorded column set") {
+		t.Errorf("the file does not explain why it still binds every footer:\n%s", sql)
+	}
+}

--- a/internal/console/views_groups_test.go
+++ b/internal/console/views_groups_test.go
@@ -24,16 +24,17 @@ func expectGroupedArchiveSource(mock sqlmock.Sqlmock, id string) {
 			AddRow(id, nil, key("04"), "event_id"))
 }
 
-// The console serves BOTH consumers of this SQL from one builder: the SQL panel
-// binds these views in-process on every statement, and the download binds them
-// in the operator's DuckDB. So the grouping has to reach the console builder,
-// not only the CLI one.
+// The console writes this SQL for someone else to run: since #1554 removed the
+// SQL page, the whole wait it saves is the operator's, in whatever DuckDB they
+// open the downloaded file in. So the grouping has to reach the console builder
+// and not only the CLI one — two producers of the same artifact, and a test on
+// each is what keeps one of them from silently losing it.
 func TestViewsAPI_groupsTheArchiveLayout(t *testing.T) {
 	const id = "aaaa"
 	srv, mock := newLiveViewsServer(t, liveTestDSN)
 	expectGroupedArchiveSource(mock, id)
 
-	rec, body := doServersReq(t, srv, "GET", "/api/views.sql", "")
+	rec, body := doServersReq(t, srv, "GET", "/api/views.sql?include_events=1", "")
 	if rec.Code != 200 {
 		t.Fatalf("code = %d, body = %s", rec.Code, body)
 	}
@@ -48,8 +49,8 @@ func TestViewsAPI_groupsTheArchiveLayout(t *testing.T) {
 		t.Errorf("the two column sets were not joined:\n%s", sql)
 	}
 	// The narrow group must pad the column it lacks rather than name it: naming
-	// it is a binder error that defines no view, which on the SQL panel means
-	// the whole page fails rather than one column reading NULL.
+	// it is a binder error that defines no view at all — the reader's whole
+	// script fails rather than one column reading NULL.
 	if !strings.Contains(sql, `NULL AS "query_text"`) {
 		t.Errorf("the group without query_text does not pad it:\n%s", sql)
 	}
@@ -77,7 +78,7 @@ func TestViewsAPI_partialRegistryKeepsTheGlob(t *testing.T) {
 			AddRow(id, nil, key("03"), "event_id,query_text").
 			AddRow(id, nil, key("04"), nil))
 
-	rec, body := doServersReq(t, srv, "GET", "/api/views.sql", "")
+	rec, body := doServersReq(t, srv, "GET", "/api/views.sql?include_events=1", "")
 	if rec.Code != 200 {
 		t.Fatalf("code = %d, body = %s", rec.Code, body)
 	}

--- a/internal/console/views_groups_test.go
+++ b/internal/console/views_groups_test.go
@@ -86,7 +86,7 @@ func TestViewsAPI_partialRegistryKeepsTheGlob(t *testing.T) {
 		t.Errorf("the console grouped a registry that cannot account for every partition, "+
 			"so event_hour=04 is not in the view at all:\n%s", sql)
 	}
-	if !strings.Contains(sql, "no recorded column set") {
+	if !strings.Contains(sql, "cannot be grouped by schema") {
 		t.Errorf("the file does not explain why it still binds every footer:\n%s", sql)
 	}
 }

--- a/internal/console/views_live_test.go
+++ b/internal/console/views_live_test.go
@@ -38,12 +38,21 @@ func newLiveViewsServer(t *testing.T, dsn string) (*Server, sqlmock.Sqlmock) {
 	return srv, mock
 }
 
-// expectArchiveSource queues the archive_state read buildViewsInput does, so
-// there is a layout to describe.
+// expectArchiveSource queues the TWO archive_state reads buildViewsInput does,
+// so there is a layout to describe: the per-source roots, then the per-column-
+// set groups (#1535).
+//
+// The group read answers with a NULL column_set on purpose. That is what a
+// registry looks like before `archive reconcile --repair` has recorded one, and
+// it keeps these tests on the globbed leg they were written against — the
+// grouped shape has its own tests, where the difference is the point.
 func expectArchiveSource(mock sqlmock.Sqlmock, id string) {
 	mock.ExpectQuery("FROM archive_state").WillReturnRows(
 		sqlmock.NewRows([]string{"bintrail_id", "sample_local", "sample_bucket", "sample_key"}).
 			AddRow(id, nil, "bkt", "events/bintrail_id="+id+"/f.parquet"))
+	mock.ExpectQuery("FROM archive_state").WillReturnRows(
+		sqlmock.NewRows([]string{"bintrail_id", "local_path", "s3_key", "column_set"}).
+			AddRow(id, nil, "events/bintrail_id="+id+"/f.parquet", nil))
 }
 
 // TestViewsAPI_includeLiveAddsTheHotLeg: the download can now carry the leg

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -685,43 +685,7 @@ func EnsureSchema(db *sql.DB) error {
 	); err != nil {
 		return err
 	}
-	// min_event_ts/max_event_ts record the content-derived event_timestamp
-	// range of each archived partition (#1037). A backfill after a capture
-	// stall lands old events in the OLDEST live RANGE partition, so the
-	// Parquet file archived under that partition's hour label can hold rows
-	// from much earlier hours; any pruning that trusts the label alone
-	// (planner hour mapping, date-scoped S3 listings) then silently skips
-	// them. The planner reads these columns to expand archive coverage and to
-	// tell the archive fetcher which mislabeled files a time-scoped read must
-	// still open. NULL on rows written before this column existed (or by
-	// upload/reconcile, which do not scan row contents): the planner falls
-	// back to label-only pruning for those rows, exactly the pre-#1037
-	// behavior.
-	if err := ensureColumn(db, "archive_state", "min_event_ts",
-		`ALTER TABLE archive_state ADD COLUMN min_event_ts DATETIME DEFAULT NULL COMMENT 'MIN(event_timestamp) of the archived rows; NULL for archives written before #1037 or registered by upload/reconcile. Content-derived pruning: may precede the partition hour label when backfilled events landed in the partition' AFTER s3_uploaded_at`,
-	); err != nil {
-		return err
-	}
-	if err := ensureColumn(db, "archive_state", "max_event_ts",
-		`ALTER TABLE archive_state ADD COLUMN max_event_ts DATETIME DEFAULT NULL COMMENT 'MAX(event_timestamp) of the archived rows; see min_event_ts (#1037)' AFTER min_event_ts`,
-	); err != nil {
-		return err
-	}
-	// column_set is the archived file's own column set (#1535): lowercase names,
-	// sorted, comma-joined. It is a GROUPING KEY, not a description — the
-	// DuckDB views generator emits one read_parquet per distinct set so the
-	// bind opens one footer per SCHEMA instead of one per file, and
-	// union_by_name (which is what makes the bind O(files)) is no longer
-	// needed within a group.
-	//
-	// NULL on every row written before this column existed. Absent means
-	// UNKNOWN, never "the same as the others": a partition with no recorded
-	// set cannot join a group, and the generator falls back to the globbed
-	// union_by_name leg rather than silently leaving it out of the view.
-	// `archive reconcile --repair` records it from the footer, offline.
-	if err := ensureColumn(db, "archive_state", "column_set",
-		`ALTER TABLE archive_state ADD COLUMN column_set VARCHAR(4096) DEFAULT NULL COMMENT 'the archived Parquet file own column set: lowercase, sorted, comma-joined (#1535). NULL = unknown (written before this column, or registered by upload); archive reconcile --repair records it from the footer' AFTER max_event_ts`,
-	); err != nil {
+	if err := EnsureArchiveStateSchema(db); err != nil {
 		return err
 	}
 	// gap_lost_at/_detail record an unfillable-gap auto-advance durably
@@ -957,4 +921,56 @@ func InsertSchemaChange(db *sql.DB, ev event.Event, snapshotID *int) error {
 		ev.Timestamp, ev.BinlogFile, ev.EndPos,
 		nullOrString(ev.GTID), ev.Schema, ev.Table, ev.DDLType, ev.DDLQuery, snapArg)
 	return err
+}
+
+
+// EnsureArchiveStateSchema adds the archive_state columns introduced after the
+// initial schema. Idempotent, like EnsureSchema, which calls it.
+//
+// Split out so a caller that needs ONLY this table does not migrate
+// binlog_events as a side effect (#1535). `archive reconcile` is that caller:
+// its dry run is documented as a read-only cron drift monitor, and adding a
+// column to the largest table in the deployment is not something such a run
+// should ever start.
+func EnsureArchiveStateSchema(db *sql.DB) error {
+	// min_event_ts/max_event_ts record the content-derived event_timestamp
+	// range of each archived partition (#1037). A backfill after a capture
+	// stall lands old events in the OLDEST live RANGE partition, so the
+	// Parquet file archived under that partition's hour label can hold rows
+	// from much earlier hours; any pruning that trusts the label alone
+	// (planner hour mapping, date-scoped S3 listings) then silently skips
+	// them. The planner reads these columns to expand archive coverage and to
+	// tell the archive fetcher which mislabeled files a time-scoped read must
+	// still open. NULL on rows written before this column existed (or by
+	// upload/reconcile, which do not scan row contents): the planner falls
+	// back to label-only pruning for those rows, exactly the pre-#1037
+	// behavior.
+	if err := ensureColumn(db, "archive_state", "min_event_ts",
+		`ALTER TABLE archive_state ADD COLUMN min_event_ts DATETIME DEFAULT NULL COMMENT 'MIN(event_timestamp) of the archived rows; NULL for archives written before #1037 or registered by upload/reconcile. Content-derived pruning: may precede the partition hour label when backfilled events landed in the partition' AFTER s3_uploaded_at`,
+	); err != nil {
+		return err
+	}
+	if err := ensureColumn(db, "archive_state", "max_event_ts",
+		`ALTER TABLE archive_state ADD COLUMN max_event_ts DATETIME DEFAULT NULL COMMENT 'MAX(event_timestamp) of the archived rows; see min_event_ts (#1037)' AFTER min_event_ts`,
+	); err != nil {
+		return err
+	}
+	// column_set is the archived file's own column set (#1535): lowercase names,
+	// sorted, comma-joined. It is a GROUPING KEY, not a description — the
+	// DuckDB views generator emits one read_parquet per distinct set so the
+	// bind opens one footer per SCHEMA instead of one per file, and
+	// union_by_name (which is what makes the bind O(files)) is no longer
+	// needed within a group.
+	//
+	// NULL on every row written before this column existed. Absent means
+	// UNKNOWN, never "the same as the others": a partition with no recorded
+	// set cannot join a group, and the generator falls back to the globbed
+	// union_by_name leg rather than silently leaving it out of the view.
+	// `archive reconcile --repair` records it from the footer, offline.
+	if err := ensureColumn(db, "archive_state", "column_set",
+		`ALTER TABLE archive_state ADD COLUMN column_set VARCHAR(4096) DEFAULT NULL COMMENT 'the archived Parquet file own column set: lowercase, sorted, comma-joined (#1535). NULL = unknown (written before this column, or registered without a footer read); archive reconcile --repair records it, needing --deep on an S3-only archive' AFTER max_event_ts`,
+	); err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -707,6 +707,23 @@ func EnsureSchema(db *sql.DB) error {
 	); err != nil {
 		return err
 	}
+	// column_set is the archived file's own column set (#1535): lowercase names,
+	// sorted, comma-joined. It is a GROUPING KEY, not a description — the
+	// DuckDB views generator emits one read_parquet per distinct set so the
+	// bind opens one footer per SCHEMA instead of one per file, and
+	// union_by_name (which is what makes the bind O(files)) is no longer
+	// needed within a group.
+	//
+	// NULL on every row written before this column existed. Absent means
+	// UNKNOWN, never "the same as the others": a partition with no recorded
+	// set cannot join a group, and the generator falls back to the globbed
+	// union_by_name leg rather than silently leaving it out of the view.
+	// `archive reconcile --repair` records it from the footer, offline.
+	if err := ensureColumn(db, "archive_state", "column_set",
+		`ALTER TABLE archive_state ADD COLUMN column_set VARCHAR(4096) DEFAULT NULL COMMENT 'the archived Parquet file own column set: lowercase, sorted, comma-joined (#1535). NULL = unknown (written before this column, or registered by upload); archive reconcile --repair records it from the footer' AFTER max_event_ts`,
+	); err != nil {
+		return err
+	}
 	// gap_lost_at/_detail record an unfillable-gap auto-advance durably
 	// (#402): the advanced checkpoint is persisted, so without these columns
 	// the only trace of the permanently lost events would be an in-memory

--- a/internal/indexer/schema.go
+++ b/internal/indexer/schema.go
@@ -219,7 +219,7 @@ const ddlArchiveState = `CREATE TABLE IF NOT EXISTS archive_state (
     s3_uploaded_at  DATETIME,
     min_event_ts    DATETIME DEFAULT NULL COMMENT 'MIN(event_timestamp) of the archived rows; NULL for archives written before #1037 or registered by upload/reconcile. Content-derived pruning: may precede the partition hour label when backfilled events landed in the partition',
     max_event_ts    DATETIME DEFAULT NULL COMMENT 'MAX(event_timestamp) of the archived rows; see min_event_ts (#1037)',
-    column_set      VARCHAR(4096) DEFAULT NULL COMMENT 'the archived Parquet file own column set: lowercase, sorted, comma-joined (#1535). NULL = unknown (written before this column, or registered by upload); archive reconcile --repair records it from the footer',
+    column_set      VARCHAR(4096) DEFAULT NULL COMMENT 'the archived Parquet file own column set: lowercase, sorted, comma-joined (#1535). NULL = unknown (written before this column, or registered without a footer read); archive reconcile --repair records it, needing --deep on an S3-only archive',
     archived_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UNIQUE KEY uq_partition (partition_name, bintrail_id)
 ) ENGINE=InnoDB`

--- a/internal/indexer/schema.go
+++ b/internal/indexer/schema.go
@@ -219,6 +219,7 @@ const ddlArchiveState = `CREATE TABLE IF NOT EXISTS archive_state (
     s3_uploaded_at  DATETIME,
     min_event_ts    DATETIME DEFAULT NULL COMMENT 'MIN(event_timestamp) of the archived rows; NULL for archives written before #1037 or registered by upload/reconcile. Content-derived pruning: may precede the partition hour label when backfilled events landed in the partition',
     max_event_ts    DATETIME DEFAULT NULL COMMENT 'MAX(event_timestamp) of the archived rows; see min_event_ts (#1037)',
+    column_set      VARCHAR(4096) DEFAULT NULL COMMENT 'the archived Parquet file own column set: lowercase, sorted, comma-joined (#1535). NULL = unknown (written before this column, or registered by upload); archive reconcile --repair records it from the footer',
     archived_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UNIQUE KEY uq_partition (partition_name, bintrail_id)
 ) ENGINE=InnoDB`

--- a/internal/query/archive_groups.go
+++ b/internal/query/archive_groups.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"os"
 	"slices"
 	"strings"
 
@@ -35,8 +36,10 @@ type ArchiveGroup struct {
 // column set (archive_state.column_set, #1535).
 //
 // unrecorded counts partitions under those sources whose column set is NOT
-// recorded — pre-#1535 rows, and rows registered by `upload`, which never reads
-// a footer. It is returned rather than folded into the groups because the two
+// recorded: rows written before #1535, rows an S3-only `archive reconcile`
+// registered without --deep (no remote footer is read without it), and rows
+// whose file is not where the registry says it is. It is returned rather than
+// folded into the groups because the two
 // halves cannot be mixed: a partition with no recorded set cannot join a group
 // (it might hold any columns), and putting each one in a group of its own would
 // restore the per-file bind this exists to remove. Callers use groups ONLY when
@@ -111,7 +114,25 @@ func ArchiveGroups(ctx context.Context, db *sql.DB, sources []string) (groups []
 			unrecorded++
 			continue
 		}
-		byColumns[set] = append(byColumns[set], base+"/"+rel)
+		path := base + "/" + rel
+		if !localFileListable(path) {
+			// A REGISTERED ROW WHOSE FILE IS GONE is a modeled state in this
+			// product, not corruption: `archive reconcile` reports it and only
+			// an explicit --prune clears it. A glob simply does not match the
+			// missing file; an explicit path list makes DuckDB fail the whole
+			// read_parquet, and since a view binds eagerly that failure takes
+			// down every statement in the generated script — events and the
+			// state views with it. So a row we cannot see on disk disqualifies
+			// grouping the same way an unrecorded one does, and the globbed
+			// leg (which tolerates it) stays.
+			//
+			// Local only. An S3 object cannot be probed without a request per
+			// row, which is the per-file cost this whole change removes, so an
+			// S3 row is taken on the registry's word.
+			unrecorded++
+			continue
+		}
+		byColumns[set] = append(byColumns[set], path)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, 0, fmt.Errorf("iterate archive_state column sets: %w", err)
@@ -123,15 +144,35 @@ func ArchiveGroups(ctx context.Context, db *sql.DB, sources []string) (groups []
 	for _, set := range slices.Sorted(maps.Keys(byColumns)) {
 		files := byColumns[set]
 		slices.Sort(files)
+		// Split here rather than through a helper in internal/archive: query
+		// cannot import that package (archive imports baseline, and baseline's
+		// tests reach back to query through recovery — a test-only import
+		// cycle). The empty case never arrives; it was refused above.
 		groups = append(groups, ArchiveGroup{Columns: strings.Split(set, ","), Files: slices.Compact(files)})
 	}
 	return groups, unrecorded, nil
 }
 
+// localFileListable reports whether a path can be named in an explicit
+// read_parquet list. An s3:// URL is taken on trust (see the call site); a
+// local path must exist, because DuckDB fails the entire scan on one absent
+// entry where a glob would simply not match it.
+func localFileListable(path string) bool {
+	if strings.HasPrefix(path, "s3://") {
+		return true
+	}
+	_, err := os.Stat(path)
+	return err == nil
+}
+
 // bintrailIDOf reads the `bintrail_id=<id>` segment an archive base path ends
 // with. Empty when the path does not carry one — the same shape
-// extractBasePath produces from a registry row, so a base without it cannot be
-// matched to a row and is left to the globbed leg.
+// extractBasePath produces from a registry row.
+//
+// A base without one matches no row, so every partition under it counts as
+// unrecorded and the caller keeps the globbed leg for the whole layout. Both
+// producers of these paths always emit the segment; this is the safe answer if
+// one ever stops.
 func bintrailIDOf(base string) string {
 	const marker = "bintrail_id="
 	i := strings.LastIndex(base, marker)

--- a/internal/query/archive_groups.go
+++ b/internal/query/archive_groups.go
@@ -1,0 +1,188 @@
+package query
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+// ArchiveGroup is one set of archived files that share a column set.
+//
+// It exists so a DuckDB view over the archives can name each file list with
+// union_by_name = false. That flag is what makes a bind O(archived files): it
+// asks DuckDB to open EVERY footer to compute a unified schema, and a view
+// re-binds on every statement (#1535). Files that already share a column set
+// need no unification, so a group binds one footer regardless of its size, and
+// the padding union_by_name used to do is written out per group instead.
+type ArchiveGroup struct {
+	// Columns is the shared column set, sorted. It is what the caller pads
+	// against: a column some OTHER group has and this one does not is emitted
+	// as NULL, which is exactly what union_by_name did implicitly.
+	Columns []string
+	// Files are the archived files in this group, as full paths (local) or
+	// s3:// URLs, sorted. Explicit paths, not a glob: a glob would put the
+	// unification back and also costs a LIST per expansion.
+	Files []string
+}
+
+// ArchiveGroups groups every partition registered under sources by its recorded
+// column set (archive_state.column_set, #1535).
+//
+// unrecorded counts partitions under those sources whose column set is NOT
+// recorded — pre-#1535 rows, and rows registered by `upload`, which never reads
+// a footer. It is returned rather than folded into the groups because the two
+// halves cannot be mixed: a partition with no recorded set cannot join a group
+// (it might hold any columns), and putting each one in a group of its own would
+// restore the per-file bind this exists to remove. Callers use groups ONLY when
+// unrecorded is zero, and otherwise keep the globbed union_by_name form —
+// leaving those files out of the view instead would be a silent narrowing of
+// what the view reads. `archive reconcile --repair` records them, offline.
+//
+// The result reads the registry, not the filesystem, so a file that exists
+// under a source but has no archive_state row is not in any group. That is the
+// same registry drift `archive reconcile` exists to report (a dry run exits
+// non-zero on it), and the generated SQL says so.
+//
+// sources are the already-routed base paths (local or s3://) from
+// ResolveArchiveSources or PortableArchiveSources — the routing decision stays
+// with the caller, and each row's file is rebuilt under the base its own
+// bintrail_id was routed to.
+func ArchiveGroups(ctx context.Context, db *sql.DB, sources []string) (groups []ArchiveGroup, unrecorded int, err error) {
+	if db == nil || len(sources) == 0 {
+		return nil, 0, nil
+	}
+	baseByID := make(map[string]string, len(sources))
+	for _, s := range sources {
+		if id := bintrailIDOf(s); id != "" {
+			baseByID[id] = strings.TrimRight(s, "/")
+		}
+	}
+	if len(baseByID) == 0 {
+		return nil, 0, nil
+	}
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT bintrail_id, local_path, s3_key, column_set
+		FROM archive_state
+		WHERE bintrail_id IS NOT NULL`)
+	if err != nil {
+		// 1146 = ER_NO_SUCH_TABLE and 1054 = ER_BAD_FIELD_ERROR: an index that
+		// predates the archive feature, or one that predates this column and
+		// has not been migrated. Neither is an error — the caller falls back to
+		// the globbed leg, which is what it did before this existed.
+		var myErr *mysql.MySQLError
+		if errors.As(err, &myErr) && (myErr.Number == 1146 || myErr.Number == 1054) {
+			return nil, 0, nil
+		}
+		return nil, 0, fmt.Errorf("query archive_state column sets: %w", err)
+	}
+	defer rows.Close()
+
+	byColumns := map[string][]string{}
+	for rows.Next() {
+		var id string
+		var localPath, s3Key, columnSet sql.NullString
+		if err := rows.Scan(&id, &localPath, &s3Key, &columnSet); err != nil {
+			return nil, 0, fmt.Errorf("scan archive_state column set: %w", err)
+		}
+		base, ok := baseByID[id]
+		if !ok {
+			// A source the caller did not route (filtered out, or registered
+			// with neither location). Not this function's to include, and not
+			// an unrecorded partition either — nothing would read it anyway.
+			continue
+		}
+		rel := archiveRelPath(base, localPath.String, s3Key.String)
+		if rel == "" {
+			// A row that names no file under its own source cannot be listed.
+			// It counts as unrecorded: the group set would silently not cover
+			// whatever it points at.
+			unrecorded++
+			continue
+		}
+		set := strings.TrimSpace(columnSet.String)
+		if set == "" {
+			unrecorded++
+			continue
+		}
+		byColumns[set] = append(byColumns[set], base+"/"+rel)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("iterate archive_state column sets: %w", err)
+	}
+
+	// Sorted throughout: the generated SQL is an artifact an operator diffs and
+	// a golden test compares, so two runs over one registry must render byte
+	// for byte the same.
+	for _, set := range slices.Sorted(maps.Keys(byColumns)) {
+		files := byColumns[set]
+		slices.Sort(files)
+		groups = append(groups, ArchiveGroup{Columns: strings.Split(set, ","), Files: slices.Compact(files)})
+	}
+	return groups, unrecorded, nil
+}
+
+// bintrailIDOf reads the `bintrail_id=<id>` segment an archive base path ends
+// with. Empty when the path does not carry one — the same shape
+// extractBasePath produces from a registry row, so a base without it cannot be
+// matched to a row and is left to the globbed leg.
+func bintrailIDOf(base string) string {
+	const marker = "bintrail_id="
+	i := strings.LastIndex(base, marker)
+	if i < 0 {
+		return ""
+	}
+	id := strings.TrimRight(base[i+len(marker):], "/")
+	if id == "" || strings.Contains(id, "/") {
+		return ""
+	}
+	return id
+}
+
+// archiveRelPath is the partition file's path RELATIVE to its source base —
+// the `event_date=…/event_hour=…/<file>.parquet` tail.
+//
+// It is taken from whichever registered location matches the base's own scheme,
+// falling back to the other: rotate writes the same Hive tail into both
+// local_path and s3_key, so either answers, but preferring the matching one
+// keeps a row whose two locations disagree from producing a path under the
+// wrong root. Empty when neither location carries the base's bintrail_id=
+// segment (an `upload --source` pointed below that directory does this).
+func archiveRelPath(base, localPath, s3Key string) string {
+	first, second := localPath, s3Key
+	if strings.HasPrefix(base, "s3://") {
+		first, second = s3Key, localPath
+	}
+	if rel := relAfterBintrailID(first); rel != "" {
+		return rel
+	}
+	return relAfterBintrailID(second)
+}
+
+// relAfterBintrailID returns everything after the `bintrail_id=<id>/` segment.
+func relAfterBintrailID(p string) string {
+	const marker = "bintrail_id="
+	i := strings.LastIndex(p, marker)
+	if i < 0 {
+		return ""
+	}
+	rest := p[i+len(marker):]
+	j := strings.Index(rest, "/")
+	if j < 0 {
+		return ""
+	}
+	rel := strings.TrimPrefix(rest[j+1:], "/")
+	// A traversal segment would build a path outside the source root. The
+	// registry is operator-writable in practice (reconcile inserts what it
+	// scanned), so refuse rather than normalize.
+	if rel == "" || strings.Contains(rel, "..") {
+		return ""
+	}
+	return rel
+}

--- a/internal/query/archive_groups_test.go
+++ b/internal/query/archive_groups_test.go
@@ -2,6 +2,8 @@ package query
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -13,6 +15,21 @@ const (
 	wide   = "commit_ts_us,event_id,query_text"
 	narrow = "event_id"
 )
+
+// touch creates an empty file at path, making it listable. ArchiveGroups stats
+// every LOCAL path it would put in a group: DuckDB fails an explicit
+// read_parquet list on one absent entry, where a glob simply does not match it,
+// so a row whose file is gone disqualifies grouping instead of poisoning it.
+func touch(t *testing.T, path string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
 
 // groupRows builds the archive_state read ArchiveGroups performs.
 func groupRows(rows ...[4]any) *sqlmock.Rows {
@@ -32,7 +49,10 @@ func TestArchiveGroups_groupsByColumnSet(t *testing.T) {
 	}
 	defer db.Close()
 	const id = "aaaa"
-	p := func(d, h string) string { return "/arc/bintrail_id=" + id + "/event_date=" + d + "/event_hour=" + h + "/e.parquet" }
+	root := t.TempDir()
+	p := func(d, h string) string {
+		return touch(t, filepath.Join(root, "bintrail_id="+id, "event_date="+d, "event_hour="+h, "e.parquet"))
+	}
 	mock.ExpectQuery("FROM archive_state").WillReturnRows(groupRows(
 		[4]any{id, p("2026-05-01", "03"), nil, wide},
 		[4]any{id, p("2026-04-01", "01"), nil, narrow},
@@ -40,7 +60,7 @@ func TestArchiveGroups_groupsByColumnSet(t *testing.T) {
 		[4]any{id, p("2026-05-01", "04"), nil, wide},
 	))
 
-	groups, ungrouped, err := ArchiveGroups(context.Background(), db, []string{"/arc/bintrail_id=" + id})
+	groups, ungrouped, err := ArchiveGroups(context.Background(), db, []string{filepath.Join(root, "bintrail_id="+id)})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +93,10 @@ func TestArchiveGroups_oneUnrecordedPartitionIsReported(t *testing.T) {
 	}
 	defer db.Close()
 	const id = "aaaa"
-	base := "/arc/bintrail_id=" + id
+	base := filepath.Join(t.TempDir(), "bintrail_id="+id)
+	touch(t, base+"/event_date=2026-05-01/event_hour=03/e.parquet")
+	touch(t, base+"/event_date=2026-05-01/event_hour=04/e.parquet")
+	touch(t, base+"/event_date=2026-05-01/event_hour=05/e.parquet")
 	mock.ExpectQuery("FROM archive_state").WillReturnRows(groupRows(
 		[4]any{id, base + "/event_date=2026-05-01/event_hour=03/e.parquet", nil, wide},
 		[4]any{id, base + "/event_date=2026-05-01/event_hour=04/e.parquet", nil, nil},
@@ -107,12 +130,16 @@ func TestArchiveGroups_rebuildsUnderTheRoutedBase(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
+	root := t.TempDir()
+	locFile := touch(t, filepath.Join(root, "bintrail_id=locsrc", "event_date=2026-05-01", "event_hour=03", "e.parquet"))
 	mock.ExpectQuery("FROM archive_state").WillReturnRows(groupRows(
 		// Routed to S3: the s3_key tail wins even though a local path exists.
+		// The local file is deliberately NOT created — an s3:// base is taken
+		// on the registry's word, so this row must still be grouped.
 		[4]any{"s3src", "/local/bintrail_id=s3src/event_date=2026-05-01/event_hour=03/local.parquet",
 			"deep/prefix/bintrail_id=s3src/event_date=2026-05-01/event_hour=03/remote.parquet", wide},
 		// Routed locally: the local tail wins.
-		[4]any{"locsrc", "/arc/bintrail_id=locsrc/event_date=2026-05-01/event_hour=03/e.parquet",
+		[4]any{"locsrc", locFile,
 			"k/bintrail_id=locsrc/event_date=2026-05-01/event_hour=03/other.parquet", wide},
 		// A source the caller did not route at all is not this function's to
 		// include, and must not count as unrecorded either.
@@ -120,7 +147,7 @@ func TestArchiveGroups_rebuildsUnderTheRoutedBase(t *testing.T) {
 	))
 
 	groups, ungrouped, err := ArchiveGroups(context.Background(), db,
-		[]string{"s3://bkt/deep/prefix/bintrail_id=s3src", "/arc/bintrail_id=locsrc"})
+		[]string{"s3://bkt/deep/prefix/bintrail_id=s3src", filepath.Join(root, "bintrail_id=locsrc")})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -128,7 +155,7 @@ func TestArchiveGroups_rebuildsUnderTheRoutedBase(t *testing.T) {
 		t.Fatalf("ungrouped = %d, want 0", ungrouped)
 	}
 	want := []string{
-		"/arc/bintrail_id=locsrc/event_date=2026-05-01/event_hour=03/e.parquet",
+		locFile,
 		"s3://bkt/deep/prefix/bintrail_id=s3src/event_date=2026-05-01/event_hour=03/remote.parquet",
 	}
 	if len(groups) != 1 || !reflect.DeepEqual(groups[0].Files, want) {
@@ -194,5 +221,67 @@ func TestArchiveGroups_toleratesAnUnmigratedIndex(t *testing.T) {
 	mock.ExpectQuery("FROM archive_state").WillReturnError(&drivermysql.MySQLError{Number: 1142})
 	if _, _, err := ArchiveGroups(context.Background(), db, []string{"/arc/bintrail_id=aaaa"}); err == nil {
 		t.Error("a permission failure was swallowed")
+	}
+}
+
+// A REGISTERED ROW WHOSE FILE IS GONE is a modeled state here: `archive
+// reconcile` reports it and only an explicit --prune clears it. A glob does not
+// match the missing file and the query returns the rest; an explicit path list
+// makes DuckDB fail the entire read_parquet, and since a view binds eagerly
+// that failure takes down every statement in the generated script.
+//
+// So a local path we cannot stat disqualifies grouping exactly like an
+// unrecorded column set does, and the globbed leg — which tolerates it — stays.
+func TestArchiveGroups_aRegisteredFileThatIsGoneDisqualifiesGrouping(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	const id = "aaaa"
+	base := filepath.Join(t.TempDir(), "bintrail_id="+id)
+	here := touch(t, base+"/event_date=2026-05-01/event_hour=03/e.parquet")
+	gone := base + "/event_date=2026-05-01/event_hour=04/e.parquet"
+	mock.ExpectQuery("FROM archive_state").WillReturnRows(groupRows(
+		[4]any{id, here, nil, wide},
+		[4]any{id, gone, nil, wide},
+	))
+
+	groups, ungrouped, err := ArchiveGroups(context.Background(), db, []string{base})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ungrouped != 1 {
+		t.Fatalf("ungrouped = %d, want 1 — the missing file must disqualify grouping, "+
+			"not be listed in a group DuckDB then refuses to bind", ungrouped)
+	}
+	for _, g := range groups {
+		for _, f := range g.Files {
+			if f == gone {
+				t.Fatalf("a file that is not on disk was put in a group: %s", f)
+			}
+		}
+	}
+}
+
+// An s3:// base is taken on the registry's word. Probing it costs one request
+// per row, which is the per-file cost this whole change exists to remove, so
+// the trade is deliberate: the SQL panel carries a retry for the half that
+// cannot be checked here.
+func TestArchiveGroups_doesNotProbeS3(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	mock.ExpectQuery("FROM archive_state").WillReturnRows(groupRows(
+		[4]any{"aaaa", nil, "k/bintrail_id=aaaa/event_date=2026-05-01/event_hour=03/e.parquet", wide},
+	))
+	groups, ungrouped, err := ArchiveGroups(context.Background(), db, []string{"s3://bkt/k/bintrail_id=aaaa"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ungrouped != 0 || len(groups) != 1 {
+		t.Fatalf("an S3 row was disqualified without being probed: groups=%v ungrouped=%d", groups, ungrouped)
 	}
 }

--- a/internal/query/archive_groups_test.go
+++ b/internal/query/archive_groups_test.go
@@ -1,0 +1,198 @@
+package query
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	drivermysql "github.com/go-sql-driver/mysql"
+)
+
+const (
+	wide   = "commit_ts_us,event_id,query_text"
+	narrow = "event_id"
+)
+
+// groupRows builds the archive_state read ArchiveGroups performs.
+func groupRows(rows ...[4]any) *sqlmock.Rows {
+	r := sqlmock.NewRows([]string{"bintrail_id", "local_path", "s3_key", "column_set"})
+	for _, row := range rows {
+		r.AddRow(row[0], row[1], row[2], row[3])
+	}
+	return r
+}
+
+// The grouping itself: two column sets over four partitions become two groups,
+// each naming its own files under the base the caller routed that source to.
+func TestArchiveGroups_groupsByColumnSet(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	const id = "aaaa"
+	p := func(d, h string) string { return "/arc/bintrail_id=" + id + "/event_date=" + d + "/event_hour=" + h + "/e.parquet" }
+	mock.ExpectQuery("FROM archive_state").WillReturnRows(groupRows(
+		[4]any{id, p("2026-05-01", "03"), nil, wide},
+		[4]any{id, p("2026-04-01", "01"), nil, narrow},
+		[4]any{id, p("2026-04-01", "02"), nil, narrow},
+		[4]any{id, p("2026-05-01", "04"), nil, wide},
+	))
+
+	groups, ungrouped, err := ArchiveGroups(context.Background(), db, []string{"/arc/bintrail_id=" + id})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ungrouped != 0 {
+		t.Fatalf("ungrouped = %d, want 0", ungrouped)
+	}
+	if len(groups) != 2 {
+		t.Fatalf("%d group(s), want 2 (one per column set)", len(groups))
+	}
+	// Sorted by the set string, so "commit_ts_us,…" sorts before "event_id".
+	if want := []string{"commit_ts_us", "event_id", "query_text"}; !reflect.DeepEqual(groups[0].Columns, want) {
+		t.Errorf("group 0 columns = %v, want %v", groups[0].Columns, want)
+	}
+	if want := []string{p("2026-05-01", "03"), p("2026-05-01", "04")}; !reflect.DeepEqual(groups[0].Files, want) {
+		t.Errorf("group 0 files = %v, want %v", groups[0].Files, want)
+	}
+	if want := []string{p("2026-04-01", "01"), p("2026-04-01", "02")}; !reflect.DeepEqual(groups[1].Files, want) {
+		t.Errorf("group 1 files = %v, want %v", groups[1].Files, want)
+	}
+}
+
+// One unrecorded partition disqualifies the whole grouping, and the count says
+// how many. This is the invariant that keeps the file list from silently
+// narrowing what the view reads: the caller only groups when the registry can
+// account for EVERY partition, and otherwise keeps the glob.
+func TestArchiveGroups_oneUnrecordedPartitionIsReported(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	const id = "aaaa"
+	base := "/arc/bintrail_id=" + id
+	mock.ExpectQuery("FROM archive_state").WillReturnRows(groupRows(
+		[4]any{id, base + "/event_date=2026-05-01/event_hour=03/e.parquet", nil, wide},
+		[4]any{id, base + "/event_date=2026-05-01/event_hour=04/e.parquet", nil, nil},
+		// An empty string is the same "not recorded" as NULL: a row an older
+		// repair wrote with a blank value must not form a group of its own,
+		// whose read_parquet would then name no columns at all.
+		[4]any{id, base + "/event_date=2026-05-01/event_hour=05/e.parquet", nil, ""},
+	))
+
+	groups, ungrouped, err := ArchiveGroups(context.Background(), db, []string{base})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ungrouped != 2 {
+		t.Errorf("ungrouped = %d, want 2 (a NULL and an empty column set)", ungrouped)
+	}
+	// The recorded ones are still returned; the CALLER decides not to use them.
+	// Returning nothing here would hide the count's meaning behind an empty
+	// slice and make the two states indistinguishable to a test.
+	if len(groups) != 1 {
+		t.Errorf("%d group(s), want the one recorded set", len(groups))
+	}
+}
+
+// Each row's file is rebuilt under the base ITS OWN source was routed to, and
+// the location matching that base's scheme is preferred. A row carrying both
+// locations must not put an s3:// tail under a local root or the reverse.
+func TestArchiveGroups_rebuildsUnderTheRoutedBase(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	mock.ExpectQuery("FROM archive_state").WillReturnRows(groupRows(
+		// Routed to S3: the s3_key tail wins even though a local path exists.
+		[4]any{"s3src", "/local/bintrail_id=s3src/event_date=2026-05-01/event_hour=03/local.parquet",
+			"deep/prefix/bintrail_id=s3src/event_date=2026-05-01/event_hour=03/remote.parquet", wide},
+		// Routed locally: the local tail wins.
+		[4]any{"locsrc", "/arc/bintrail_id=locsrc/event_date=2026-05-01/event_hour=03/e.parquet",
+			"k/bintrail_id=locsrc/event_date=2026-05-01/event_hour=03/other.parquet", wide},
+		// A source the caller did not route at all is not this function's to
+		// include, and must not count as unrecorded either.
+		[4]any{"unrouted", "/arc/bintrail_id=unrouted/event_date=2026-05-01/event_hour=03/e.parquet", nil, wide},
+	))
+
+	groups, ungrouped, err := ArchiveGroups(context.Background(), db,
+		[]string{"s3://bkt/deep/prefix/bintrail_id=s3src", "/arc/bintrail_id=locsrc"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ungrouped != 0 {
+		t.Fatalf("ungrouped = %d, want 0", ungrouped)
+	}
+	want := []string{
+		"/arc/bintrail_id=locsrc/event_date=2026-05-01/event_hour=03/e.parquet",
+		"s3://bkt/deep/prefix/bintrail_id=s3src/event_date=2026-05-01/event_hour=03/remote.parquet",
+	}
+	if len(groups) != 1 || !reflect.DeepEqual(groups[0].Files, want) {
+		t.Errorf("files = %v, want %v", groups, want)
+	}
+}
+
+// A registry row whose path escapes its own source root is refused rather than
+// normalized, and counts as unrecorded so the caller falls back to the glob.
+// reconcile inserts rows from what it scanned, so this value is not
+// hand-audited anywhere upstream.
+func TestArchiveGroups_refusesATraversalPath(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	mock.ExpectQuery("FROM archive_state").WillReturnRows(groupRows(
+		[4]any{"aaaa", "/arc/bintrail_id=aaaa/../../etc/passwd.parquet", nil, wide},
+	))
+	groups, ungrouped, err := ArchiveGroups(context.Background(), db, []string{"/arc/bintrail_id=aaaa"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(groups) != 0 || ungrouped != 1 {
+		t.Errorf("groups = %v, ungrouped = %d; want the row refused and counted", groups, ungrouped)
+	}
+}
+
+// An index that predates the column is not an error: the caller keeps the
+// globbed leg it has always emitted. Same contract ResolveArchiveSources keeps
+// for a missing archive_state table.
+func TestArchiveGroups_toleratesAnUnmigratedIndex(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		code uint16
+	}{
+		{"no archive_state table", 1146},
+		{"no column_set column", 1054},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			mock.ExpectQuery("FROM archive_state").WillReturnError(&drivermysql.MySQLError{Number: tc.code})
+			groups, ungrouped, err := ArchiveGroups(context.Background(), db, []string{"/arc/bintrail_id=aaaa"})
+			if err != nil || groups != nil || ungrouped != 0 {
+				t.Errorf("groups=%v ungrouped=%d err=%v; want a clean empty result", groups, ungrouped, err)
+			}
+		})
+	}
+
+	// Any OTHER read failure IS an error. Swallowing it would silently drop to
+	// the slow bind with nothing said, which is the same class of quiet
+	// degradation #383 closed on the source list.
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	mock.ExpectQuery("FROM archive_state").WillReturnError(&drivermysql.MySQLError{Number: 1142})
+	if _, _, err := ArchiveGroups(context.Background(), db, []string{"/arc/bintrail_id=aaaa"}); err == nil {
+		t.Error("a permission failure was swallowed")
+	}
+}

--- a/internal/rotation/columnset_integration_test.go
+++ b/internal/rotation/columnset_integration_test.go
@@ -1,0 +1,65 @@
+//go:build integration
+
+package rotation_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/archive"
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/rotation"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// The FORWARD half of #1535: an archive rotation writes now carries its own
+// column set, so a deployment on this build never needs the reconcile backfill
+// for anything it archives from here on.
+//
+// It is a separate test from the reconcile one on purpose. That one inserts its
+// archive_state row BY HAND, so it exercises the repair and not the wiring from
+// ArchivePartition's report into rotation's upsert — which is why blanking
+// `st.Columns` at that call site survived the whole suite, unit and integration
+// alike, leaving the feature inert with CI green.
+func TestIntegrationRotateRecordsTheColumnSet(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	ctx := context.Background()
+
+	// One partition old enough for retention to archive and drop it.
+	h := time.Now().UTC().Add(-48 * time.Hour).Truncate(time.Hour)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h})
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200,
+		h.Add(30*time.Minute).Format("2006-01-02 15:04:05"), nil,
+		"testdb", "orders", 1, "42", nil, nil, []byte(`{"id":42}`))
+
+	const bintrailID = "deadbeef-dead-beef-dead-beefdeadbeef"
+	if _, err := rotation.Perform(ctx, db, dbName, rotation.Options{
+		RetainDur:          24 * time.Hour,
+		RetainRaw:          "24h",
+		ArchiveDir:         t.TempDir(),
+		ArchiveCompression: "zstd",
+		BintrailID:         bintrailID,
+		Format:             "json",
+	}); err != nil {
+		t.Fatalf("rotation.Perform: %v", err)
+	}
+
+	var recorded sql.NullString
+	if err := db.QueryRowContext(ctx,
+		`SELECT column_set FROM archive_state WHERE bintrail_id = ?`, bintrailID).Scan(&recorded); err != nil {
+		t.Fatalf("read back column_set: %v", err)
+	}
+	want := archive.ColumnSet(archive.BinlogEventColumns)
+	if !recorded.Valid || recorded.String != want {
+		t.Fatalf("rotate recorded column_set = %+v, want %q.\n"+
+			"An empty value is worse than a NULL one: reconcile then reports "+
+			"\"column set drift\" instead of \"not recorded\", and the views stay on the per-file bind.",
+			recorded, want)
+	}
+}

--- a/internal/rotation/rotation.go
+++ b/internal/rotation/rotation.go
@@ -159,6 +159,7 @@ func Perform(ctx context.Context, db *sql.DB, dbName string, opts Options) (Resu
 					}
 					var n int64
 					var minTS, maxTS time.Time
+					var columnSet string
 					skipped := false
 					if opts.Retry && fileExists(outPath) {
 						// A file existing at outPath with size>0 is NOT sufficient
@@ -194,7 +195,7 @@ func Perform(ctx context.Context, db *sql.DB, dbName string, opts Options) (Resu
 						if aerr != nil {
 							return Result{}, fmt.Errorf("archive partition %s: %w", name, aerr)
 						}
-						n, minTS, maxTS = st.Rows, st.MinEventTS, st.MaxEventTS
+						n, minTS, maxTS, columnSet = st.Rows, st.MinEventTS, st.MaxEventTS, st.Columns
 						// A partition whose CONTENT escapes its hour label holds
 						// backfilled events (#1037): old rows replayed after a
 						// capture stall land in the oldest live RANGE partition.
@@ -249,10 +250,15 @@ func Perform(ctx context.Context, db *sql.DB, dbName string, opts Options) (Resu
 						if !maxTS.IsZero() {
 							insertMax = maxTS.UTC()
 						}
+						// column_set: the file's own column set, straight from
+						// the writer that just produced it (#1535). Recorded
+						// here so the views generator can group the layout by
+						// schema instead of making DuckDB open every footer at
+						// bind time.
 						if _, err := db.ExecContext(ctx,
 							`INSERT INTO archive_state
-								(partition_name, bintrail_id, local_path, file_size_bytes, row_count, s3_bucket, s3_key, min_event_ts, max_event_ts)
-							VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+								(partition_name, bintrail_id, local_path, file_size_bytes, row_count, s3_bucket, s3_key, min_event_ts, max_event_ts, column_set)
+							VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 							ON DUPLICATE KEY UPDATE
 								local_path = VALUES(local_path),
 								file_size_bytes = VALUES(file_size_bytes),
@@ -260,8 +266,9 @@ func Perform(ctx context.Context, db *sql.DB, dbName string, opts Options) (Resu
 								s3_bucket = COALESCE(VALUES(s3_bucket), s3_bucket),
 								s3_key = COALESCE(VALUES(s3_key), s3_key),
 								min_event_ts = VALUES(min_event_ts),
-								max_event_ts = VALUES(max_event_ts)`,
-							name, opts.BintrailID, outPath, fileSize, n, insertBucket, insertKey, insertMin, insertMax,
+								max_event_ts = VALUES(max_event_ts),
+								column_set = VALUES(column_set)`,
+							name, opts.BintrailID, outPath, fileSize, n, insertBucket, insertKey, insertMin, insertMax, columnSet,
 						); err != nil {
 							return Result{}, fmt.Errorf("record archive state for %s: %w", name, err)
 						}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -388,6 +388,7 @@ func InitIndexTables(t *testing.T, db *sql.DB) {
 		s3_uploaded_at  DATETIME,
 		min_event_ts    DATETIME DEFAULT NULL,
 		max_event_ts    DATETIME DEFAULT NULL,
+		column_set      VARCHAR(4096) DEFAULT NULL,
 		archived_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 		UNIQUE KEY uq_partition (partition_name, bintrail_id)
 	) ENGINE=InnoDB`)

--- a/internal/views/groups_execute_test.go
+++ b/internal/views/groups_execute_test.go
@@ -158,3 +158,103 @@ func lower(names []string) []string {
 	}
 	return out
 }
+
+// The grouped file names its archives explicitly, so it stops covering anything
+// rotated after it was written. The globbed form does not: DuckDB expands the
+// glob on every statement.
+//
+// That difference is invisible in the result — a query over the most recent
+// hours just returns nothing for them — so the file has to say which of the two
+// it is. The header used to assert the globbed behaviour unconditionally, which
+// on a grouped file is a sentence telling the reader the exact opposite of what
+// will happen.
+func TestGeneratedSQL_saysWhetherItsFileListIsFixed(t *testing.T) {
+	base := "/arc/bintrail_id=aaaa"
+	globbed := Generate(Input{ArchiveSources: []string{base}})
+	grouped := Generate(Input{
+		ArchiveSources: []string{base},
+		ArchiveGroups: []ArchiveGroup{{
+			Columns: []string{"event_id"},
+			Files:   []string{base + "/event_date=2026-05-01/event_hour=03/e.parquet"},
+		}},
+	})
+
+	if !strings.Contains(globbed, "globs below") ||
+		!strings.Contains(globbed, "keep picking up newly rotated partitions") {
+		t.Errorf("the globbed file no longer states that it follows the layout:\n%s", globbed)
+	}
+	if strings.Contains(grouped, "keep picking up newly rotated partitions") {
+		t.Errorf("the grouped file claims it follows the layout; its file list is fixed:\n%s", grouped)
+	}
+	for _, want := range []string{
+		"NOTHING here updates itself",
+		"no error and no warning",
+		"schedule your rotation archives on",
+	} {
+		if !strings.Contains(grouped, want) {
+			t.Errorf("the grouped file does not warn that its list is frozen (missing %q):\n%s", want, grouped)
+		}
+	}
+	// And the events view repeats it where the list actually is, because that
+	// is what a reader scrolls to when a recent query comes back empty.
+	if !strings.Contains(grouped, "The file list is FIXED") {
+		t.Errorf("the events view does not state that its file list is fixed:\n%s", grouped)
+	}
+}
+
+// A registered partition whose file is gone is a MODELED state: reconcile
+// reports it and only an explicit --prune clears it. A glob does not match the
+// missing file and the query returns the rest; an explicit path list makes
+// DuckDB fail the whole read_parquet, and a view binds eagerly, so that failure
+// takes down every statement in the script — the events view and every state
+// view after it.
+//
+// Executed rather than asserted on text: which of the two DuckDB does is the
+// entire finding, and only the engine can be asked.
+func TestGroupedEvents_aMissingFileWouldBreakEveryView(t *testing.T) {
+	root := t.TempDir()
+	const id = "11111111-2222-3333-4444-555555555555"
+	writeNarrowFixtureArchive(t, root, id, "2026-05-01", "03", 0)
+	base := filepath.Join(root, "bintrail_id="+id)
+	present := filepath.Join(base, "event_date=2026-05-01", "event_hour=03", "events.parquet")
+	gone := filepath.Join(base, "event_date=2026-04-01", "event_hour=01", "events.parquet")
+
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// What the generator must never emit: a group listing a file that is not
+	// there. Proven here so the guard in query.ArchiveGroups has a stated
+	// consequence rather than a plausible one.
+	grouped := Generate(Input{
+		ArchiveSources: []string{base},
+		ArchiveGroups:  []ArchiveGroup{{Columns: lower(archiveColumnNames()), Files: []string{present, gone}}},
+	})
+	if _, err := db.Exec(grouped); err == nil {
+		t.Fatal("DuckDB accepted a file list naming a file that does not exist; " +
+			"the guard in query.ArchiveGroups would then be protecting against nothing")
+	} else if !strings.Contains(err.Error(), "No files found") {
+		t.Fatalf("unexpected failure shape: %v", err)
+	}
+
+	// The globbed form over the same layout is unaffected: it never names the
+	// missing file. This is what the fallback preserves.
+	globbed := Generate(Input{ArchiveSources: []string{base}})
+	if _, err := db.Exec(globbed); err != nil {
+		t.Fatalf("the globbed form failed over a layout with a registered-but-missing file: %v", err)
+	}
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM events`).Scan(&n); err != nil || n != 1 {
+		t.Fatalf("globbed events: n=%d err=%v, want the surviving row", n, err)
+	}
+}
+
+func archiveColumnNames() []string {
+	out := make([]string, len(archive.BinlogEventColumns))
+	for i, c := range archive.BinlogEventColumns {
+		out[i] = c.Name
+	}
+	return out
+}

--- a/internal/views/groups_execute_test.go
+++ b/internal/views/groups_execute_test.go
@@ -1,0 +1,160 @@
+package views
+
+import (
+	"database/sql"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+
+	"github.com/dbtrail/dbtrail/internal/archive"
+	"github.com/dbtrail/dbtrail/internal/baseline"
+)
+
+// writeNarrowFixtureArchive writes an archived partition the way a build that
+// predates a column would have: the REAL writer, over a PREFIX of the real
+// column set.
+//
+// The narrow shape is what makes union_by_name load-bearing on this layout and
+// is therefore the only fixture that can tell a correct grouping from a wrong
+// one. A fixture where every file has every column passes under any scheme,
+// including the two DuckDB behaviours #1535 measured and rejected (silently
+// dropping a column with the narrow file first, failing the read with the wide
+// file first).
+func writeNarrowFixtureArchive(t *testing.T, root, id, date, hour string, drop int) []string {
+	t.Helper()
+	cols := slices.Clone(archive.BinlogEventColumns)
+	cols = cols[:len(cols)-drop]
+	path := filepath.Join(root, "bintrail_id="+id, "event_date="+date, "event_hour="+hour, "events.parquet")
+	w, err := baseline.NewWriter(path, cols, baseline.WriterConfig{Compression: "none", RowGroupSize: 100})
+	if err != nil {
+		t.Fatalf("archive writer: %v", err)
+	}
+	values := []string{
+		"7", "binlog.000001", "100", "200", "2026-05-01 " + hour + ":00:00", "",
+		"42", "shop", "orders", "1", "7",
+		`["status"]`, `{"id":7}`, `{"id":7,"status":"paid"}`,
+		"1", "UPDATE orders SET status='paid'", "abc123", "1777000000000000",
+	}
+	nulls := make([]bool, len(cols))
+	nulls[5] = true // gtid
+	if err := w.WriteRow(values[:len(cols)], nulls); err != nil {
+		t.Fatalf("write archive row: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close archive writer: %v", err)
+	}
+	names := make([]string, len(cols))
+	for i, c := range cols {
+		names[i] = c.Name
+	}
+	return names
+}
+
+// TestGroupedEvents_executeInDuckDB is the discriminating test for #1535: two
+// groups whose column sets DIFFER, executed by the real engine, queried for the
+// column only one of them has.
+//
+// A generator test cannot catch this. The two failure modes the issue measured
+// are both SILENT or engine-side: reading both groups' files in one
+// union_by_name = false scan either drops query_text from the result with no
+// error at all (narrow file first) or fails at read time (wide file first).
+// Only running the SQL distinguishes them, and only a fixture where one file
+// genuinely lacks the column makes either reachable.
+func TestGroupedEvents_executeInDuckDB(t *testing.T) {
+	root := t.TempDir()
+	const id = "11111111-2222-3333-4444-555555555555"
+	// Two generations of the same source: an old partition written before
+	// query_text/query_hash/commit_ts_us existed, and a current one.
+	oldCols := writeNarrowFixtureArchive(t, root, id, "2026-04-01", "01", 3)
+	newCols := writeNarrowFixtureArchive(t, root, id, "2026-05-01", "03", 0)
+	if len(oldCols) == len(newCols) {
+		t.Fatal("the fixture's two groups have the same column set, so it cannot discriminate")
+	}
+
+	base := filepath.Join(root, "bintrail_id="+id)
+	in := Input{
+		GeneratedAt:    time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
+		Version:        "test",
+		ArchiveSources: []string{base},
+		ArchiveGroups: []ArchiveGroup{
+			{Columns: lower(oldCols), Files: []string{filepath.Join(base, "event_date=2026-04-01", "event_hour=01", "events.parquet")}},
+			{Columns: lower(newCols), Files: []string{filepath.Join(base, "event_date=2026-05-01", "event_hour=03", "events.parquet")}},
+		},
+	}
+	sqlText := Generate(in)
+
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(sqlText); err != nil {
+		t.Fatalf("DuckDB rejected the grouped views:\n%v\n\n--- generated ---\n%s", err, sqlText)
+	}
+
+	// Both groups' rows are in the view, each attributed to its own partition.
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM events`).Scan(&n); err != nil {
+		t.Fatalf("count events: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("events has %d row(s), want 2 — one group is missing from the union", n)
+	}
+
+	// The column only the NEW group has: present on its row, NULL on the old
+	// one. Both halves matter. A wrong grouping that drops the column entirely
+	// still returns two rows and still has query_text = NULL on both.
+	rows, err := db.Query(`SELECT CAST("event_date" AS VARCHAR), "query_text" FROM events ORDER BY 1`)
+	if err != nil {
+		t.Fatalf("query query_text: %v", err)
+	}
+	defer rows.Close()
+	got := map[string]sql.NullString{}
+	for rows.Next() {
+		var d string
+		var q sql.NullString
+		if err := rows.Scan(&d, &q); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got[d] = q
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+	if q := got["2026-04-01"]; q.Valid {
+		t.Errorf("the old partition reports query_text = %q; its file does not have the column, so it must read NULL", q.String)
+	}
+	if q := got["2026-05-01"]; !q.Valid || q.String != "UPDATE orders SET status='paid'" {
+		t.Errorf("the new partition's query_text = %+v, want the statement it stored — "+
+			"a group that reads its files without its own column set loses the column silently", q)
+	}
+
+	// commit_time is derived from commit_ts_us, which the old group lacks. The
+	// derived column has to be padded too, or the two legs project a different
+	// number of columns and the UNION lines the wrong pairs up.
+	var ct sql.NullTime
+	if err := db.QueryRow(`SELECT "commit_time" FROM events WHERE CAST("event_date" AS VARCHAR) = '2026-04-01'`).Scan(&ct); err != nil {
+		t.Fatalf("query commit_time: %v", err)
+	}
+	if ct.Valid {
+		t.Errorf("the old partition reports commit_time = %s from a file with no commit_ts_us", ct.Time)
+	}
+
+	// Not cosmetic: union_by_name = true here is the 114s bind the issue
+	// measured, and it would still pass every assertion above.
+	if strings.Contains(sqlText, "union_by_name = true") {
+		t.Errorf("a grouped events view still asks for union_by_name; the bind stays O(archived files):\n%s", sqlText)
+	}
+}
+
+func lower(names []string) []string {
+	out := make([]string, len(names))
+	for i, n := range names {
+		out[i] = strings.ToLower(n)
+	}
+	return out
+}

--- a/internal/views/testdata/views.follow.golden.sql
+++ b/internal/views/testdata/views.follow.golden.sql
@@ -120,7 +120,12 @@ CREATE OR REPLACE VIEW "state_shop_order_items_2" AS
 -- union_by_name is required, not cosmetic: archives written before a column
 -- existed simply lack it, and those files must read back with NULLs rather
 -- than failing the whole scan. A column absent from EVERY archived file is
--- still an error: drop it from the SELECT if you hit that on an old archive.
+-- still an error here: drop it from the SELECT if you hit that on an old
+-- archive. (The grouped form this file is not using pads it with NULL.)
+--
+-- COST: union_by_name makes DuckDB open one Parquet footer per archived file
+-- to unify the schema, and a view re-binds on every statement, so the wait
+-- before the first row grows with the archive.
 --
 -- SCOPE: these are the ARCHIVED events only. Partitions rotation has not
 -- archived yet exist solely in the index, so the most recent window is

--- a/internal/views/testdata/views.golden.sql
+++ b/internal/views/testdata/views.golden.sql
@@ -83,7 +83,8 @@ CREATE OR REPLACE VIEW "state_shop_order_items_2" AS
 -- union_by_name is required, not cosmetic: archives written before a column
 -- existed simply lack it, and those files must read back with NULLs rather
 -- than failing the whole scan. A column absent from EVERY archived file is
--- still an error: drop it from the SELECT if you hit that on an old archive.
+-- still an error here: drop it from the SELECT if you hit that on an old
+-- archive. (The grouped form this file is not using pads it with NULL.)
 --
 -- COST: union_by_name makes DuckDB open one Parquet footer per archived file
 -- to unify the schema, and a view re-binds on every statement, so the wait

--- a/internal/views/testdata/views.golden.sql
+++ b/internal/views/testdata/views.golden.sql
@@ -85,6 +85,10 @@ CREATE OR REPLACE VIEW "state_shop_order_items_2" AS
 -- than failing the whole scan. A column absent from EVERY archived file is
 -- still an error: drop it from the SELECT if you hit that on an old archive.
 --
+-- COST: union_by_name makes DuckDB open one Parquet footer per archived file
+-- to unify the schema, and a view re-binds on every statement, so the wait
+-- before the first row grows with the archive.
+--
 -- SCOPE: these are the ARCHIVED events only. Partitions rotation has not
 -- archived yet exist solely in the index, so the most recent window is
 -- absent here and reads as if nothing happened.

--- a/internal/views/testdata/views.live.golden.sql
+++ b/internal/views/testdata/views.live.golden.sql
@@ -114,7 +114,12 @@ ATTACH '' AS "bintrail_live" (TYPE mysql, SECRET "bintrail_index", READ_ONLY);
 -- union_by_name is required, not cosmetic: archives written before a column
 -- existed simply lack it, and those files must read back with NULLs rather
 -- than failing the whole scan. A column absent from EVERY archived file is
--- still an error: drop it from the SELECT if you hit that on an old archive.
+-- still an error here: drop it from the SELECT if you hit that on an old
+-- archive. (The grouped form this file is not using pads it with NULL.)
+--
+-- COST: union_by_name makes DuckDB open one Parquet footer per archived file
+-- to unify the schema, and a view re-binds on every statement, so the wait
+-- before the first row grows with the archive.
 --
 -- Two legs: the Parquet for everything rotation has archived, the index for
 -- events it has not. A partition that has been archived but not yet dropped

--- a/internal/views/testdata/views.newest.golden.sql
+++ b/internal/views/testdata/views.newest.golden.sql
@@ -140,7 +140,12 @@ CREATE OR REPLACE VIEW "state_shop_order_items_2" AS
 -- union_by_name is required, not cosmetic: archives written before a column
 -- existed simply lack it, and those files must read back with NULLs rather
 -- than failing the whole scan. A column absent from EVERY archived file is
--- still an error: drop it from the SELECT if you hit that on an old archive.
+-- still an error here: drop it from the SELECT if you hit that on an old
+-- archive. (The grouped form this file is not using pads it with NULL.)
+--
+-- COST: union_by_name makes DuckDB open one Parquet footer per archived file
+-- to unify the schema, and a view re-binds on every statement, so the wait
+-- before the first row grows with the archive.
 --
 -- SCOPE: these are the ARCHIVED events only. Partitions rotation has not
 -- archived yet exist solely in the index, so the most recent window is

--- a/internal/views/views.go
+++ b/internal/views/views.go
@@ -90,6 +90,18 @@ type BaselineTable struct {
 	SchemaKnown bool
 }
 
+// ArchiveGroup is one set of archived files that share a column set, as read
+// back from archive_state by query.ArchiveGroups (#1535). Restated here as a
+// plain struct so this package keeps generating text out of values and links
+// nothing to reach the registry.
+type ArchiveGroup struct {
+	// Columns is the group's shared column set, lowercase. A column another
+	// group has and this one does not is emitted as NULL.
+	Columns []string
+	// Files are the group's archived files: full local paths or s3:// URLs.
+	Files []string
+}
+
 // LiveIndex names the index whose `binlog_events` the events view unions in as
 // its hot leg, so a query is fresh to capture lag instead of to the archive
 // retention window (#1480).
@@ -187,6 +199,22 @@ type Input struct {
 	// named the roots with --archive-dir/--archive-s3 gets exactly what they
 	// named, both of them if they passed both (#1456).
 	PortableRouting bool
+	// ArchiveGroups, when non-empty, REPLACES the single globbed cold leg with
+	// one leg per column set (#1535). Each group names its files explicitly and
+	// reads them with union_by_name = false, so the bind opens one footer per
+	// GROUP instead of one per file — the cost that made a statement over the
+	// events view wait on every archive ever written.
+	//
+	// Correctness is preserved by writing out what union_by_name was doing: a
+	// column a group does not have is emitted as NULL. Absent groups keep the
+	// globbed form, which is what every caller did before this existed.
+	ArchiveGroups []ArchiveGroup
+	// UngroupedPartitions is how many registered partitions have no recorded
+	// column set. It must be zero for ArchiveGroups to be used — see
+	// query.ArchiveGroups — and it is carried here so the file can SAY why it
+	// still binds the slow way instead of leaving the operator to wonder.
+	UngroupedPartitions int
+
 	// ArchiveDiscoveryFailed is set when the registry could not be read at
 	// all. The file then says so instead of "none registered", which would
 	// state a cause the caller does not know. A bool, not the error: the
@@ -1164,10 +1192,32 @@ func writeEventsView(b *strings.Builder, in Input, stateSurvives bool) bool {
 
 	if cold {
 		b.WriteString("--\n")
-		b.WriteString("-- union_by_name is required, not cosmetic: archives written before a column\n")
-		b.WriteString("-- existed simply lack it, and those files must read back with NULLs rather\n")
-		b.WriteString("-- than failing the whole scan. A column absent from EVERY archived file is\n")
-		b.WriteString("-- still an error: drop it from the SELECT if you hit that on an old archive.\n")
+		if len(in.ArchiveGroups) > 0 {
+			fmt.Fprintf(b, "-- The archives are read in %d group(s), one per column set. Archives written\n", len(in.ArchiveGroups))
+			b.WriteString("-- before a column existed simply lack it, so that column is selected as NULL\n")
+			b.WriteString("-- for the group that lacks it. Files inside a group share a column set, which\n")
+			b.WriteString("-- is why each read_parquet can say union_by_name = false: with it on, DuckDB\n")
+			b.WriteString("-- opens EVERY file's footer to unify the schema, on every statement, and the\n")
+			b.WriteString("-- wait grows with the archive. Grouping makes that one footer per group.\n")
+			b.WriteString("--\n")
+			b.WriteString("-- The file list comes from archive_state, so a file under one of these roots\n")
+			b.WriteString("-- with no row there is not read. `bintrail archive reconcile` reports those.\n")
+		} else {
+			b.WriteString("-- union_by_name is required, not cosmetic: archives written before a column\n")
+			b.WriteString("-- existed simply lack it, and those files must read back with NULLs rather\n")
+			b.WriteString("-- than failing the whole scan. A column absent from EVERY archived file is\n")
+			b.WriteString("-- still an error: drop it from the SELECT if you hit that on an old archive.\n")
+			b.WriteString("--\n")
+			b.WriteString("-- COST: union_by_name makes DuckDB open one Parquet footer per archived file\n")
+			b.WriteString("-- to unify the schema, and a view re-binds on every statement, so the wait\n")
+			b.WriteString("-- before the first row grows with the archive.\n")
+			if in.UngroupedPartitions > 0 {
+				fmt.Fprintf(b, "-- %d archived partition(s) have no recorded column set, so they cannot be\n", in.UngroupedPartitions)
+				b.WriteString("-- grouped by schema. `bintrail archive reconcile --repair` records it from\n")
+				b.WriteString("-- each footer, once, offline; regenerating this file afterwards emits one\n")
+				b.WriteString("-- read_parquet per column set instead, which binds one footer per group.\n")
+			}
+		}
 	}
 
 	switch {
@@ -1189,9 +1239,9 @@ func writeEventsView(b *strings.Builder, in Input, stateSurvives bool) bool {
 		writeLiveCostNote(b, true)
 		b.WriteString("CREATE OR REPLACE VIEW \"events\" AS\n")
 		b.WriteString("  WITH cold AS (\n")
-		writeEventSelect(b, in, false, "    ")
+		writeColdSide(b, in, "    ")
 		b.WriteString("\n  ), hot AS (\n")
-		writeEventSelect(b, in, true, "    ")
+		writeEventSelect(b, in, true, nil, "    ")
 		b.WriteString("\n  )\n")
 		b.WriteString("  SELECT * FROM cold\n")
 		b.WriteString("  UNION ALL BY NAME\n")
@@ -1211,7 +1261,7 @@ func writeEventsView(b *strings.Builder, in Input, stateSurvives bool) bool {
 		writeAttachDegradeNote(b, stateSurvives, false)
 		writeLiveCostNote(b, false)
 		b.WriteString("CREATE OR REPLACE VIEW \"events\" AS\n")
-		writeEventSelect(b, in, true, "  ")
+		writeEventSelect(b, in, true, nil, "  ")
 		b.WriteString(";\n\n")
 	default:
 		b.WriteString("--\n")
@@ -1232,7 +1282,7 @@ func writeEventsView(b *strings.Builder, in Input, stateSurvives bool) bool {
 			b.WriteString("--   bintrail views --index-dsn ... --include-live\n")
 		}
 		b.WriteString("CREATE OR REPLACE VIEW \"events\" AS\n")
-		writeEventSelect(b, in, false, "  ")
+		writeColdSide(b, in, "  ")
 		b.WriteString(";\n\n")
 	}
 	return true
@@ -1265,11 +1315,33 @@ func writeLiveCostNote(b *strings.Builder, withCold bool) {
 	b.WriteString("-- event_timestamp and on schema_name/table_name.\n")
 }
 
+// writeColdSide renders the archive half of the events view: one SELECT over
+// the whole globbed layout, or — when the column sets are recorded — one per
+// group, joined by UNION ALL BY NAME.
+//
+// BY NAME, not positional: the groups pad different columns, so their projected
+// order is the same only because both walk archive.BinlogEventColumns. Relying
+// on that would make a future reordering of that list silently misalign two
+// groups' columns instead of failing, and a UNION that misaligns is a wrong
+// answer, not an error.
+func writeColdSide(b *strings.Builder, in Input, indent string) {
+	if len(in.ArchiveGroups) == 0 {
+		writeEventSelect(b, in, false, nil, indent)
+		return
+	}
+	for i := range in.ArchiveGroups {
+		if i > 0 {
+			b.WriteString("\n" + indent + "UNION ALL BY NAME\n")
+		}
+		writeEventSelect(b, in, false, &in.ArchiveGroups[i], indent)
+	}
+}
+
 // writeEventSelect renders one leg of the events view. Both legs go through
 // here so the derived columns (the event_type label, commit_time) cannot drift
 // between them: two hand-written copies of one projection is how a UNION starts
 // reporting different things for the same event depending on its age.
-func writeEventSelect(b *strings.Builder, in Input, live bool, indent string) {
+func writeEventSelect(b *strings.Builder, in Input, live bool, group *ArchiveGroup, indent string) {
 	exclude := make(map[string]bool, len(in.ExcludeEventColumns))
 	for _, c := range in.ExcludeEventColumns {
 		exclude[strings.ToLower(c)] = true
@@ -1305,18 +1377,21 @@ func writeEventSelect(b *strings.Builder, in Input, live bool, indent string) {
 		b.WriteString(col + "\"bintrail_id\", \"event_date\", \"event_hour\",\n")
 	}
 
-	has := liveColumnSet(in, live)
+	has := legColumnSet(in, live, group)
 	for _, c := range archive.BinlogEventColumns {
 		if exclude[strings.ToLower(c.Name)] {
 			continue
 		}
 		if has != nil && !has[strings.ToLower(c.Name)] {
-			// The hot leg's union_by_name. This index does not have the column
-			// (it was migrated to an older point than this build's schema);
-			// naming it would fail the whole file with a binder error and
-			// define no view at all, so it reads back NULL the same way an old
-			// archive's missing column does.
-			writeMissingLiveColumn(b, col, c.Name)
+			// The leg's own union_by_name, written out. On the HOT leg the
+			// index does not have the column (it was migrated to an older
+			// point than this build's schema); naming it would fail the whole
+			// file with a binder error and define no view at all. On a COLD
+			// GROUP the archived files in it were written before the column
+			// existed, which is precisely what union_by_name used to paper
+			// over for the whole layout at the cost of a footer read per file.
+			// Either way it reads back NULL.
+			writeMissingColumn(b, col, c.Name, missingReason(live))
 			continue
 		}
 		switch c.Name {
@@ -1378,18 +1453,35 @@ func writeEventSelect(b *strings.Builder, in Input, live bool, indent string) {
 		fmt.Fprintf(b, "\n%sFROM %s.\"binlog_events\"", indent, quoteIdent(liveAttachAlias))
 		return
 	}
+	paths := make([]string, 0, len(in.ArchiveSources))
+	if group != nil {
+		paths = append(paths, group.Files...)
+	} else {
+		for _, src := range in.ArchiveSources {
+			paths = append(paths, archiveGlob(src))
+		}
+	}
 	b.WriteString("\n" + indent + "FROM read_parquet(\n")
 	b.WriteString(indent + "  [\n")
-	for i, src := range in.ArchiveSources {
+	for i, p := range paths {
 		sep := ","
-		if i == len(in.ArchiveSources)-1 {
+		if i == len(paths)-1 {
 			sep = ""
 		}
-		fmt.Fprintf(b, "%s    %s%s\n", indent, sqlString(archiveGlob(src)), sep)
+		fmt.Fprintf(b, "%s    %s%s\n", indent, sqlString(p), sep)
 	}
 	b.WriteString(indent + "  ],\n")
 	b.WriteString(indent + "  hive_partitioning = true,\n")
-	b.WriteString(indent + "  union_by_name = true\n")
+	// The whole point of a group: its files share a column set, so there is
+	// nothing to unify and DuckDB binds ONE footer for the list instead of
+	// opening every one of them. hive_partitioning still reads bintrail_id,
+	// event_date and event_hour off these explicit paths, and a filter on them
+	// still prunes files, exactly as it does over a glob.
+	if group != nil {
+		b.WriteString(indent + "  union_by_name = false\n")
+	} else {
+		b.WriteString(indent + "  union_by_name = true\n")
+	}
 	b.WriteString(indent + ")")
 }
 
@@ -1454,25 +1546,47 @@ func commentSafe(s string) string {
 	return strings.NewReplacer("\n", " ", "\r", " ").Replace(s)
 }
 
-// liveColumnSet returns the lookup for which columns the hot leg may name, or
-// nil when every column is nameable — the cold leg (whose union_by_name handles
-// its own absences) and a producer that observed no column set.
-func liveColumnSet(in Input, live bool) map[string]bool {
-	if !live || len(in.LiveIndex.TableColumns) == 0 {
+// legColumnSet returns the lookup for which columns THIS leg may name, or nil
+// when every column is nameable: a producer that observed no column set, and
+// the globbed cold leg, whose union_by_name still handles its own absences.
+//
+// A cold GROUP always has one, even when it holds every column: the set is what
+// the group was formed on, so trusting it is not an extra assumption, and a
+// group that named a column its files lack would fail the whole view with a
+// binder error — the failure union_by_name = false trades away.
+func legColumnSet(in Input, live bool, group *ArchiveGroup) map[string]bool {
+	var names []string
+	switch {
+	case group != nil:
+		names = group.Columns
+	case live:
+		names = in.LiveIndex.TableColumns
+	}
+	if len(names) == 0 {
 		return nil
 	}
-	has := make(map[string]bool, len(in.LiveIndex.TableColumns))
-	for _, c := range in.LiveIndex.TableColumns {
+	has := make(map[string]bool, len(names))
+	for _, c := range names {
 		has[strings.ToLower(c)] = true
 	}
 	return has
 }
 
-// writeMissingLiveColumn emits the NULL placeholders for one column this index
-// does not have. It follows the projection's own shape: the two columns that
-// render as two outputs must produce two NULLs, or the legs stop lining up.
-func writeMissingLiveColumn(b *strings.Builder, col, name string) {
-	const why = " -- not a column of this index's binlog_events\n"
+// missingReason is the end-of-line comment a NULL placeholder carries, naming
+// the leg it is missing FROM. Two legs put a NULL in the same output column for
+// unrelated reasons, and a reader deciding whether to re-archive or re-migrate
+// needs to know which one they are looking at.
+func missingReason(live bool) string {
+	if live {
+		return " -- not a column of this index's binlog_events\n"
+	}
+	return " -- not a column of the archives in this group\n"
+}
+
+// writeMissingColumn emits the NULL placeholders for one column this leg does
+// not have. It follows the projection's own shape: the two columns that render
+// as two outputs must produce two NULLs, or the legs stop lining up.
+func writeMissingColumn(b *strings.Builder, col, name, why string) {
 	switch name {
 	case "event_type":
 		b.WriteString(col + "NULL AS \"event_type_code\"," + why)

--- a/internal/views/views.go
+++ b/internal/views/views.go
@@ -582,6 +582,14 @@ func writeHeader(b *strings.Builder, in Input) {
 		orUnknown(in.Version), in.GeneratedAt.UTC().Format(time.RFC3339))
 	b.WriteString("--\n")
 	b.WriteString("-- THIS FILE IS A SNAPSHOT OF THE LAYOUT, NOT A LIVE BINDING. ")
+	// The events view follows the layout only when it is GLOBBED. A grouped one
+	// (#1535) names its archived files one by one, which is what buys the cheap
+	// bind and what costs the self-updating: partitions archived later are not
+	// in it. Every sentence below that says the file keeps up with rotation is
+	// gated on this, because getting it wrong is worse than saying nothing —
+	// the reader keeps a file that quietly stopped covering the recent end of
+	// their history.
+	grouped := len(in.ArchiveGroups) > 0
 	// checksSnapshot, not Follow.follows(), for the sentence below that names
 	// the dropped-table check. The two are the same today for every render a
 	// producer makes, and they come apart for a filtered one: writeStateViews
@@ -603,7 +611,14 @@ func writeHeader(b *strings.Builder, in Input) {
 		if in.Follow == FollowNewest {
 			how = "select the newest completed snapshot"
 		}
-		if in.rendersEvents() {
+		if in.rendersEvents() && grouped {
+			b.WriteString("The events view below\n")
+			b.WriteString("-- names the archived files it reads one by one, so partitions archived\n")
+			b.WriteString("-- after this file was written are NOT in it, with no error and no warning:\n")
+			b.WriteString("-- a query over the most recent hours simply returns nothing for them.\n")
+			b.WriteString("-- Regenerate on the schedule your rotation archives on. The baseline state\n")
+			b.WriteString("-- views do " + how + ", so a refreshed baseline reaches them\n")
+		} else if in.rendersEvents() {
 			b.WriteString("The globs below\n")
 			b.WriteString("-- keep picking up newly rotated partitions, and the baseline state views\n")
 			b.WriteString("-- " + how + ", so a refreshed baseline reaches them\n")
@@ -635,6 +650,16 @@ func writeHeader(b *strings.Builder, in Input) {
 		b.WriteString("-- changes to some other type arrives as whatever the new file holds (an\n")
 		b.WriteString("-- ORDER BY can start sorting text), and an archive source added later is\n")
 		b.WriteString("-- simply not here. None of those raise an error.\n")
+	} else if in.rendersEvents() && grouped {
+		b.WriteString("The events view below\n")
+		b.WriteString("-- names the archived files it reads, one by one, and the baseline state views\n")
+		b.WriteString("-- point at ONE snapshot. NOTHING here updates itself: partitions archived\n")
+		b.WriteString("-- after this file was written are not in it, with no error and no warning —\n")
+		b.WriteString("-- a query over the most recent hours simply returns nothing for them.\n")
+		b.WriteString("-- Regenerate this file on the schedule your rotation archives on, and after\n")
+		b.WriteString("-- taking or refreshing a baseline, and whenever archive sources are added or\n")
+		b.WriteString("-- removed. Re-run `bintrail views`, or download the file again from the\n")
+		b.WriteString("-- console.\n")
 	} else if in.rendersEvents() {
 		// The one self-following half of the file, and only the events view
 		// has it: its globs are evaluated per query. Claimed only when that
@@ -1200,22 +1225,38 @@ func writeEventsView(b *strings.Builder, in Input, stateSurvives bool) bool {
 			b.WriteString("-- opens EVERY file's footer to unify the schema, on every statement, and the\n")
 			b.WriteString("-- wait grows with the archive. Grouping makes that one footer per group.\n")
 			b.WriteString("--\n")
-			b.WriteString("-- The file list comes from archive_state, so a file under one of these roots\n")
-			b.WriteString("-- with no row there is not read. `bintrail archive reconcile` reports those.\n")
+			b.WriteString("-- The file list is FIXED, and it comes from archive_state. Two consequences,\n")
+			b.WriteString("-- both worth knowing before you save this file:\n")
+			b.WriteString("--   - partitions archived after this was generated are not read. Regenerate.\n")
+			b.WriteString("--   - a file under one of these roots with no archive_state row is not read.\n")
+			b.WriteString("-- `bintrail archive reconcile` exits non-zero on both kinds of drift; it\n")
+			b.WriteString("-- reports counts per partition, not file paths.\n")
 		} else {
 			b.WriteString("-- union_by_name is required, not cosmetic: archives written before a column\n")
 			b.WriteString("-- existed simply lack it, and those files must read back with NULLs rather\n")
 			b.WriteString("-- than failing the whole scan. A column absent from EVERY archived file is\n")
-			b.WriteString("-- still an error: drop it from the SELECT if you hit that on an old archive.\n")
+			b.WriteString("-- still an error here: drop it from the SELECT if you hit that on an old\n")
+			b.WriteString("-- archive. (The grouped form this file is not using pads it with NULL.)\n")
 			b.WriteString("--\n")
 			b.WriteString("-- COST: union_by_name makes DuckDB open one Parquet footer per archived file\n")
 			b.WriteString("-- to unify the schema, and a view re-binds on every statement, so the wait\n")
 			b.WriteString("-- before the first row grows with the archive.\n")
 			if in.UngroupedPartitions > 0 {
-				fmt.Fprintf(b, "-- %d archived partition(s) have no recorded column set, so they cannot be\n", in.UngroupedPartitions)
-				b.WriteString("-- grouped by schema. `bintrail archive reconcile --repair` records it from\n")
-				b.WriteString("-- each footer, once, offline; regenerating this file afterwards emits one\n")
-				b.WriteString("-- read_parquet per column set instead, which binds one footer per group.\n")
+				fmt.Fprintf(b, "-- %d archived partition(s) cannot be grouped by schema: no recorded column\n", in.UngroupedPartitions)
+				b.WriteString("-- set, or a registered file that is not on disk. Recording the set reads\n")
+				b.WriteString("-- each footer once, offline:\n")
+				if in.NeedsS3() {
+					// --deep is not optional on S3: without it the scan never
+					// opens a remote footer, so the repair finds nothing to
+					// record and the wait stays exactly as it is.
+					b.WriteString("--   bintrail archive reconcile --index-dsn ... --archive-s3 ... --deep --repair\n")
+					b.WriteString("-- `--deep` is what reads the footers over S3; without it the repair records\n")
+					b.WriteString("-- nothing and this note comes back unchanged.\n")
+				} else {
+					b.WriteString("--   bintrail archive reconcile --index-dsn ... --archive-dir ... --repair\n")
+				}
+				b.WriteString("-- Regenerating this file afterwards emits one read_parquet per column set,\n")
+				b.WriteString("-- which binds one footer per group instead of one per file.\n")
 			}
 		}
 	}


### PR DESCRIPTION
closes #1535

## The problem

`select * from events limit 1` in the SQL panel failed after ~47s with
`set up views over the Parquet layout: context deadline exceeded`. The query
never ran; the time went into `CREATE VIEW`.

`union_by_name = true` makes DuckDB open the Parquet footer of **every** file
in the glob at bind time, and a view re-binds on each statement. The cost is
O(archived files) and grows for as long as the archive does. Measured on one
real source of 1886 files: 2.5s to expand the glob, 3.2s to create the view
with `union_by_name = false`, **114.2s** with it on.

It cannot simply be turned off. With the narrow file first DuckDB silently
drops the columns it lacks; with the wide file first it fails the read. It is
load-bearing for correctness in both orders.

## The fix

Record what it was computing. `archive_state` gains `column_set` — the archived
file's own column set, lowercase, sorted, comma-joined — and the generator
emits one `read_parquet` per distinct set, each with an explicit file list and
`union_by_name = false`, padding the columns a group lacks with `NULL` and
joining the groups with `UNION ALL BY NAME`.

Bind cost becomes one footer per GROUP, which is a handful. The S3 LIST the
glob needed disappears too, since the paths are explicit.

Verified against real DuckDB before building on it: `hive_partitioning` reads
`bintrail_id`/`event_date`/`event_hour` off explicit paths exactly as it does
off a glob, and a filter on them still prunes (`Scanning Files: 1/2`).

## Two decisions worth reviewing

**Grouping is all-or-nothing.** The file list comes from the registry rather
than a glob, so a partial one would leave the unrecorded partitions out of the
view — a wrong answer, not a slow one. Until every registered partition has a
recorded set, the globbed form stays and the generated SQL says why and names
`bintrail archive reconcile --repair`. Guarded on both surfaces separately;
the console guard was added after a mutation showed the CLI test did not cover it.

**The registry, not the filesystem, is the file list.** A file under a source
with no `archive_state` row is not read. `ArchiveSources` already came from
`archive_state`, so this narrows from "everything under a registered source" to
"every registered partition" — the drift `archive reconcile` exists to report
(a dry run exits non-zero on it). The generated SQL states it.

## Backfill

`archive reconcile --repair` records the set from the footer it already reads
for `row_count`: no extra file opens, and not gated on `--deep` (a set that was
not read is empty, so the condition never fires on S3 without it). `archive
reconcile` now runs `EnsureSchema` first, like the other `archive_state`
readers — without it, reconcile against an index whose rotation predates this
binary fails on the new column.

## Test plan

- [x] `go test ./... -count=1`
- [x] `go test -tags integration ./...` against Docker MySQL
- [x] The generated SQL is EXECUTED in real DuckDB over two groups with
      genuinely different column sets, asserting the column only one group has
      reads back on that group's row and NULL on the other. Red under both
      failure shapes: naming a column the group lacks (binder error) and
      merging the groups into one scan (silent drop).
- [x] End-to-end backfill against real MySQL and a real footer: archive,
      unrecorded row, repair, read back, group, and a second reconcile that
      reports no drift.
- [x] Mutations run: group column set dropped, groups merged, empty set treated
      as recorded, base scheme ignored when picking the file tail,
      all-or-nothing gate removed on each surface, footer column read removed.
