### PR TITLE
doctor: warn about tables with no primary key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **`doctor` warns about tables with no primary key** (#1608). Capture of those
-  tables works and nothing in the pipeline says a word, which is the problem:
-  their row images carry an empty `pk_values`, so `recover` cannot address the
-  row, `reconstruct` refuses the table (`supportedPKType`), and
-  `verify --check recover` grades them unwalkable rather than verified (#318).
-  Captured and unrecoverable is the worst state for a backup product, because
-  it looks like it is working. A WARN and never a FAIL: capture of those tables
-  is still worth having, and refusing to start would trade a partial capability
-  for none. The check names the tables, up to ten, keeps the count exact past
-  that, and its remediation carries both the `ALTER TABLE` forms and the query
-  that lists the rest.
+- **`doctor` warns about tables with no primary key** (#1608). Those tables are
+  not captured at all: the first snapshot REFUSES outright and the stream does
+  not start, and a later snapshot after a schema change EXCLUDES them and skips
+  their row events. Until now nothing said so before the refusal. The check
+  names the tables, up to ten, keeps the count exact past that, and its
+  remediation states what actually happens rather than describing degraded
+  recovery over data that does not exist.
+  It is advisory on every path, including its own errors: nothing downstream
+  consumes the answer, since the snapshot re-derives it and refuses on its own,
+  so a transient `information_schema` error must not stop capture on a source
+  that is healthy. Nothing visible in scope reports `skip`, never `pass`.
+  The finding comes from `metadata.TablesWithoutPrimaryKey`, which is the
+  snapshot's OWN classifier, rather than a second query asking a similar
+  question. Both directions of drift were measured on live servers before this
+  landed: a `TABLE_CONSTRAINTS` question warns about a `UNIQUE NOT NULL` table
+  that MySQL marks `COLUMN_KEY = 'PRI'` and the product keys perfectly well,
+  and a `TABLE_TYPE = 'BASE TABLE'` filter misses MariaDB's `SYSTEM VERSIONED`
+  tables, which is the shape where the data loss is total (#1272).
 
 ## [0.77.0] - 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`doctor` warns about tables with no primary key** (#1608). Capture of those
+  tables works and nothing in the pipeline says a word, which is the problem:
+  their row images carry an empty `pk_values`, so `recover` cannot address the
+  row, `reconstruct` refuses the table (`supportedPKType`), and
+  `verify --check recover` grades them unwalkable rather than verified (#318).
+  Captured and unrecoverable is the worst state for a backup product, because
+  it looks like it is working. A WARN and never a FAIL: capture of those tables
+  is still worth having, and refusing to start would trade a partial capability
+  for none. The check names the tables, up to ten, keeps the count exact past
+  that, and its remediation carries both the `ALTER TABLE` forms and the query
+  that lists the rest.
+
 ## [0.77.0] - 2026-09-03
 
 ### Fixed

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -158,6 +158,7 @@ func Build(parent context.Context, sourceDSN, indexDSN, schemasCSV string, index
 	report.add(checkServerIDCollision(ctx, sourceDB, sourceDSN))
 	report.add(checkFKCascades(sourceDB, schemas))
 	report.add(checkSchemaVisibility(ctx, sourceDB, schemas))
+	report.add(checkPrimaryKeys(ctx, sourceDB, schemas))
 
 	// ── Index MySQL checks (optional) ─────────────────────────────────────────
 	if indexDSN != "" {
@@ -815,6 +816,122 @@ func checkFKCascades(db *sql.DB, schemas []string) CheckResult {
 			"schemas — it WARNS and proceeds — so the FK graph is captured for cascade recovery.\n" +
 			"Plain `recover` still produces incomplete SQL for cascade-affected tables; use\n" +
 			"`recover-cascade` instead for those.",
+	}
+}
+
+// pkNameLimit caps how many table names a missing-primary-key warning prints
+// before it falls back to counting. A schema converted from MyISAM can have
+// hundreds, and a wall of names is read as noise where a count plus a query
+// is read as a task.
+const pkNameLimit = 10
+
+// checkPrimaryKeys warns about tables with no PRIMARY KEY.
+//
+// A WARN and never a FAIL, deliberately. Capture of those tables still works
+// and is still worth having: the events are indexed, they are queryable, and
+// refusing to start would trade a partial capability for none. What the
+// operator loses is everything keyed by the row's identity, and losing it
+// SILENTLY is the reason this check exists at all — nothing else in the
+// pipeline says a word. The row images carry an empty pk_values, and from
+// there `recover` cannot address the row, `reconstruct` refuses the table
+// outright (supportedPKType), and `verify --check recover` cannot walk the
+// chain and grades it unwalkable (#318). Captured and unrecoverable is the
+// worst state for a backup product, because it looks like it is working.
+func checkPrimaryKeys(ctx context.Context, db *sql.DB, schemas []string) CheckResult {
+	const name = "Every table has a PRIMARY KEY"
+	// LEFT JOIN over TABLE_CONSTRAINTS rather than COLUMN_KEY = 'PRI': the
+	// column view reports the first column of any unique-ish key on some
+	// versions, and the constraint is the thing being asserted.
+	query := `SELECT t.TABLE_SCHEMA, t.TABLE_NAME
+		FROM information_schema.TABLES t
+		LEFT JOIN information_schema.TABLE_CONSTRAINTS c
+		  ON  c.TABLE_SCHEMA = t.TABLE_SCHEMA
+		  AND c.TABLE_NAME = t.TABLE_NAME
+		  AND c.CONSTRAINT_TYPE = 'PRIMARY KEY'
+		WHERE t.TABLE_TYPE = 'BASE TABLE'
+		  AND c.CONSTRAINT_NAME IS NULL`
+	var args []any
+	if len(schemas) > 0 {
+		placeholders := strings.TrimRight(strings.Repeat("?,", len(schemas)), ",")
+		query += fmt.Sprintf(" AND t.TABLE_SCHEMA IN (%s)", placeholders)
+		for _, sc := range schemas {
+			args = append(args, sc)
+		}
+	} else {
+		query += " AND t.TABLE_SCHEMA NOT IN ('information_schema','performance_schema','mysql','sys')"
+	}
+	query += " ORDER BY t.TABLE_SCHEMA, t.TABLE_NAME"
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return CheckResult{
+			Name:        name,
+			Status:      StatusFail,
+			Detail:      err.Error(),
+			Remediation: queryErrorRemediation("information_schema.TABLE_CONSTRAINTS"),
+		}
+	}
+	defer rows.Close()
+
+	var names []string
+	total := 0
+	for rows.Next() {
+		var schema, table string
+		if err := rows.Scan(&schema, &table); err != nil {
+			return CheckResult{
+				Name:        name,
+				Status:      StatusFail,
+				Detail:      err.Error(),
+				Remediation: queryErrorRemediation("information_schema.TABLE_CONSTRAINTS"),
+			}
+		}
+		total++
+		if len(names) < pkNameLimit {
+			names = append(names, schema+"."+table)
+		}
+	}
+	// Checked, not ignored: a driver error mid-iteration would otherwise
+	// report the tables seen so far as if that were the whole answer, and
+	// "no tables without a primary key" is the reassuring half.
+	if err := rows.Err(); err != nil {
+		return CheckResult{
+			Name:        name,
+			Status:      StatusFail,
+			Detail:      err.Error(),
+			Remediation: queryErrorRemediation("information_schema.TABLE_CONSTRAINTS"),
+		}
+	}
+	if total == 0 {
+		return CheckResult{Name: name, Status: StatusPass}
+	}
+
+	detail := fmt.Sprintf("%d table(s) without a primary key: %s", total, strings.Join(names, ", "))
+	if total > len(names) {
+		detail += fmt.Sprintf(", and %d more", total-len(names))
+	}
+	return CheckResult{
+		Name:   name,
+		Status: StatusWarn,
+		Detail: detail,
+		Remediation: "Changes to these tables are captured, but they cannot be addressed by row:\n" +
+			"bintrail identifies a row by its primary key, and without one the stored image\n" +
+			"carries no key at all. For these tables that means:\n\n" +
+			"  - `bintrail recover` cannot generate SQL that targets the affected row\n" +
+			"  - `bintrail reconstruct` refuses the table\n" +
+			"  - `bintrail verify --check recover` reports them as unwalkable, not as verified\n\n" +
+			"Capture is not blocked and the events are still queryable, so this is a warning\n" +
+			"rather than a refusal. To close the gap, give each table a primary key:\n\n" +
+			"  ALTER TABLE <schema>.<table> ADD PRIMARY KEY (<existing unique column>);\n\n" +
+			"When no column is unique, an added surrogate key works and is what InnoDB is\n" +
+			"already keeping internally, invisibly:\n\n" +
+			"  ALTER TABLE <schema>.<table> ADD COLUMN id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST;\n\n" +
+			"Rows captured BEFORE the key is added keep their empty key, so the gap closes\n" +
+			"for new changes only. List them all with:\n\n" +
+			"  SELECT t.TABLE_SCHEMA, t.TABLE_NAME FROM information_schema.TABLES t\n" +
+			"    LEFT JOIN information_schema.TABLE_CONSTRAINTS c\n" +
+			"      ON c.TABLE_SCHEMA = t.TABLE_SCHEMA AND c.TABLE_NAME = t.TABLE_NAME\n" +
+			"     AND c.CONSTRAINT_TYPE = 'PRIMARY KEY'\n" +
+			"    WHERE t.TABLE_TYPE = 'BASE TABLE' AND c.CONSTRAINT_NAME IS NULL;",
 	}
 }
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -158,7 +158,7 @@ func Build(parent context.Context, sourceDSN, indexDSN, schemasCSV string, index
 	report.add(checkServerIDCollision(ctx, sourceDB, sourceDSN))
 	report.add(checkFKCascades(sourceDB, schemas))
 	report.add(checkSchemaVisibility(ctx, sourceDB, schemas))
-	report.add(checkPrimaryKeys(ctx, sourceDB, schemas))
+	report.add(checkPrimaryKeys(sourceDB, schemas))
 
 	// ── Index MySQL checks (optional) ─────────────────────────────────────────
 	if indexDSN != "" {
@@ -819,119 +819,101 @@ func checkFKCascades(db *sql.DB, schemas []string) CheckResult {
 	}
 }
 
-// pkNameLimit caps how many table names a missing-primary-key warning prints
+// pkNameLimit caps how many table names a missing-primary-key finding prints
 // before it falls back to counting. A schema converted from MyISAM can have
 // hundreds, and a wall of names is read as noise where a count plus a query
 // is read as a task.
 const pkNameLimit = 10
 
-// checkPrimaryKeys warns about tables with no PRIMARY KEY.
+// PrimaryKeyCheckName is the check that reports tables with no primary key.
+// Exported so the daemons can hold it advisory the way they hold the capacity
+// check: nothing here gates the snapshot, so a failure to ASK the question
+// must not refuse boot on a source that is capturing fine.
+const PrimaryKeyCheckName = "Every table has a PRIMARY KEY"
+
+// checkPrimaryKeys reports tables the snapshot will not capture for lack of a
+// primary key.
 //
-// A WARN and never a FAIL, deliberately. Capture of those tables still works
-// and is still worth having: the events are indexed, they are queryable, and
-// refusing to start would trade a partial capability for none. What the
-// operator loses is everything keyed by the row's identity, and losing it
-// SILENTLY is the reason this check exists at all — nothing else in the
-// pipeline says a word. The row images carry an empty pk_values, and from
-// there `recover` cannot address the row, `reconstruct` refuses the table
-// outright (supportedPKType), and `verify --check recover` cannot walk the
-// chain and grades it unwalkable (#318). Captured and unrecoverable is the
-// worst state for a backup product, because it looks like it is working.
-func checkPrimaryKeys(ctx context.Context, db *sql.DB, schemas []string) CheckResult {
-	const name = "Every table has a PRIMARY KEY"
-	// LEFT JOIN over TABLE_CONSTRAINTS rather than COLUMN_KEY = 'PRI': the
-	// column view reports the first column of any unique-ish key on some
-	// versions, and the constraint is the thing being asserted.
-	query := `SELECT t.TABLE_SCHEMA, t.TABLE_NAME
-		FROM information_schema.TABLES t
-		LEFT JOIN information_schema.TABLE_CONSTRAINTS c
-		  ON  c.TABLE_SCHEMA = t.TABLE_SCHEMA
-		  AND c.TABLE_NAME = t.TABLE_NAME
-		  AND c.CONSTRAINT_TYPE = 'PRIMARY KEY'
-		WHERE t.TABLE_TYPE = 'BASE TABLE'
-		  AND c.CONSTRAINT_NAME IS NULL`
-	var args []any
+// It calls metadata.TablesWithoutPrimaryKey, which is the snapshot's OWN
+// classifier, rather than asking information_schema a similar question. That
+// is the whole design: a preflight that predicts the pipeline with a second
+// implementation drifts from it, and both directions of drift were measured on
+// live servers before this landed. A TABLE_CONSTRAINTS-shaped question warns
+// about a UNIQUE NOT NULL table that MySQL marks COLUMN_KEY = 'PRI' and the
+// product keys perfectly well, and a TABLE_TYPE = 'BASE TABLE' filter misses
+// MariaDB's SYSTEM VERSIONED tables, which is the one shape where the data
+// loss is total (#1272).
+//
+// WARN, never FAIL, on every path including its own errors. Nothing downstream
+// consumes this answer: the snapshot re-derives it and refuses or excludes on
+// its own. Failing here would let a transient information_schema error stop
+// capture on a source that is otherwise healthy, which is the trade
+// checkIndexCapacity already refused to make.
+func checkPrimaryKeys(db *sql.DB, schemas []string) CheckResult {
+	tables, err := metadata.TablesWithoutPrimaryKey(db, schemas)
+	switch {
+	case errors.Is(err, metadata.ErrNoColumnsVisible):
+		// Not a pass. Schema visibility has its own check and has already
+		// spoken; this one simply has no evidence, and saying "every table
+		// has a primary key" on no evidence is the failure it exists to break.
+		return CheckResult{
+			Name:   PrimaryKeyCheckName,
+			Status: StatusSkip,
+			Detail: "no tables are visible in the requested scope, so this was not checked",
+		}
+	case err != nil:
+		return CheckResult{
+			Name:   PrimaryKeyCheckName,
+			Status: StatusWarn,
+			Detail: "could not be checked: " + err.Error(),
+			Remediation: "This check is advisory and does not block capture. The snapshot applies the\n" +
+				"same rule itself and will refuse or exclude a table with no primary key when\n" +
+				"it runs, so the gap is reported either way, later and less conveniently.\n\n" +
+				"The account needs to read information_schema.COLUMNS and\n" +
+				"information_schema.TABLES for the monitored schemas.",
+		}
+	case len(tables) == 0:
+		return CheckResult{Name: PrimaryKeyCheckName, Status: StatusPass}
+	}
+
+	names := tables
+	if len(names) > pkNameLimit {
+		names = names[:pkNameLimit]
+	}
+	detail := fmt.Sprintf("%d table(s) without a primary key: %s", len(tables), strings.Join(names, ", "))
+	if len(tables) > len(names) {
+		detail += fmt.Sprintf(", and %d more", len(tables)-len(names))
+	}
+	scope := ""
 	if len(schemas) > 0 {
-		placeholders := strings.TrimRight(strings.Repeat("?,", len(schemas)), ",")
-		query += fmt.Sprintf(" AND t.TABLE_SCHEMA IN (%s)", placeholders)
-		for _, sc := range schemas {
-			args = append(args, sc)
-		}
-	} else {
-		query += " AND t.TABLE_SCHEMA NOT IN ('information_schema','performance_schema','mysql','sys')"
-	}
-	query += " ORDER BY t.TABLE_SCHEMA, t.TABLE_NAME"
-
-	rows, err := db.QueryContext(ctx, query, args...)
-	if err != nil {
-		return CheckResult{
-			Name:        name,
-			Status:      StatusFail,
-			Detail:      err.Error(),
-			Remediation: queryErrorRemediation("information_schema.TABLE_CONSTRAINTS"),
-		}
-	}
-	defer rows.Close()
-
-	var names []string
-	total := 0
-	for rows.Next() {
-		var schema, table string
-		if err := rows.Scan(&schema, &table); err != nil {
-			return CheckResult{
-				Name:        name,
-				Status:      StatusFail,
-				Detail:      err.Error(),
-				Remediation: queryErrorRemediation("information_schema.TABLE_CONSTRAINTS"),
-			}
-		}
-		total++
-		if len(names) < pkNameLimit {
-			names = append(names, schema+"."+table)
-		}
-	}
-	// Checked, not ignored: a driver error mid-iteration would otherwise
-	// report the tables seen so far as if that were the whole answer, and
-	// "no tables without a primary key" is the reassuring half.
-	if err := rows.Err(); err != nil {
-		return CheckResult{
-			Name:        name,
-			Status:      StatusFail,
-			Detail:      err.Error(),
-			Remediation: queryErrorRemediation("information_schema.TABLE_CONSTRAINTS"),
-		}
-	}
-	if total == 0 {
-		return CheckResult{Name: name, Status: StatusPass}
-	}
-
-	detail := fmt.Sprintf("%d table(s) without a primary key: %s", total, strings.Join(names, ", "))
-	if total > len(names) {
-		detail += fmt.Sprintf(", and %d more", total-len(names))
+		scope = " --schemas " + strings.Join(schemas, ",")
 	}
 	return CheckResult{
-		Name:   name,
+		Name:   PrimaryKeyCheckName,
 		Status: StatusWarn,
 		Detail: detail,
-		Remediation: "Changes to these tables are captured, but they cannot be addressed by row:\n" +
-			"bintrail identifies a row by its primary key, and without one the stored image\n" +
-			"carries no key at all. For these tables that means:\n\n" +
-			"  - `bintrail recover` cannot generate SQL that targets the affected row\n" +
-			"  - `bintrail reconstruct` refuses the table\n" +
-			"  - `bintrail verify --check recover` reports them as unwalkable, not as verified\n\n" +
-			"Capture is not blocked and the events are still queryable, so this is a warning\n" +
-			"rather than a refusal. To close the gap, give each table a primary key:\n\n" +
-			"  ALTER TABLE <schema>.<table> ADD PRIMARY KEY (<existing unique column>);\n\n" +
-			"When no column is unique, an added surrogate key works and is what InnoDB is\n" +
-			"already keeping internally, invisibly:\n\n" +
+		// States what HAPPENS, not what degrades. An earlier draft of this said
+		// the tables were captured but could not be addressed by row, which is
+		// wrong in the reassuring direction: the operator reads it as degraded
+		// recovery over data they still hold, and they hold none.
+		Remediation: "These tables are NOT captured. bintrail identifies a row by its primary key,\n" +
+			"and a table without one is refused rather than captured without identity:\n\n" +
+			"  - taking the first snapshot REFUSES outright, and the stream does not start\n" +
+			"  - a later snapshot, after a schema change, EXCLUDES them and skips their\n" +
+			"    row events, capturing every other table\n\n" +
+			"So this is not degraded recovery for those tables. There is no history for\n" +
+			"them at all, and none of it can be recovered later by adding the key: only\n" +
+			"changes made AFTER the key exists are captured.\n\n" +
+			"Give each table a primary key. Any existing column that is UNIQUE and\n" +
+			"NOT NULL will do:\n\n" +
+			"  ALTER TABLE <schema>.<table> ADD PRIMARY KEY (<unique, NOT NULL column>);\n\n" +
+			"When no column qualifies, add a surrogate key, which is what InnoDB is\n" +
+			"already keeping internally and invisibly:\n\n" +
 			"  ALTER TABLE <schema>.<table> ADD COLUMN id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST;\n\n" +
-			"Rows captured BEFORE the key is added keep their empty key, so the gap closes\n" +
-			"for new changes only. List them all with:\n\n" +
-			"  SELECT t.TABLE_SCHEMA, t.TABLE_NAME FROM information_schema.TABLES t\n" +
-			"    LEFT JOIN information_schema.TABLE_CONSTRAINTS c\n" +
-			"      ON c.TABLE_SCHEMA = t.TABLE_SCHEMA AND c.TABLE_NAME = t.TABLE_NAME\n" +
-			"     AND c.CONSTRAINT_TYPE = 'PRIMARY KEY'\n" +
-			"    WHERE t.TABLE_TYPE = 'BASE TABLE' AND c.CONSTRAINT_NAME IS NULL;",
+			"To list them all yourself, in the same scope this check used:\n\n" +
+			"  bintrail doctor --source-dsn <dsn>" + scope + "\n\n" +
+			"This check is advisory: it does not block anything. The snapshot is what\n" +
+			"refuses, when it runs.",
 	}
 }
 

--- a/internal/doctor/doctor_integration_test.go
+++ b/internal/doctor/doctor_integration_test.go
@@ -78,3 +78,35 @@ func TestIndexChecksWithAbsentDatabase(t *testing.T) {
 		t.Errorf("unreachable server: Name = %q", bad.Name)
 	}
 }
+
+// TestBuildRegistersThePrimaryKeyCheck: the check has to be IN the report.
+//
+// Unwiring `report.add(checkPrimaryKeys(...))` from Build left the entire
+// suite green, tagged and untagged, so the feature could be deleted from the
+// report and CI would say nothing. Asserted through Build rather than by
+// reading the source, because what matters is that a real run produces it.
+//
+// It also pins the advisory contract the daemons depend on: whatever this
+// check answers on a healthy fixture, it must never be the FAIL that makes
+// watch and up refuse to boot (consoleapp/watch.go passes only the capacity
+// check to ErrExcluding, so any other FAIL is a boot refusal).
+func TestBuildRegistersThePrimaryKeyCheck(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+
+	report := Build(t.Context(), testutil.BaseDSN()+"/?parseTime=true", "", "", 0)
+
+	var found *CheckResult
+	for i := range report.Checks {
+		if report.Checks[i].Name == PrimaryKeyCheckName {
+			found = &report.Checks[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("Build produced no %q check, so it never runs. Checks: %d", PrimaryKeyCheckName, len(report.Checks))
+	}
+	if found.Status == StatusFail {
+		t.Errorf("%q returned FAIL (detail=%q). Nothing consumes this answer, and a FAIL here "+
+			"refuses to boot watch and up on a source that captures fine", PrimaryKeyCheckName, found.Detail)
+	}
+}

--- a/internal/doctor/primarykey_test.go
+++ b/internal/doctor/primarykey_test.go
@@ -1,0 +1,164 @@
+package doctor
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+)
+
+// pkRows is the shape the check scans: one row per table WITHOUT a primary key.
+func pkRows(pairs ...[2]string) *sqlmock.Rows {
+	r := sqlmock.NewRows([]string{"TABLE_SCHEMA", "TABLE_NAME"})
+	for _, p := range pairs {
+		r.AddRow(p[0], p[1])
+	}
+	return r
+}
+
+// A table with no primary key is captured and largely unrecoverable, and
+// nothing else in the pipeline says so. The check exists to break that
+// silence, so the table NAME is the payload: a warning that says "some tables"
+// leaves the operator with the same query to write that they had before.
+func TestCheckPrimaryKeys_namesTheTables(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	mock.ExpectQuery("TABLE_CONSTRAINTS").
+		WillReturnRows(pkRows([2]string{"shop", "audit_log"}, [2]string{"shop", "sessions"}))
+
+	got := checkPrimaryKeys(context.Background(), db, nil)
+
+	if got.Status != StatusWarn {
+		t.Errorf("status = %v, want WARN. A FAIL would refuse to start capture over tables whose "+
+			"capture is still worth having; a PASS is the silence this check exists to break", got.Status)
+	}
+	for _, want := range []string{"shop.audit_log", "shop.sessions"} {
+		if !strings.Contains(got.Detail, want) {
+			t.Errorf("detail does not name %s: %q", want, got.Detail)
+		}
+	}
+	if !strings.Contains(got.Detail, "2 table") {
+		t.Errorf("detail does not count them: %q", got.Detail)
+	}
+	if !strings.Contains(got.Remediation, "ADD PRIMARY KEY") {
+		t.Error("the remediation does not say how to fix it")
+	}
+}
+
+// Every table has one: the reassuring answer must be reachable, or the check
+// would warn on every install and be dismissed everywhere.
+func TestCheckPrimaryKeys_passesWhenEveryTableHasOne(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	mock.ExpectQuery("TABLE_CONSTRAINTS").WillReturnRows(pkRows())
+
+	got := checkPrimaryKeys(context.Background(), db, nil)
+	if got.Status != StatusPass {
+		t.Errorf("status = %v, want PASS with no keyless tables (detail %q)", got.Status, got.Detail)
+	}
+}
+
+// A schema converted from MyISAM can have hundreds. The names stop at the cap
+// and the COUNT stays exact: an operator sizing the work needs the real number,
+// and a truncated list that also truncated the count would understate it.
+func TestCheckPrimaryKeys_capsTheNamesButNotTheCount(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var pairs [][2]string
+	for i := 0; i < pkNameLimit+7; i++ {
+		pairs = append(pairs, [2]string{"shop", "t" + string(rune('a'+i))})
+	}
+	mock.ExpectQuery("TABLE_CONSTRAINTS").WillReturnRows(pkRows(pairs...))
+
+	got := checkPrimaryKeys(context.Background(), db, nil)
+
+	if !strings.Contains(got.Detail, "17 table") {
+		t.Errorf("the count must be the real one, not the number of names printed: %q", got.Detail)
+	}
+	if !strings.Contains(got.Detail, "and 7 more") {
+		t.Errorf("detail does not say the list was cut: %q", got.Detail)
+	}
+	if n := strings.Count(got.Detail, "shop."); n != pkNameLimit {
+		t.Errorf("printed %d names, want the cap of %d: %q", n, pkNameLimit, got.Detail)
+	}
+}
+
+// A query that fails is NOT "no tables without a primary key". Reporting the
+// reassuring answer from an error is the shape this whole check exists to
+// avoid, one level up.
+func TestCheckPrimaryKeys_aFailedQueryIsNotAPass(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	mock.ExpectQuery("TABLE_CONSTRAINTS").WillReturnError(errors.New("Error 1142: SELECT command denied to user"))
+
+	got := checkPrimaryKeys(context.Background(), db, nil)
+	if got.Status == StatusPass {
+		t.Fatal("a query the account could not run reported PASS, which tells the operator every " +
+			"table has a primary key on the evidence of having learned nothing")
+	}
+	if got.Status != StatusFail {
+		t.Errorf("status = %v, want FAIL", got.Status)
+	}
+}
+
+// The scoped form must not silently widen to every schema on the server: an
+// operator monitoring one schema would be warned about tables bintrail will
+// never capture, and would go fix the wrong database.
+func TestCheckPrimaryKeys_scopesToTheGivenSchemas(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	// The QUERY TEXT, not just the argument: dropping the IN clause while still
+	// passing the argument leaves WithArgs satisfied, so an args-only
+	// expectation cannot see the filter go missing.
+	mock.ExpectQuery(`TABLE_SCHEMA IN \(\?\)`).
+		WithArgs("shop").
+		WillReturnRows(pkRows([2]string{"shop", "audit_log"}))
+
+	if got := checkPrimaryKeys(context.Background(), db, []string{"shop"}); got.Status != StatusWarn {
+		t.Fatalf("status = %v, detail %q", got.Status, got.Detail)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("the schema filter was not passed as an argument: %v", err)
+	}
+}
+
+// A driver error that arrives PART WAY through the rows must not be reported
+// as the tables seen so far. The reassuring half of this check is "and no
+// others", and a truncated scan cannot say it.
+func TestCheckPrimaryKeys_anErrorMidScanIsNotAShorterList(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	rows := pkRows([2]string{"shop", "audit_log"}, [2]string{"shop", "sessions"}).
+		RowError(1, errors.New("Error 2013: lost connection during query"))
+	mock.ExpectQuery("TABLE_CONSTRAINTS").WillReturnRows(rows)
+
+	got := checkPrimaryKeys(context.Background(), db, nil)
+
+	if got.Status == StatusWarn && strings.Contains(got.Detail, "1 table") {
+		t.Fatal("the scan died after one row and the check reported that one as the whole answer, " +
+			"so a server with fifty keyless tables would be described as having one")
+	}
+	if got.Status != StatusFail {
+		t.Errorf("status = %v, want FAIL: the question was not answered", got.Status)
+	}
+}

--- a/internal/doctor/primarykey_test.go
+++ b/internal/doctor/primarykey_test.go
@@ -1,164 +1,194 @@
 package doctor
 
 import (
-	"context"
+	"database/sql"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 )
 
-// pkRows is the shape the check scans: one row per table WITHOUT a primary key.
-func pkRows(pairs ...[2]string) *sqlmock.Rows {
-	r := sqlmock.NewRows([]string{"TABLE_SCHEMA", "TABLE_NAME"})
-	for _, p := range pairs {
-		r.AddRow(p[0], p[1])
+// colRows feeds metadata.TablesWithoutPrimaryKey's first query
+// (information_schema.COLUMNS). key is COLUMN_KEY: "PRI" is what bintrail
+// treats as row identity, everywhere.
+func colRows(rows ...[3]string) *sqlmock.Rows {
+	r := sqlmock.NewRows([]string{
+		"TABLE_SCHEMA", "TABLE_NAME", "COLUMN_NAME", "ORDINAL_POSITION", "COLUMN_KEY",
+		"DATA_TYPE", "COLUMN_TYPE", "IS_NULLABLE", "COLUMN_DEFAULT", "GENERATION_EXPRESSION", "CHARACTER_SET_NAME",
+	})
+	for _, c := range rows {
+		r.AddRow(c[0], c[1], "col", 1, c[2], "int", "int", "NO", nil, nil, nil)
 	}
 	return r
 }
 
-// A table with no primary key is captured and largely unrecoverable, and
-// nothing else in the pipeline says so. The check exists to break that
-// silence, so the table NAME is the payload: a warning that says "some tables"
-// leaves the operator with the same query to write that they had before.
-func TestCheckPrimaryKeys_namesTheTables(t *testing.T) {
-	db, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatal(err)
+// tabRows feeds the second query (information_schema.TABLES).
+func tabRows(rows ...[3]string) *sqlmock.Rows {
+	r := sqlmock.NewRows([]string{"TABLE_SCHEMA", "TABLE_NAME", "ENGINE", "TABLE_TYPE"})
+	for _, t := range rows {
+		r.AddRow(t[0], t[1], "InnoDB", t[2])
 	}
-	defer db.Close()
-	mock.ExpectQuery("TABLE_CONSTRAINTS").
-		WillReturnRows(pkRows([2]string{"shop", "audit_log"}, [2]string{"shop", "sessions"}))
-
-	got := checkPrimaryKeys(context.Background(), db, nil)
-
-	if got.Status != StatusWarn {
-		t.Errorf("status = %v, want WARN. A FAIL would refuse to start capture over tables whose "+
-			"capture is still worth having; a PASS is the silence this check exists to break", got.Status)
-	}
-	for _, want := range []string{"shop.audit_log", "shop.sessions"} {
-		if !strings.Contains(got.Detail, want) {
-			t.Errorf("detail does not name %s: %q", want, got.Detail)
-		}
-	}
-	if !strings.Contains(got.Detail, "2 table") {
-		t.Errorf("detail does not count them: %q", got.Detail)
-	}
-	if !strings.Contains(got.Remediation, "ADD PRIMARY KEY") {
-		t.Error("the remediation does not say how to fix it")
-	}
+	return r
 }
 
-// Every table has one: the reassuring answer must be reachable, or the check
-// would warn on every install and be dismissed everywhere.
-func TestCheckPrimaryKeys_passesWhenEveryTableHasOne(t *testing.T) {
+func pkDB(t *testing.T) (*sql.DB, sqlmock.Sqlmock, func()) {
+	t.Helper()
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
-	mock.ExpectQuery("TABLE_CONSTRAINTS").WillReturnRows(pkRows())
+	return db, mock, func() { db.Close() }
+}
 
-	got := checkPrimaryKeys(context.Background(), db, nil)
+var errPKProbe = errors.New("Error 1142: SELECT command denied to user")
+
+// A table whose only key is a UNIQUE NOT NULL column is NOT a finding, because
+// MySQL reports COLUMN_KEY = 'PRI' for it and that is exactly what bintrail
+// uses as row identity. Measured on live MySQL 8.4 and MariaDB 11.4: the
+// snapshot accepts such a table and the resolver hands back its column as the
+// PK, so warning about it would send the operator to fix something that works
+// and would assert three failures that do not happen.
+//
+// This is the case a TABLE_CONSTRAINTS-shaped question gets wrong, which is
+// why the check calls the snapshot's own classifier instead.
+func TestCheckPrimaryKeys_aUniqueNotNullColumnIsAKey(t *testing.T) {
+	db, mock, done := pkDB(t)
+	defer done()
+	mock.ExpectQuery("information_schema.COLUMNS").
+		WillReturnRows(colRows([3]string{"shop", "uniq_notnull", "PRI"}))
+	mock.ExpectQuery("information_schema.TABLES").
+		WillReturnRows(tabRows([3]string{"shop", "uniq_notnull", "BASE TABLE"}))
+
+	got := checkPrimaryKeys(db, nil)
 	if got.Status != StatusPass {
-		t.Errorf("status = %v, want PASS with no keyless tables (detail %q)", got.Status, got.Detail)
+		t.Errorf("status = %v (%q), want PASS. COLUMN_KEY='PRI' IS bintrail's row identity, so "+
+			"this table is captured and recoverable; warning about it is a false alarm with "+
+			"remediation that asserts failures which will not happen", got.Status, got.Detail)
 	}
 }
 
-// A schema converted from MyISAM can have hundreds. The names stop at the cap
-// and the COUNT stays exact: an operator sizing the work needs the real number,
-// and a truncated list that also truncated the count would understate it.
-func TestCheckPrimaryKeys_capsTheNamesButNotTheCount(t *testing.T) {
-	db, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	var pairs [][2]string
-	for i := 0; i < pkNameLimit+7; i++ {
-		pairs = append(pairs, [2]string{"shop", "t" + string(rune('a'+i))})
-	}
-	mock.ExpectQuery("TABLE_CONSTRAINTS").WillReturnRows(pkRows(pairs...))
+// A MariaDB system-versioned table without a key IS a finding. The pipeline
+// classifies TABLE_TYPE IN ('BASE TABLE','SYSTEM VERSIONED') because the
+// narrower filter was itself the bug (#1272), and this is the shape where the
+// data loss is total: the snapshot excludes the table and capture skips its
+// row events while a BASE TABLE-only check prints a clean tick.
+func TestCheckPrimaryKeys_aSystemVersionedTableIsNotInvisible(t *testing.T) {
+	db, mock, done := pkDB(t)
+	defer done()
+	mock.ExpectQuery("information_schema.COLUMNS").
+		WillReturnRows(colRows([3]string{"shop", "sv_nopk", ""}))
+	// The QUERY TEXT: the classifier must ASK for SYSTEM VERSIONED. sqlmock
+	// returns canned rows whatever the SQL says, so an expectation that only
+	// named the table would stay satisfied with the filter narrowed back to
+	// BASE TABLE, which is the #1272 bypass. Measured: metadata's own tests
+	// pin this only on the scoped branch, so the unscoped one rides on this.
+	mock.ExpectQuery(`TABLE_TYPE IN \('BASE TABLE', 'SYSTEM VERSIONED'\)`).
+		WillReturnRows(tabRows([3]string{"shop", "sv_nopk", "SYSTEM VERSIONED"}))
 
-	got := checkPrimaryKeys(context.Background(), db, nil)
-
-	if !strings.Contains(got.Detail, "17 table") {
-		t.Errorf("the count must be the real one, not the number of names printed: %q", got.Detail)
-	}
-	if !strings.Contains(got.Detail, "and 7 more") {
-		t.Errorf("detail does not say the list was cut: %q", got.Detail)
-	}
-	if n := strings.Count(got.Detail, "shop."); n != pkNameLimit {
-		t.Errorf("printed %d names, want the cap of %d: %q", n, pkNameLimit, got.Detail)
+	got := checkPrimaryKeys(db, nil)
+	if got.Status != StatusWarn || !strings.Contains(got.Detail, "shop.sv_nopk") {
+		t.Errorf("status = %v detail = %q, want a WARN naming shop.sv_nopk. On MariaDB this is the "+
+			"one shape with total data loss, and it is the one a BASE TABLE filter cannot see", got.Status, got.Detail)
 	}
 }
 
-// A query that fails is NOT "no tables without a primary key". Reporting the
-// reassuring answer from an error is the shape this whole check exists to
-// avoid, one level up.
-func TestCheckPrimaryKeys_aFailedQueryIsNotAPass(t *testing.T) {
-	db, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	mock.ExpectQuery("TABLE_CONSTRAINTS").WillReturnError(errors.New("Error 1142: SELECT command denied to user"))
+// The reassuring answer must stay reachable, or the check warns on every
+// install and gets dismissed everywhere.
+func TestCheckPrimaryKeys_passesWhenEveryTableHasOne(t *testing.T) {
+	db, mock, done := pkDB(t)
+	defer done()
+	mock.ExpectQuery("information_schema.COLUMNS").
+		WillReturnRows(colRows([3]string{"shop", "orders", "PRI"}))
+	mock.ExpectQuery("information_schema.TABLES").
+		WillReturnRows(tabRows([3]string{"shop", "orders", "BASE TABLE"}))
 
-	got := checkPrimaryKeys(context.Background(), db, nil)
+	if got := checkPrimaryKeys(db, nil); got.Status != StatusPass {
+		t.Errorf("status = %v (%q), want PASS", got.Status, got.Detail)
+	}
+}
+
+// Nothing visible is not "every table has a primary key". It is the same
+// reassuring-answer-from-no-evidence shape this check exists to break, one
+// level up, so it reports SKIP.
+func TestCheckPrimaryKeys_nothingVisibleIsNotAPass(t *testing.T) {
+	db, mock, done := pkDB(t)
+	defer done()
+	mock.ExpectQuery("information_schema.COLUMNS").WillReturnRows(colRows())
+
+	got := checkPrimaryKeys(db, nil)
 	if got.Status == StatusPass {
-		t.Fatal("a query the account could not run reported PASS, which tells the operator every " +
-			"table has a primary key on the evidence of having learned nothing")
+		t.Fatal("reported PASS with no tables visible, which tells the operator every table has a " +
+			"primary key on the evidence of having seen none")
 	}
-	if got.Status != StatusFail {
-		t.Errorf("status = %v, want FAIL", got.Status)
-	}
-}
-
-// The scoped form must not silently widen to every schema on the server: an
-// operator monitoring one schema would be warned about tables bintrail will
-// never capture, and would go fix the wrong database.
-func TestCheckPrimaryKeys_scopesToTheGivenSchemas(t *testing.T) {
-	db, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	// The QUERY TEXT, not just the argument: dropping the IN clause while still
-	// passing the argument leaves WithArgs satisfied, so an args-only
-	// expectation cannot see the filter go missing.
-	mock.ExpectQuery(`TABLE_SCHEMA IN \(\?\)`).
-		WithArgs("shop").
-		WillReturnRows(pkRows([2]string{"shop", "audit_log"}))
-
-	if got := checkPrimaryKeys(context.Background(), db, []string{"shop"}); got.Status != StatusWarn {
-		t.Fatalf("status = %v, detail %q", got.Status, got.Detail)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Errorf("the schema filter was not passed as an argument: %v", err)
+	if got.Status != StatusSkip {
+		t.Errorf("status = %v, want SKIP", got.Status)
 	}
 }
 
-// A driver error that arrives PART WAY through the rows must not be reported
-// as the tables seen so far. The reassuring half of this check is "and no
-// others", and a truncated scan cannot say it.
-func TestCheckPrimaryKeys_anErrorMidScanIsNotAShorterList(t *testing.T) {
-	db, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	rows := pkRows([2]string{"shop", "audit_log"}, [2]string{"shop", "sessions"}).
-		RowError(1, errors.New("Error 2013: lost connection during query"))
-	mock.ExpectQuery("TABLE_CONSTRAINTS").WillReturnRows(rows)
+// A failed query is advisory here and must NOT be a FAIL: watch and up refuse
+// to boot on any non-advisory FAIL, so a transient information_schema error
+// would stop capture on a source that is capturing fine. The snapshot applies
+// the same rule itself, so nothing is lost by warning.
+func TestCheckPrimaryKeys_aFailedQueryWarnsAndDoesNotBlockBoot(t *testing.T) {
+	db, mock, done := pkDB(t)
+	defer done()
+	mock.ExpectQuery("information_schema.COLUMNS").
+		WillReturnError(errPKProbe)
 
-	got := checkPrimaryKeys(context.Background(), db, nil)
-
-	if got.Status == StatusWarn && strings.Contains(got.Detail, "1 table") {
-		t.Fatal("the scan died after one row and the check reported that one as the whole answer, " +
-			"so a server with fifty keyless tables would be described as having one")
+	got := checkPrimaryKeys(db, nil)
+	if got.Status == StatusFail {
+		t.Fatal("returned FAIL, which makes watch and up refuse to start over an advisory check " +
+			"whose answer gates nothing")
 	}
-	if got.Status != StatusFail {
-		t.Errorf("status = %v, want FAIL: the question was not answered", got.Status)
+	if got.Status != StatusWarn {
+		t.Errorf("status = %v, want WARN", got.Status)
+	}
+	if got.Remediation == "" {
+		t.Error("a warning with no next step")
+	}
+}
+
+// The names stop at the cap and the count stays exact. Both boundaries are
+// covered: at exactly the cap there is no "and N more" to print, and one past
+// it there is exactly one.
+func TestCheckPrimaryKeys_capBoundaries(t *testing.T) {
+	for _, tc := range []struct {
+		n        int
+		wantMore string
+		notWant  string
+	}{
+		{pkNameLimit, "", "more"},
+		{pkNameLimit + 1, "and 1 more", ""},
+		{pkNameLimit + 7, "and 7 more", ""},
+	} {
+		db, mock, done := pkDB(t)
+		var cols, tabs [][3]string
+		for i := 0; i < tc.n; i++ {
+			name := "t" + string(rune('a'+i))
+			cols = append(cols, [3]string{"shop", name, ""})
+			tabs = append(tabs, [3]string{"shop", name, "BASE TABLE"})
+		}
+		mock.ExpectQuery("information_schema.COLUMNS").WillReturnRows(colRows(cols...))
+		mock.ExpectQuery("information_schema.TABLES").WillReturnRows(tabRows(tabs...))
+
+		got := checkPrimaryKeys(db, nil)
+		if tc.wantMore != "" && !strings.Contains(got.Detail, tc.wantMore) {
+			t.Errorf("n=%d: detail %q does not carry %q", tc.n, got.Detail, tc.wantMore)
+		}
+		if tc.notWant != "" && strings.Contains(got.Detail, tc.notWant) {
+			t.Errorf("n=%d: detail %q says %q at exactly the cap, where nothing was cut", tc.n, got.Detail, tc.notWant)
+		}
+		if n := strings.Count(got.Detail, "shop."); n > pkNameLimit {
+			t.Errorf("n=%d: printed %d names, over the cap of %d", tc.n, n, pkNameLimit)
+		}
+		// The COUNT is the real total, not the number of names printed. An
+		// operator sizing the work needs it, and a count that shrank with the
+		// list would understate the problem by exactly the amount that was cut.
+		if want := fmt.Sprintf("%d table(s)", tc.n); !strings.Contains(got.Detail, want) {
+			t.Errorf("n=%d: detail %q does not carry the real total %q", tc.n, got.Detail, want)
+		}
+		done()
 	}
 }

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -1182,6 +1182,96 @@ func TakeSnapshotExcludingInvalid(sourceDB, indexDB *sql.DB, schemas []string) (
 	return takeSnapshot(sourceDB, indexDB, schemas, true)
 }
 
+// TablesWithoutPrimaryKey reports the tables the snapshot would refuse (strict)
+// or exclude (degraded) for having no primary key, as "schema.table", sorted.
+//
+// Exported so `doctor` can warn about them BEFORE capture hits the refusal,
+// and deliberately implemented by calling the snapshot's own classifier rather
+// than asking information_schema a similar question. Two oracles for "has a
+// primary key" is how a preflight comes to disagree with the pipeline it is
+// predicting: bintrail's row identity is COLUMN_KEY == "PRI" (see ColumnMeta),
+// which MySQL also sets on a UNIQUE NOT NULL index with no declared PRIMARY
+// KEY, so a TABLE_CONSTRAINTS-shaped question warns about tables the product
+// keys perfectly well. The table-type filter has the same hazard in the other
+// direction (#1272, see invalidTables).
+func TablesWithoutPrimaryKey(sourceDB *sql.DB, schemas []string) ([]string, error) {
+	columns, err := fetchColumnRows(sourceDB, schemas)
+	if err != nil {
+		return nil, err
+	}
+	if len(columns) == 0 {
+		// No columns visible is not "every table has a primary key". The
+		// caller decides what to say; it must not be the reassuring answer.
+		return nil, ErrNoColumnsVisible
+	}
+	_, noPK, _, err := invalidTables(sourceDB, schemas, columns)
+	if err != nil {
+		return nil, err
+	}
+	return noPK, nil
+}
+
+// ErrNoColumnsVisible marks a source whose information_schema.COLUMNS answered
+// with nothing for the requested scope: an empty schema, a misspelled name, or
+// an account that cannot see it. Every one of those means the question was not
+// answered, which is different from a clean answer.
+var ErrNoColumnsVisible = errors.New("no columns are visible for the requested schemas")
+
+// fetchColumnRows reads the source's column metadata for the requested scope.
+// Shared by takeSnapshot and TablesWithoutPrimaryKey so the set of tables the
+// two reason about cannot drift apart.
+func fetchColumnRows(sourceDB *sql.DB, schemas []string) ([]columnRow, error) {
+	var (
+		query string
+		args  []any
+	)
+
+	if len(schemas) == 0 {
+		query = `
+			SELECT TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME,
+			       ORDINAL_POSITION, COLUMN_KEY, DATA_TYPE, COLUMN_TYPE,
+			       IS_NULLABLE, COLUMN_DEFAULT, GENERATION_EXPRESSION, CHARACTER_SET_NAME
+			FROM information_schema.COLUMNS
+			WHERE TABLE_SCHEMA NOT IN ('information_schema','performance_schema','mysql','sys')
+			ORDER BY TABLE_SCHEMA, TABLE_NAME, ORDINAL_POSITION`
+	} else {
+		placeholders := strings.TrimRight(strings.Repeat("?,", len(schemas)), ",")
+		query = fmt.Sprintf(`
+			SELECT TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME,
+			       ORDINAL_POSITION, COLUMN_KEY, DATA_TYPE, COLUMN_TYPE,
+			       IS_NULLABLE, COLUMN_DEFAULT, GENERATION_EXPRESSION, CHARACTER_SET_NAME
+			FROM information_schema.COLUMNS
+			WHERE TABLE_SCHEMA IN (%s)
+			ORDER BY TABLE_SCHEMA, TABLE_NAME, ORDINAL_POSITION`, placeholders)
+		for _, s := range schemas {
+			args = append(args, s)
+		}
+	}
+
+	srcRows, err := sourceDB.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query information_schema.COLUMNS: %w", err)
+	}
+	defer srcRows.Close()
+
+	var columns []columnRow
+	for srcRows.Next() {
+		var c columnRow
+		if err := srcRows.Scan(
+			&c.schemaName, &c.tableName, &c.columnName,
+			&c.ordinalPosition, &c.columnKey, &c.dataType, &c.columnType,
+			&c.isNullable, &c.columnDefault, &c.generationExpression, &c.characterSet,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan column row: %w", err)
+		}
+		columns = append(columns, c)
+	}
+	if err := srcRows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate source columns: %w", err)
+	}
+	return columns, nil
+}
+
 func takeSnapshot(sourceDB, indexDB *sql.DB, schemas []string, excludeInvalid bool) (SnapshotStats, error) {
 	// ── 1. Query information_schema on the source server ─────────────────────
 	var (


### PR DESCRIPTION
Part of #1608.

Preflight checks `log_bin`, `binlog_format`, `binlog_row_image`, binlog retention, schema visibility and FK cascades. It has never looked at primary keys, and a table without one is the quietest failure in the product.

Capture of such a table works, so nothing fails loudly. What is lost is everything keyed by the row's identity, and it is lost silently:

- the stored row images carry an empty `pk_values`
- `recover` cannot generate SQL that targets the affected row
- `reconstruct` refuses the table (`supportedPKType`)
- `verify --check recover` cannot walk the chain and grades it unwalkable, not verified (#318)

Captured and unrecoverable is the worst combination a backup product can present, because it looks like it is working.

## Shape

**WARN, never FAIL.** Capture of those tables is still worth having: the events are indexed and queryable. Refusing to start would trade a partial capability for none, which is worse than the gap.

**The names are the payload.** "Some tables have no primary key" leaves the operator writing the same query they would have written anyway. The detail names up to ten and keeps the count exact past the cap, because a schema converted from MyISAM can have hundreds and someone sizing the work needs the real number. The remediation carries both `ALTER TABLE` forms (existing unique column, and the surrogate key InnoDB is already keeping invisibly) plus the query that lists the rest.

**`LEFT JOIN` over `TABLE_CONSTRAINTS`, not `COLUMN_KEY = 'PRI'`.** The column view reports the first column of any unique-ish key on some versions; the constraint is the thing being asserted.

**A failed query is a FAIL.** Reporting "no tables without a primary key" on the evidence of having learned nothing is the exact failure mode this check exists to break, one level up. `rows.Err()` is checked for the same reason: a scan that dies after one row must not present that one as the whole answer.

## Guards

Five, each seen red before green, mutations scoped to the function and reverted by rewriting the file from a pristine copy:

| Mutation | Result |
|---|---|
| WARN → PASS | RED |
| the name cap also truncates the count | RED |
| a failed query returns PASS | RED |
| `rows.Err()` ignored | RED |
| the schema filter dropped from the query | RED |

The last two survived their first pass and needed better tests, not better claims: nothing exercised `RowError`, and `WithArgs` alone stays satisfied when the `IN` clause is dropped, so that assertion moved onto the query text.

`go build`, `go vet` and the full `go test ./...` are green.