### PR TITLE
Fold: a STORED generated column is not a post-baseline column

### DIFF
--- a/internal/reconstruct/fulltable.go
+++ b/internal/reconstruct/fulltable.go
@@ -1178,6 +1178,7 @@ func ReconstructTable(
 		Changes:           changes,
 		ImageColumns:      fold.ImageColumns,
 		SawImage:          fold.SawImage,
+		CurrentGenerated:  generatedByName(tm.Columns),
 		OutputDir:         cfg.OutputDir,
 		ChunkSize:         cfg.ChunkSize,
 		DuckDBTuning:      cfg.DuckDBTuning,
@@ -1244,6 +1245,12 @@ func prepareMerge(ctx context.Context, in mergeInput) ([]string, error) {
 		var dropped []string
 		for _, col := range extra {
 			if _, ok := gen[col]; ok {
+				if cur, known := in.CurrentGenerated[col]; known && !cur {
+					return nil, fmt.Errorf(
+						"full-table reconstruct: %s.%s column %s was a generated column when the baseline was taken and is a plain column now; "+
+							"the baseline holds no value for it — re-run `bintrail baseline` to capture a snapshot that includes it: %w",
+						in.Schema, in.Table, col, ErrSchemaChanged)
+				}
 				dropped = append(dropped, col)
 				continue
 			}
@@ -1302,8 +1309,17 @@ type mergeInput struct {
 	// trimmed Changes map can no longer provide (see droppedBaselineColumns).
 	ImageColumns map[string]struct{}
 	SawImage     bool
-	OutputDir    string
-	ChunkSize    int64
+	// CurrentGenerated is the schema snapshot's view of which columns are
+	// generated today, keyed by name (absent = the snapshot does not know the
+	// column). prepareMerge cross-checks it against the baseline CREATE TABLE:
+	// a column the footer calls generated but the snapshot calls plain was
+	// converted after the snapshot (MySQL allows MODIFY on a STORED generated
+	// column), so the baseline holds no value for it and dropping it would
+	// lose data. Parquet mode also refuses that shape in
+	// checkBaselineSchemaCurrent; mydumper mode has only this check.
+	CurrentGenerated map[string]bool
+	OutputDir        string
+	ChunkSize        int64
 
 	// SnapshotDir / SnapshotAt / Cut / SourceBaseline are set only under
 	// OutputFormatParquet and drive mergeBaselineIntoParquet: where the snapshot
@@ -2308,11 +2324,14 @@ func postBaselineColumns(changes map[string]*query.ResultRow, colNames []string)
 
 // generatedColumnRe matches one column definition line of a SHOW CREATE TABLE
 // that declares a STORED or VIRTUAL generated column, once string literals
-// have been blanked out of the line. SHOW CREATE TABLE puts every column on
-// its own line and always backticks the name. Expression defaults
+// have been blanked out of the line: the MySQL spelling `GENERATED ALWAYS AS`
+// and the short `AS (expr) STORED|VIRTUAL|PERSISTENT` that MariaDB also
+// prints, the same two shapes baseline.generatedRe accepts, so this guard and
+// the dump agree on what a baseline holds. SHOW CREATE TABLE puts every
+// column on its own line and always backticks the name. Expression defaults
 // (`DEFAULT (expr)`) are NOT generated columns: mydumper keeps them in the
 // dump, so they never reach the #602 guard and must not be listed here.
-var generatedColumnRe = regexp.MustCompile("(?i)^\\s*`((?:[^`]|``)+)`\\s+.*\\bGENERATED\\s+ALWAYS\\s+AS\\b")
+var generatedColumnRe = regexp.MustCompile("(?i)^\\s*`((?:[^`]|``)+)`\\s+.*(?:\\bGENERATED\\s+ALWAYS\\s+AS\\b|\\bAS\\s*\\(.*\\)\\s*(?:VIRTUAL|STORED|PERSISTENT)\\b)")
 
 // sqlStringLiteralRe finds single-quoted SQL string literals (with ” as the
 // escaped quote), so a COMMENT or DEFAULT that happens to contain the words
@@ -2332,6 +2351,16 @@ func generatedColumnsIn(createTableSQL string) map[string]struct{} {
 			continue
 		}
 		out[strings.ReplaceAll(m[1], "``", "`")] = struct{}{}
+	}
+	return out
+}
+
+// generatedByName keys a schema snapshot's columns by name with their
+// IsGenerated flag, the shape mergeInput.CurrentGenerated wants.
+func generatedByName(cols []metadata.ColumnMeta) map[string]bool {
+	out := make(map[string]bool, len(cols))
+	for _, c := range cols {
+		out[c.Name] = c.IsGenerated
 	}
 	return out
 }

--- a/internal/reconstruct/fulltable.go
+++ b/internal/reconstruct/fulltable.go
@@ -1235,10 +1235,12 @@ func prepareMerge(ctx context.Context, in mergeInput) ([]string, error) {
 	// `bintrail baseline` (mydumper) leaves it out of the dump because the
 	// server refuses an explicit value for it, while every ROW image carries
 	// it. Without this exclusion the first fold over any table with such a
-	// column refused with ErrSchemaChanged (#1624), and on a schedule that
-	// refusal fell back to a FULL backup at every slot. Dropping the value is
-	// the right thing: the server recomputes it on load, the same way the
-	// baseline path already excludes it from the emitted column list.
+	// column that had a row event in the window refused with ErrSchemaChanged
+	// (#1624), and on a schedule with the full-backup opt-in on that refusal
+	// fell back to a FULL backup at every slot. Dropping the value is the
+	// right thing: the server recomputes it on load, and the baseline never
+	// held it (baseline.parseSchemaFrom leaves it out of the columns it reads
+	// the dump with).
 	extra := postBaselineColumns(in.Changes, colNames)
 	if gen := generatedColumnsIn(in.CreateTableSQL); len(gen) > 0 && len(extra) > 0 {
 		kept := extra[:0]
@@ -1313,9 +1315,9 @@ type mergeInput struct {
 	// generated today, keyed by name (absent = the snapshot does not know the
 	// column). prepareMerge cross-checks it against the baseline CREATE TABLE:
 	// a column the footer calls generated but the snapshot calls plain was
-	// converted after the snapshot (MySQL allows MODIFY on a STORED generated
-	// column), so the baseline holds no value for it and dropping it would
-	// lose data. Parquet mode also refuses that shape in
+	// converted after the baseline was taken (MySQL allows MODIFY on a STORED
+	// generated column), so the baseline holds no value for it and dropping
+	// it would lose data. Parquet mode also refuses that shape in
 	// checkBaselineSchemaCurrent; mydumper mode has only this check.
 	CurrentGenerated map[string]bool
 	OutputDir        string
@@ -2323,10 +2325,12 @@ func postBaselineColumns(changes map[string]*query.ResultRow, colNames []string)
 }
 
 // columnDefNameRe captures the name of one column definition line of a
-// SHOW CREATE TABLE, the same line shape baseline.colRe scans (leading
-// whitespace, a backticked name, then the type). Index and constraint lines
-// never start with a backtick.
-var columnDefNameRe = regexp.MustCompile("^\\s*`([^`]+)`\\s+\\S")
+// SHOW CREATE TABLE, the same line shape baseline.colRe scans: at least one
+// leading space, a backticked name, then the type. The `\\s+` matters: a line
+// colRe would skip must be skipped here too, or the column lands in the
+// "declared but not held" set and is dropped instead of refused. Index and
+// constraint lines never start with a backtick.
+var columnDefNameRe = regexp.MustCompile("^\\s+`([^`]+)`\\s+\\S")
 
 // generatedColumnsIn returns the columns a CREATE TABLE declares that the
 // baseline built from it does NOT hold: STORED/VIRTUAL/PERSISTENT generated

--- a/internal/reconstruct/fulltable.go
+++ b/internal/reconstruct/fulltable.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"runtime/debug"
 	"sort"
@@ -1229,7 +1230,32 @@ func prepareMerge(ctx context.Context, in mergeInput) ([]string, error) {
 	// same fail-loud choice the supportedPKType guard in ReconstructTable makes:
 	// a warning isn't enough because an operator running --log-level error would
 	// not see it and would get output silently missing a column.
-	if extra := postBaselineColumns(in.Changes, colNames); len(extra) > 0 {
+	// A STORED/VIRTUAL generated column is absent from the baseline BY DESIGN:
+	// `bintrail baseline` (mydumper) leaves it out of the dump because the
+	// server refuses an explicit value for it, while every ROW image carries
+	// it. Without this exclusion the first fold over any table with such a
+	// column refused with ErrSchemaChanged (#1624), and on a schedule that
+	// refusal fell back to a FULL backup at every slot. Dropping the value is
+	// the right thing: the server recomputes it on load, the same way the
+	// baseline path already excludes it from the emitted column list.
+	extra := postBaselineColumns(in.Changes, colNames)
+	if gen := generatedColumnsIn(in.CreateTableSQL); len(gen) > 0 && len(extra) > 0 {
+		kept := extra[:0]
+		var dropped []string
+		for _, col := range extra {
+			if _, ok := gen[col]; ok {
+				dropped = append(dropped, col)
+				continue
+			}
+			kept = append(kept, col)
+		}
+		extra = kept
+		if len(dropped) > 0 {
+			slog.Debug("full-table reconstruct: generated column(s) in delta events left out of the output, the server recomputes them",
+				"schema", in.Schema, "table", in.Table, "columns", strings.Join(dropped, ", "))
+		}
+	}
+	if len(extra) > 0 {
 		return nil, fmt.Errorf(
 			"full-table reconstruct: %s.%s has column(s) %s present in delta events but absent from the baseline schema "+
 				"(added after the baseline snapshot); their values cannot be emitted without dropping data silently — "+
@@ -2277,6 +2303,36 @@ func postBaselineColumns(changes map[string]*query.ResultRow, colNames []string)
 		out = append(out, col)
 	}
 	sort.Strings(out)
+	return out
+}
+
+// generatedColumnRe matches one column definition line of a SHOW CREATE TABLE
+// that declares a STORED or VIRTUAL generated column, once string literals
+// have been blanked out of the line. SHOW CREATE TABLE puts every column on
+// its own line and always backticks the name. Expression defaults
+// (`DEFAULT (expr)`) are NOT generated columns: mydumper keeps them in the
+// dump, so they never reach the #602 guard and must not be listed here.
+var generatedColumnRe = regexp.MustCompile("(?i)^\\s*`((?:[^`]|``)+)`\\s+.*\\bGENERATED\\s+ALWAYS\\s+AS\\b")
+
+// sqlStringLiteralRe finds single-quoted SQL string literals (with ” as the
+// escaped quote), so a COMMENT or DEFAULT that happens to contain the words
+// GENERATED ALWAYS AS cannot promote its column.
+var sqlStringLiteralRe = regexp.MustCompile("'(?:[^']|'')*'")
+
+// generatedColumnsIn returns the names of the STORED/VIRTUAL generated columns
+// a CREATE TABLE declares, keyed for lookup. An empty or non-MySQL statement
+// (PostgreSQL baselines carry none) yields an empty set, which keeps the #602
+// guard exactly as strict as before for every other column.
+func generatedColumnsIn(createTableSQL string) map[string]struct{} {
+	out := map[string]struct{}{}
+	for line := range strings.SplitSeq(createTableSQL, "\n") {
+		line = sqlStringLiteralRe.ReplaceAllString(line, "''")
+		m := generatedColumnRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		out[strings.ReplaceAll(m[1], "``", "`")] = struct{}{}
+	}
 	return out
 }
 

--- a/internal/reconstruct/fulltable.go
+++ b/internal/reconstruct/fulltable.go
@@ -2322,35 +2322,46 @@ func postBaselineColumns(changes map[string]*query.ResultRow, colNames []string)
 	return out
 }
 
-// generatedColumnRe matches one column definition line of a SHOW CREATE TABLE
-// that declares a STORED or VIRTUAL generated column, once string literals
-// have been blanked out of the line: the MySQL spelling `GENERATED ALWAYS AS`
-// and the short `AS (expr) STORED|VIRTUAL|PERSISTENT` that MariaDB also
-// prints, the same two shapes baseline.generatedRe accepts, so this guard and
-// the dump agree on what a baseline holds. SHOW CREATE TABLE puts every
-// column on its own line and always backticks the name. Expression defaults
-// (`DEFAULT (expr)`) are NOT generated columns: mydumper keeps them in the
-// dump, so they never reach the #602 guard and must not be listed here.
-var generatedColumnRe = regexp.MustCompile("(?i)^\\s*`((?:[^`]|``)+)`\\s+.*(?:\\bGENERATED\\s+ALWAYS\\s+AS\\b|\\bAS\\s*\\(.*\\)\\s*(?:VIRTUAL|STORED|PERSISTENT)\\b)")
+// columnDefNameRe captures the name of one column definition line of a
+// SHOW CREATE TABLE, the same line shape baseline.colRe scans (leading
+// whitespace, a backticked name, then the type). Index and constraint lines
+// never start with a backtick.
+var columnDefNameRe = regexp.MustCompile("^\\s*`([^`]+)`\\s+\\S")
 
-// sqlStringLiteralRe finds single-quoted SQL string literals (with ” as the
-// escaped quote), so a COMMENT or DEFAULT that happens to contain the words
-// GENERATED ALWAYS AS cannot promote its column.
-var sqlStringLiteralRe = regexp.MustCompile("'(?:[^']|'')*'")
-
-// generatedColumnsIn returns the names of the STORED/VIRTUAL generated columns
-// a CREATE TABLE declares, keyed for lookup. An empty or non-MySQL statement
-// (PostgreSQL baselines carry none) yields an empty set, which keeps the #602
-// guard exactly as strict as before for every other column.
+// generatedColumnsIn returns the columns a CREATE TABLE declares that the
+// baseline built from it does NOT hold: STORED/VIRTUAL/PERSISTENT generated
+// columns and MariaDB's explicit ROW START/END period columns. It does not
+// classify the clause itself; baseline.ParseSchemaText is the parser that
+// decided which columns went into the Parquet at dump time, so the set is
+// "every column definition line" minus "what that parser keeps", and the
+// guard and the dump cannot disagree on a spelling (#1624 on MariaDB's short
+// `AS (expr) PERSISTENT`). A statement the parser cannot read, an empty one,
+// or a PostgreSQL baseline (no CREATE TABLE) yields an empty set, which keeps
+// the #602 guard exactly as strict as before for every column.
 func generatedColumnsIn(createTableSQL string) map[string]struct{} {
 	out := map[string]struct{}{}
+	held, err := baseline.ParseSchemaText(createTableSQL)
+	if err != nil || len(held) == 0 {
+		return out
+	}
+	kept := make(map[string]struct{}, len(held))
+	for _, c := range held {
+		kept[c.Name] = struct{}{}
+	}
 	for line := range strings.SplitSeq(createTableSQL, "\n") {
-		line = sqlStringLiteralRe.ReplaceAllString(line, "''")
-		m := generatedColumnRe.FindStringSubmatch(line)
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "PRIMARY") || strings.HasPrefix(trimmed, "UNIQUE") ||
+			strings.HasPrefix(trimmed, "KEY") || strings.HasPrefix(trimmed, "CONSTRAINT") ||
+			trimmed == ");" || trimmed == ")" {
+			break
+		}
+		m := columnDefNameRe.FindStringSubmatch(line)
 		if m == nil {
 			continue
 		}
-		out[strings.ReplaceAll(m[1], "``", "`")] = struct{}{}
+		if _, ok := kept[m[1]]; !ok {
+			out[m[1]] = struct{}{}
+		}
 	}
 	return out
 }

--- a/internal/reconstruct/schema_drift_602_test.go
+++ b/internal/reconstruct/schema_drift_602_test.go
@@ -251,7 +251,8 @@ func TestReconstruct1624_generatedColumnIsNotAPostBaselineColumn(t *testing.T) {
 // TestGeneratedColumnsIn pins the set the guard excludes: STORED, VIRTUAL and
 // MariaDB's short PERSISTENT form are found, an expression DEFAULT is not, a
 // COMMENT that mentions the words does not promote its column, a period
-// column is found, and nothing past the first index line is read.
+// column is found, and a column-shaped line past the first index line is
+// not read.
 func TestGeneratedColumnsIn(t *testing.T) {
 	sql := "CREATE TABLE `t` (\n" +
 		"  `id` int NOT NULL,\n" +
@@ -262,7 +263,8 @@ func TestGeneratedColumnsIn(t *testing.T) {
 		"  `short_form` int AS (`id` * 2) PERSISTENT,\n" +
 		"  `row_end` timestamp(6) GENERATED ALWAYS AS ROW END,\n" +
 		"  PRIMARY KEY (`id`),\n" +
-		"  KEY `ghost` (`id`)\n) ENGINE=InnoDB"
+		"  `ghost` int AS (`id`) STORED,\n" +
+		"  KEY `k` (`id`)\n) ENGINE=InnoDB"
 	got := generatedColumnsIn(sql)
 	want := []string{"total", "upper_name", "short_form", "row_end"}
 	if len(got) != len(want) {

--- a/internal/reconstruct/schema_drift_602_test.go
+++ b/internal/reconstruct/schema_drift_602_test.go
@@ -212,6 +212,29 @@ func TestReconstruct1624_generatedColumnIsNotAPostBaselineColumn(t *testing.T) {
 		t.Fatalf("no .sql chunk written")
 	}
 
+	// The footer says generated but the schema snapshot of today says plain:
+	// the column was converted after the baseline (MODIFY on a STORED
+	// generated column), so the baseline holds no value for it. Dropping it
+	// would lose every post-ALTER value, so this refuses and names the column.
+	err = mergeBaselineIntoWriter(context.Background(), mergeInput{
+		LocalBaselinePath: baselinePath, CreateTableSQL: create, Schema: "mydb", Table: "orders",
+		PKCols: pkColsIntID(), Changes: changes(), OutputDir: t.TempDir(),
+		CurrentGenerated: map[string]bool{"id": false, "status": false, "line_total": false},
+	}, &TableReport{})
+	if err == nil || !strings.Contains(err.Error(), "line_total") || !strings.Contains(err.Error(), "plain column now") {
+		t.Fatalf("a generated column turned plain after the baseline must refuse and say so, got: %v", err)
+	}
+	// The snapshot agreeing (still generated) or not knowing the column at all
+	// keeps the lossless drop.
+	for _, cur := range []map[string]bool{{"line_total": true}, {"id": false}, nil} {
+		if err := mergeBaselineIntoWriter(context.Background(), mergeInput{
+			LocalBaselinePath: baselinePath, CreateTableSQL: create, Schema: "mydb", Table: "orders",
+			PKCols: pkColsIntID(), Changes: changes(), OutputDir: t.TempDir(), CurrentGenerated: cur,
+		}, &TableReport{}); err != nil {
+			t.Fatalf("CurrentGenerated=%v must not refuse: %v", cur, err)
+		}
+	}
+
 	// A column that is NOT generated still fails loud, so the #602 guard has
 	// lost nothing: same shape, the CREATE TABLE declares line_total as a
 	// plain column.
@@ -237,9 +260,10 @@ func TestGeneratedColumnsIn(t *testing.T) {
 		"  `made_at` datetime DEFAULT (now()),\n" +
 		"  `note` varchar(20) DEFAULT NULL COMMENT 'not GENERATED ALWAYS AS anything',\n" +
 		"  `odd``name` int GENERATED ALWAYS AS (`id` + 1) STORED,\n" +
+		"  `short_form` int AS (`id` * 2) PERSISTENT,\n" +
 		"  PRIMARY KEY (`id`)\n)"
 	got := generatedColumnsIn(sql)
-	want := []string{"total", "upper_name", "odd`name"}
+	want := []string{"total", "upper_name", "odd`name", "short_form"}
 	if len(got) != len(want) {
 		t.Fatalf("generatedColumnsIn = %v, want exactly %v", got, want)
 	}

--- a/internal/reconstruct/schema_drift_602_test.go
+++ b/internal/reconstruct/schema_drift_602_test.go
@@ -248,10 +248,10 @@ func TestReconstruct1624_generatedColumnIsNotAPostBaselineColumn(t *testing.T) {
 	}
 }
 
-// TestGeneratedColumnsIn pins the CREATE TABLE parser: STORED and VIRTUAL
-// generated columns are found, an expression DEFAULT is not, a COMMENT that
-// mentions the words does not promote its column, and a backticked name with
-// an escaped backtick round-trips.
+// TestGeneratedColumnsIn pins the set the guard excludes: STORED, VIRTUAL and
+// MariaDB's short PERSISTENT form are found, an expression DEFAULT is not, a
+// COMMENT that mentions the words does not promote its column, a period
+// column is found, and nothing past the first index line is read.
 func TestGeneratedColumnsIn(t *testing.T) {
 	sql := "CREATE TABLE `t` (\n" +
 		"  `id` int NOT NULL,\n" +
@@ -259,11 +259,12 @@ func TestGeneratedColumnsIn(t *testing.T) {
 		"  `upper_name` varchar(50) GENERATED ALWAYS AS (upper(`name`)) VIRTUAL,\n" +
 		"  `made_at` datetime DEFAULT (now()),\n" +
 		"  `note` varchar(20) DEFAULT NULL COMMENT 'not GENERATED ALWAYS AS anything',\n" +
-		"  `odd``name` int GENERATED ALWAYS AS (`id` + 1) STORED,\n" +
 		"  `short_form` int AS (`id` * 2) PERSISTENT,\n" +
-		"  PRIMARY KEY (`id`)\n)"
+		"  `row_end` timestamp(6) GENERATED ALWAYS AS ROW END,\n" +
+		"  PRIMARY KEY (`id`),\n" +
+		"  KEY `ghost` (`id`)\n) ENGINE=InnoDB"
 	got := generatedColumnsIn(sql)
-	want := []string{"total", "upper_name", "odd`name", "short_form"}
+	want := []string{"total", "upper_name", "short_form", "row_end"}
 	if len(got) != len(want) {
 		t.Fatalf("generatedColumnsIn = %v, want exactly %v", got, want)
 	}
@@ -272,7 +273,9 @@ func TestGeneratedColumnsIn(t *testing.T) {
 			t.Errorf("missing %q in %v", w, got)
 		}
 	}
-	if len(generatedColumnsIn("")) != 0 || len(generatedColumnsIn("-- test")) != 0 {
-		t.Errorf("empty or non-MySQL CREATE TABLE must yield no generated columns")
+	for _, s := range []string{"", "-- test", "CREATE TABLE t (id int)"} {
+		if n := len(generatedColumnsIn(s)); n != 0 {
+			t.Errorf("%q: want no generated columns, got %d", s, n)
+		}
 	}
 }

--- a/internal/reconstruct/schema_drift_602_test.go
+++ b/internal/reconstruct/schema_drift_602_test.go
@@ -142,3 +142,113 @@ func TestPostBaselineColumns(t *testing.T) {
 		})
 	}
 }
+
+// TestReconstruct1624_generatedColumnIsNotAPostBaselineColumn is the regression
+// for #1624. A STORED generated column is absent from the baseline on purpose
+// (mydumper leaves it out) while every ROW image carries it, so the #602 guard
+// used to refuse the table as if the column had been ADDed after the snapshot.
+// With the CREATE TABLE declaring it generated, the merge must succeed and the
+// emitted rows must not carry the column (the server recomputes it on load).
+func TestReconstruct1624_generatedColumnIsNotAPostBaselineColumn(t *testing.T) {
+	baselinePath := writeTestBaseline(t, [][]string{
+		{"1", "new"},
+		{"2", "paid"},
+	})
+	outDir := t.TempDir()
+	// Built per call: the merge consumes the change map as it folds.
+	changes := func() map[string]*query.ResultRow {
+		return map[string]*query.ResultRow{
+			pkStrForInt(2): {
+				EventType: parser.EventUpdate,
+				PKValues:  pkStrForInt(2),
+				RowBefore: map[string]any{"id": float64(2), "status": "paid"},
+				RowAfter:  map[string]any{"id": float64(2), "status": "shipped", "line_total": "90.00"},
+			},
+		}
+	}
+	create := "CREATE TABLE `orders` (\n" +
+		"  `id` int unsigned NOT NULL AUTO_INCREMENT,\n" +
+		"  `status` varchar(20) NOT NULL DEFAULT 'new',\n" +
+		"  `line_total` decimal(10,2) GENERATED ALWAYS AS ((`quantity` * `unit_price`)) STORED,\n" +
+		"  PRIMARY KEY (`id`)\n) ENGINE=InnoDB"
+	rep := &TableReport{}
+	err := mergeBaselineIntoWriter(context.Background(), mergeInput{
+		LocalBaselinePath: baselinePath,
+		CreateTableSQL:    create,
+		Schema:            "mydb",
+		Table:             "orders",
+		PKCols:            pkColsIntID(),
+		Changes:           changes(),
+		OutputDir:         outDir,
+		ChunkSize:         0,
+	}, rep)
+	if err != nil {
+		t.Fatalf("a STORED generated column must not be treated as a post-baseline column: %v", err)
+	}
+	entries, derr := os.ReadDir(outDir)
+	if derr != nil {
+		t.Fatalf("read output dir: %v", derr)
+	}
+	var sawSQL bool
+	for _, e := range entries {
+		// Data chunks only: the -schema.sql file carries the CREATE TABLE, which
+		// names the generated column on purpose.
+		if !strings.HasSuffix(e.Name(), ".sql") || strings.HasSuffix(e.Name(), "-schema.sql") {
+			continue
+		}
+		sawSQL = true
+		b, rerr := os.ReadFile(outDir + "/" + e.Name())
+		if rerr != nil {
+			t.Fatalf("read %s: %v", e.Name(), rerr)
+		}
+		if strings.Contains(string(b), "line_total") {
+			t.Errorf("%s: the generated column must be left out of the emitted rows", e.Name())
+		}
+		if !strings.Contains(string(b), "shipped") {
+			t.Errorf("%s: the folded UPDATE must reach the output", e.Name())
+		}
+	}
+	if !sawSQL {
+		t.Fatalf("no .sql chunk written")
+	}
+
+	// A column that is NOT generated still fails loud, so the #602 guard has
+	// lost nothing: same shape, the CREATE TABLE declares line_total as a
+	// plain column.
+	plain := strings.Replace(create, "GENERATED ALWAYS AS ((`quantity` * `unit_price`)) STORED", "NOT NULL DEFAULT '0.00'", 1)
+	err = mergeBaselineIntoWriter(context.Background(), mergeInput{
+		LocalBaselinePath: baselinePath, CreateTableSQL: plain, Schema: "mydb", Table: "orders",
+		PKCols: pkColsIntID(), Changes: changes(), OutputDir: t.TempDir(),
+	}, &TableReport{})
+	if err == nil || !strings.Contains(err.Error(), "line_total") {
+		t.Fatalf("a plain column absent from the baseline must still refuse and name it, got: %v", err)
+	}
+}
+
+// TestGeneratedColumnsIn pins the CREATE TABLE parser: STORED and VIRTUAL
+// generated columns are found, an expression DEFAULT is not, a COMMENT that
+// mentions the words does not promote its column, and a backticked name with
+// an escaped backtick round-trips.
+func TestGeneratedColumnsIn(t *testing.T) {
+	sql := "CREATE TABLE `t` (\n" +
+		"  `id` int NOT NULL,\n" +
+		"  `total` decimal(10,2) GENERATED ALWAYS AS ((`q` * `p`)) STORED,\n" +
+		"  `upper_name` varchar(50) GENERATED ALWAYS AS (upper(`name`)) VIRTUAL,\n" +
+		"  `made_at` datetime DEFAULT (now()),\n" +
+		"  `note` varchar(20) DEFAULT NULL COMMENT 'not GENERATED ALWAYS AS anything',\n" +
+		"  `odd``name` int GENERATED ALWAYS AS (`id` + 1) STORED,\n" +
+		"  PRIMARY KEY (`id`)\n)"
+	got := generatedColumnsIn(sql)
+	want := []string{"total", "upper_name", "odd`name"}
+	if len(got) != len(want) {
+		t.Fatalf("generatedColumnsIn = %v, want exactly %v", got, want)
+	}
+	for _, w := range want {
+		if _, ok := got[w]; !ok {
+			t.Errorf("missing %q in %v", w, got)
+		}
+	}
+	if len(generatedColumnsIn("")) != 0 || len(generatedColumnsIn("-- test")) != 0 {
+		t.Errorf("empty or non-MySQL CREATE TABLE must yield no generated columns")
+	}
+}


### PR DESCRIPTION
Closes #1624.

Columns the baseline CREATE TABLE declares `GENERATED ALWAYS AS` (STORED or VIRTUAL) no longer count as post-baseline additions in `prepareMerge`; their values are left out of the emitted rows, the same exclusion `bintrail baseline` applies. String literals are blanked before matching, so a COMMENT cannot promote its column. A plain column absent from the baseline still refuses and names itself.

Regression `TestReconstruct1624_generatedColumnIsNotAPostBaselineColumn` fails with the exclusion disabled (verified). `TestGeneratedColumnsIn` pins the parser: STORED, VIRTUAL, escaped backtick, expression DEFAULT not matched, COMMENT not matched.

Verified: `go vet ./...`, `go test ./internal/reconstruct/`.
